### PR TITLE
[test] Set timeout for meson test

### DIFF
--- a/tests/capi/meson.build
+++ b/tests/capi/meson.build
@@ -4,7 +4,7 @@ unittest_capi_inference = executable('unittest_capi_inference',
   install: get_option('install-test'),
   install_dir: unittest_install_dir
 )
-test('unittest_capi_inference', unittest_capi_inference, env: testenv)
+test('unittest_capi_inference', unittest_capi_inference, env: testenv, timeout: 100)
 
 unittest_capi_inference_latency = executable('unittest_capi_inference_latency',
   'unittest_capi_inference_latency.cc',
@@ -12,7 +12,7 @@ unittest_capi_inference_latency = executable('unittest_capi_inference_latency',
   install: get_option('install-test'),
   install_dir: unittest_install_dir
 )
-test('unittest_capi_inference_latency', unittest_capi_inference_latency, env: testenv)
+test('unittest_capi_inference_latency', unittest_capi_inference_latency, env: testenv, timeout: 100)
 
 if nnfw_dep.found()
   unittest_capi_inference_nnfw_runtime = executable('unittest_capi_inference_nnfw_runtime',
@@ -21,5 +21,5 @@ if nnfw_dep.found()
     install: get_option('install-test'),
     install_dir: unittest_install_dir
   )
-  test('unittest_capi_inference_nnfw_runtime', unittest_capi_inference_nnfw_runtime, env: testenv)
+  test('unittest_capi_inference_nnfw_runtime', unittest_capi_inference_nnfw_runtime, env: testenv, timeout: 100)
 endif


### PR DESCRIPTION
- Default timeout value for meson test is 30 secs
- Set timeout value of 100 secs for unittests

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

Before:
```
$ ninja test                                                                                                   
[0/1] Running all tests.                                                                                       
1/2 unittest_capi_inference                 OK      16.85 s                                                    
2/2 unittest_capi_inference_latency         TIMEOUT 30.00 s                                                    
                                                                                                               
Ok:                    1                                                                                       
Expected Fail:         0                                                                                       
Fail:                  0                                                                                       
Unexpected Pass:       0                                                                                       
Skipped:               0                                                                                       
Timeout:               1                                                                                       
```

After:
```
$ ninja test
[0/1] Running all tests.
1/2 unittest_capi_inference                 OK      16.90 s
2/2 unittest_capi_inference_latency         OK      69.52 s

Ok:                    2
Expected Fail:         0
Fail:                  0
Unexpected Pass:       0
Skipped:               0
Timeout:               0
```