### PR TITLE
[Tizen/Privilege] Use newly exported MMFW headers @open sesame 4/5 18:56

### DIFF
--- a/c/include/nnstreamer-capi-private.h
+++ b/c/include/nnstreamer-capi-private.h
@@ -56,12 +56,15 @@ typedef enum
 #define release_tizen_resource(...) ml_tizen_release_resource(__VA_ARGS__)
 #define TIZEN5PLUS 1
 
+#if ((TIZENVERSION > 6) || (TIZENVERSION == 6 && TIZENVERSIONMINOR >= 5))
+#define TIZENMMCONF 1
+#endif
+
 #elif (TIZENVERSION < 5)
 #define get_tizen_resource(...) (0)
 #define release_tizen_resource(...) do { } while (0)
 typedef void * mm_resource_manager_h;
 typedef enum { MM_RESOURCE_MANAGER_RES_TYPE_MAX } mm_resource_manager_res_type_e;
-#define TIZEN5PLUS 0
 
 #else
 #error Tizen version is not defined.
@@ -72,7 +75,6 @@ typedef enum { MM_RESOURCE_MANAGER_RES_TYPE_MAX } mm_resource_manager_res_type_e
 #define convert_tizen_element(...) ML_ERROR_NONE
 #define get_tizen_resource(...) ML_ERROR_NONE
 #define release_tizen_resource(...)
-#define TIZEN5PLUS 0
 
 #endif  /* __PRIVILEGE_CHECK_SUPPORT__ */
 
@@ -82,8 +84,14 @@ typedef enum { MM_RESOURCE_MANAGER_RES_TYPE_MAX } mm_resource_manager_res_type_e
 #define convert_tizen_element(...) ML_ERROR_NONE
 #define get_tizen_resource(...) ML_ERROR_NONE
 #define release_tizen_resource(...)
-#define TIZEN5PLUS 0
 #endif  /* __TIZEN__ */
+
+#ifndef TIZEN5PLUS
+#define TIZEN5PLUS 0
+#endif /* TIZEN5PLUS */
+#ifndef TIZENMMCONF
+#define TIZENMMCONF 0
+#endif /* TIZENMMCONF */
 
 #define EOS_MESSAGE_TIME_LIMIT 100
 #define WAIT_PAUSED_TIME_LIMIT 100

--- a/c/src/nnstreamer-capi-single.c
+++ b/c/src/nnstreamer-capi-single.c
@@ -333,7 +333,9 @@ invoke_thread (void *arg)
   }
 
 exit:
-  single_h->state = IDLE;
+  /* Do not set IDLE if JOIN_REQUESTED */
+  if (single_h->state == RUNNING)
+    single_h->state = IDLE;
   g_mutex_unlock (&single_h->mutex);
   return NULL;
 }

--- a/meson.build
+++ b/meson.build
@@ -74,7 +74,9 @@ if get_option('enable-tizen')
   add_project_arguments('-D__TIZEN__=1', language: ['c', 'cpp'])
 
   tizenVmajor = get_option('tizen-version-major')
+  tizenVminor = get_option('tizen-version-minor')
   add_project_arguments('-DTIZENVERSION='+tizenVmajor.to_string(), language: ['c', 'cpp'])
+  add_project_arguments('-DTIZENVERSIONMINOR='+tizenVminor.to_string(), language: ['c', 'cpp'])
 
   if get_option('enable-tizen-feature-check')
     add_project_arguments('-D__FEATURE_CHECK_SUPPORT__', language: ['c', 'cpp'])

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,5 +2,6 @@ option('enable-test', type: 'boolean', value: true)
 option('install-test', type: 'boolean', value: false)
 option('enable-tizen', type: 'boolean', value: false)
 option('tizen-version-major', type: 'integer', min : 4, max : 9999, value: 9999) # 9999 means "not Tizen"
+option('tizen-version-minor', type: 'integer', min : 0, max : 9999, value: 0)
 option('enable-tizen-feature-check', type: 'boolean', value: false)
 option('enable-tizen-privilege-check', type: 'boolean', value: false)

--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -185,7 +185,7 @@ Unittests for Tizen Machine Learning API.
 %define enable_tizen_feature_check -Denable-tizen-feature-check=false
 
 %if %{with tizen}
-%define enable_tizen -Denable-tizen=true -Dtizen-version-major=0%{tizen_version_major}
+%define enable_tizen -Denable-tizen=true -Dtizen-version-major=0%{?tizen_version_major} -Dtizen-version-minor=0%{?tizen_version_minor}
 
 %if 0%{?enable_tizen_privilege}
 %define enable_tizen_privilege_check -Denable-tizen-privilege-check=true


### PR DESCRIPTION
This requires
https://review.tizen.org/gerrit/#/c/platform/core/multimedia/libmm-camcorder/+/255956/ (updated)
to be merged and deployed. Or maintainers may do group-SR.

Fixes https://github.com/nnstreamer/nnstreamer/issues/1734

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>