### PR TITLE
[Spec] Remove 'Provides' field in spec file @open sesame 02/17 08:20

### DIFF
--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -36,7 +36,6 @@ Release:	0
 Group:		Machine Learning/ML Framework
 Packager:	MyungJoo Ham <myungjoo.ham@samsung.com>
 License:	Apache-2.0
-Provides:	capi-nnstreamer = %{version}-%{release}
 Source0:	machine-learning-api-%{version}.tar.gz
 Source1001:	capi-machine-learning-inference.manifest
 
@@ -80,7 +79,6 @@ You can construct a data stream pipeline with neural networks easily.
 %package devel
 Summary:	Tizen Native API Devel Kit for NNStreamer
 Group:		Machine Learning/ML Framework
-Provides:	capi-nnstreamer-devel = %{version}-%{release}
 Requires:	capi-machine-learning-inference = %{version}-%{release}
 Requires:	capi-machine-learning-common-devel
 %description devel
@@ -96,7 +94,6 @@ Static library of capi-machine-learning-inference-devel package.
 %package -n capi-machine-learning-common-devel
 Summary:	Common headers for Tizen Machine Learning API
 Group:		Machine Learning/ML Framework
-Provides:	capi-ml-common-devel = %{version}-%{release}
 %description -n capi-machine-learning-common-devel
 Common headers for Tizen Machine Learning API.
 


### PR DESCRIPTION
'Provides' field in spec file causes unresolvable problems since our
customers use pkg-config files like 'BuildRequires: pkgconfig(capi-nnstreamer)'.
This patch removes 'Provides' field so that this package successfully
builds on the OBS server.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped