### PR TITLE
[spec] Add Requires section for Tizen platform image @open sesame 02/26 14:35

### DIFF
--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -11,6 +11,7 @@
 %define		tensorflow2_gpu_delegate_support 1
 %define		nnfw_support 1
 %define		armnn_support 0
+%define		tizen_sensor_support 0
 
 %define		release_test 0
 %define		test_script $(pwd)/packaging/run_unittests.sh
@@ -32,6 +33,10 @@
 # Disable a few features for TV releases
 %if "%{?profile}" == "tv"
 %define		enable_tizen_privilege 0
+%endif
+
+%if 0%{tizen_version_major} >= 6
+%define		tizen_sensor_support 1
 %endif
 
 # If it is tizen, we can export Tizen API packages.
@@ -126,6 +131,11 @@ BuildRequires:	libarmcl
 BuildConflicts:	libarmcl-release
 %endif
 %endif # unit_test
+
+Requires:	nnstreamer-misc
+%if 0%{?tizen_sensor_support}
+Requires:	nnstreamer-tizen-sensor
+%endif
 
 %description
 Tizen ML(Machine Learning) native API for NNStreamer.


### PR DESCRIPTION
Some necessary packages such as nnstreamer-tizen-sensor are omitted from
Tizen platform image. This patch adds the 'Requires' section to
capi-machine-learning-inference package to operate properly.

* Related Issue: https://code.sec.samsung.net/jira/browse/TSDF-247

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
3. Tizen UTC is passed.