### PR TITLE
[C-Api] fix res leak in timeout mode

### DIFF
--- a/c/include/nnstreamer-capi-private.h
+++ b/c/include/nnstreamer-capi-private.h
@@ -123,6 +123,15 @@ typedef struct {
 } ml_tensors_info_s;
 
 /**
+ * @brief The function to be called when destroying the allocated handle.
+ * @since_tizen 6.5
+ * @param[in] handle The handle created for ML API.
+ * @param[in,out] user_data The user data to pass to the callback function.
+ * @return @c 0 on success. Otherwise a negative error value.
+ */
+typedef int (*ml_handle_destroy_cb) (void *handle, void *user_data);
+
+/**
  * @brief An instance of a single input or output frame.
  * @since_tizen 5.5
  */
@@ -138,7 +147,10 @@ typedef struct {
 typedef struct {
   unsigned int num_tensors; /**< The number of tensors. */
   ml_tensor_data_s tensors[ML_TENSOR_SIZE_LIMIT]; /**< The list of tensor data. NULL for unused tensors. */
-  void *handle; /**< The handle which owns this buffer and will be used to de-alloc the data */
+
+  /* private */
+  void *user_data; /**< The user data to pass to the callback function */
+  ml_handle_destroy_cb destroy; /**< The function to be called to release the allocated buffer */
 } ml_tensors_data_s;
 
 /**
@@ -399,8 +411,6 @@ ml_nnfw_type_e ml_get_nnfw_type_by_subplugin_name (const char *name);
  * @return The reference of pipeline itself. Null if the pipeline is not constructed or closed.
  */
 GstElement* ml_pipeline_get_gst_element (ml_pipeline_h pipe);
-
-int ml_single_destroy_notify (ml_single_h single, ml_tensors_data_s *data);
 
 #if defined (__TIZEN__)
 /**

--- a/c/src/nnstreamer-capi-single.c
+++ b/c/src/nnstreamer-capi-single.c
@@ -96,7 +96,6 @@ typedef struct
   ml_tensors_data_h output;           /**< output to be sent back to user */
   guint timeout;                      /**< timeout for invoking */
   thread_state state;                 /**< current state of the thread */
-  gboolean ignore_output;             /**< ignore and free the output */
   gboolean free_output;               /**< true if output tensors are allocated in single-shot */
   int status;                         /**< status of processing */
 
@@ -137,22 +136,6 @@ __setup_in_out_tensors (ml_single * single_h)
 }
 
 /**
- * @brief setup the destroy notify for the allocated output data.
- * @note this stores the data entry in the single list.
- * @note this has not overhead if the allocation of output is not performed by
- * the framework but by tensor filter element.
- */
-static void
-set_destroy_notify (ml_single * single_h, ml_tensors_data_s * data)
-{
-  if (single_h->klass->allocate_in_invoke (single_h->filter)) {
-    data->handle = single_h;
-    single_h->destroy_data_list = g_list_append (single_h->destroy_data_list,
-        (gpointer) data);
-  }
-}
-
-/**
  * @brief To call the framework to destroy the allocated output data
  */
 static inline void
@@ -163,19 +146,26 @@ __destroy_notify (gpointer data_h, gpointer single_data)
 
   data = (ml_tensors_data_s *) data_h;
   single_h = (ml_single *) single_data;
+
   if (G_LIKELY (single_h->filter)) {
-    single_h->klass->destroy_notify (single_h->filter,
-        (GstTensorMemory *) data->tensors);
+    if (single_h->klass->allocate_in_invoke (single_h->filter)) {
+      single_h->klass->destroy_notify (single_h->filter,
+          (GstTensorMemory *) data->tensors);
+    }
   }
-  data->handle = NULL;
+
+  /* reset callback function */
+  data->destroy = NULL;
 }
 
 /**
  * @brief Wrapper function for __destroy_notify
  */
-int
-ml_single_destroy_notify (ml_single_h single, ml_tensors_data_s * data)
+static int
+ml_single_destroy_notify_cb (void *handle, void *user_data)
 {
+  ml_tensors_data_h data = (ml_tensors_data_h) handle;
+  ml_single_h single = (ml_single_h) user_data;
   ml_single *single_h;
   int status = ML_ERROR_NONE;
 
@@ -202,17 +192,39 @@ exit:
 }
 
 /**
+ * @brief setup the destroy notify for the allocated output data.
+ * @note this stores the data entry in the single list.
+ * @note this has not overhead if the allocation of output is not performed by
+ * the framework but by tensor filter element.
+ */
+static void
+set_destroy_notify (ml_single * single_h, ml_tensors_data_s * data,
+    gboolean add)
+{
+  if (single_h->klass->allocate_in_invoke (single_h->filter)) {
+    data->destroy = ml_single_destroy_notify_cb;
+    data->user_data = single_h;
+    add = TRUE;
+  }
+
+  if (add) {
+    single_h->destroy_data_list = g_list_append (single_h->destroy_data_list,
+        (gpointer) data);
+  }
+}
+
+/**
  * @brief Internal function to call subplugin's invoke
  */
 static inline int
-__invoke (ml_single * single_h)
+__invoke (ml_single * single_h, ml_tensors_data_h in, ml_tensors_data_h out)
 {
   ml_tensors_data_s *in_data, *out_data;
   int status = ML_ERROR_NONE;
   GstTensorMemory *in_tensors, *out_tensors;
 
-  in_data = (ml_tensors_data_s *) single_h->input;
-  out_data = (ml_tensors_data_s *) single_h->output;
+  in_data = (ml_tensors_data_s *) in;
+  out_data = (ml_tensors_data_s *) out;
 
   in_tensors = (GstTensorMemory *) in_data->tensors;
   out_tensors = (GstTensorMemory *) out_data->tensors;
@@ -222,9 +234,6 @@ __invoke (ml_single * single_h)
           single_h->free_output)) {
     ml_loge ("Failed to invoke the tensors.");
     status = ML_ERROR_STREAMS_PIPE;
-    if (single_h->free_output)
-      ml_tensors_data_destroy (single_h->output);
-    single_h->output = NULL;
   }
 
   return status;
@@ -234,7 +243,7 @@ __invoke (ml_single * single_h)
  * @brief Internal function to post-process given output.
  */
 static inline void
-__process_output (ml_single * single_h)
+__process_output (ml_single * single_h, ml_tensors_data_h output)
 {
   ml_tensors_data_s *out_data;
 
@@ -243,16 +252,17 @@ __process_output (ml_single * single_h)
     return;
   }
 
-  if (single_h->ignore_output == TRUE) {
+  if (g_list_find (single_h->destroy_data_list, output)) {
     /**
-     * Caller of the invoke thread has returned back with timeout
-     * so, free the memory allocated by the invoke as their is no receiver
+     * Caller of the invoke thread has returned back with timeout.
+     * So, free the memory allocated by the invoke as their is no receiver.
      */
-    ml_tensors_data_destroy (single_h->output);
-    single_h->output = NULL;
+    single_h->destroy_data_list =
+        g_list_remove (single_h->destroy_data_list, output);
+    ml_tensors_data_destroy (output);
   } else {
-    out_data = (ml_tensors_data_s *) single_h->output;
-    set_destroy_notify (single_h, out_data);
+    out_data = (ml_tensors_data_s *) output;
+    set_destroy_notify (single_h, out_data, FALSE);
   }
 }
 
@@ -279,6 +289,7 @@ static void *
 invoke_thread (void *arg)
 {
   ml_single *single_h;
+  ml_tensors_data_h input, output;
 
   single_h = (ml_single *) arg;
 
@@ -294,14 +305,24 @@ invoke_thread (void *arg)
         goto exit;
     }
 
+    input = single_h->input;
+    output = single_h->output;
+
     g_mutex_unlock (&single_h->mutex);
-    status = __invoke (single_h);
+    status = __invoke (single_h, input, output);
     g_mutex_lock (&single_h->mutex);
 
-    if (status != ML_ERROR_NONE)
-      goto wait_for_next;
+    if (status != ML_ERROR_NONE) {
+      if (single_h->free_output) {
+        single_h->destroy_data_list =
+            g_list_remove (single_h->destroy_data_list, output);
+        ml_tensors_data_destroy (output);
+      }
 
-    __process_output (single_h);
+      goto wait_for_next;
+    }
+
+    __process_output (single_h, output);
 
     /** loop over to wait for the next element */
   wait_for_next:
@@ -563,7 +584,6 @@ ml_single_create_handle (ml_nnfw_type_e nnfw)
   single_h->timeout = SINGLE_DEFAULT_TIMEOUT;
   single_h->nnfw = nnfw;
   single_h->state = IDLE;
-  single_h->ignore_output = FALSE;
   single_h->thread = NULL;
   single_h->input = NULL;
   single_h->output = NULL;
@@ -1004,7 +1024,6 @@ _ml_single_invoke_internal (ml_single_h single,
 
   single_h->input = input;
   single_h->state = RUNNING;
-  single_h->ignore_output = FALSE;
   single_h->free_output = need_alloc;
 
   if (single_h->timeout > 0) {
@@ -1021,7 +1040,8 @@ _ml_single_invoke_internal (ml_single_h single,
       ml_logw ("Wait for invoke has timed out");
       status = ML_ERROR_TIMED_OUT;
       /** This is set to notify invoke_thread to not process if timed out */
-      single_h->ignore_output = TRUE;
+      if (need_alloc)
+        set_destroy_notify (single_h, single_h->output, TRUE);
     }
   } else {
     /**
@@ -1032,24 +1052,28 @@ _ml_single_invoke_internal (ml_single_h single,
      * with the same handle. Thus we can call __invoke without
      * having yet another mutex for __invoke.
      */
-    status = __invoke (single_h);
-    if (status != ML_ERROR_NONE)
-      goto exit;
-    __process_output (single_h);
+    status = __invoke (single_h, single_h->input, single_h->output);
     single_h->state = IDLE;
-  }
 
-  if (single_h->ignore_output == FALSE) {
-    if (need_alloc)
-      *output = single_h->output;
-    single_h->output = NULL;
+    if (status != ML_ERROR_NONE) {
+      if (need_alloc)
+        ml_tensors_data_destroy (single_h->output);
+      goto exit;
+    }
+
+    __process_output (single_h, single_h->output);
   }
 
 exit:
-  ML_SINGLE_HANDLE_UNLOCK (single_h);
-
-  if (G_UNLIKELY (status != ML_ERROR_NONE))
+  if (G_UNLIKELY (status != ML_ERROR_NONE)) {
     ml_loge ("Failed to invoke the model.");
+  } else {
+    if (need_alloc)
+      *output = single_h->output;
+  }
+
+  single_h->output = NULL;
+  ML_SINGLE_HANDLE_UNLOCK (single_h);
   return status;
 }
 

--- a/c/src/nnstreamer-capi-util.c
+++ b/c/src/nnstreamer-capi-util.c
@@ -560,8 +560,8 @@ ml_tensors_data_destroy (ml_tensors_data_h data)
 
   _data = (ml_tensors_data_s *) data;
 
-  if (_data->handle != NULL) {
-    status = ml_single_destroy_notify (_data->handle, _data);
+  if (_data->destroy) {
+    status = _data->destroy (_data, _data->user_data);
   } else {
     for (i = 0; i < ML_TENSOR_SIZE_LIMIT; i++) {
       if (_data->tensors[i].tensor) {
@@ -601,7 +601,6 @@ ml_tensors_data_create_no_alloc (const ml_tensors_info_h info,
     return ML_ERROR_OUT_OF_MEMORY;
   }
 
-  _data->handle = NULL;
   _info = (ml_tensors_info_s *) info;
   if (_info != NULL) {
     _data->num_tensors = _info->num_tensors;
@@ -639,7 +638,6 @@ ml_tensors_data_clone_no_alloc (const ml_tensors_data_s * data_src,
     return ML_ERROR_OUT_OF_MEMORY;
   }
 
-  _data->handle = NULL;
   _data->num_tensors = data_src->num_tensors;
   memcpy (_data->tensors, data_src->tensors,
       sizeof (ml_tensor_data_s) * data_src->num_tensors);


### PR DESCRIPTION
In single-shot timeout case, the flag to release output handle may reset when setting short timeout value.
To prevent this case, add output handle to del-list and change params to set input/output handle in invoke thread.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
