### PR TITLE
[Singleshot] Support nntrainer inference

### DIFF
--- a/c/src/nnstreamer-capi-util.c
+++ b/c/src/nnstreamer-capi-util.c
@@ -35,6 +35,7 @@ static const char *ml_nnfw_subplugin_name[] = {
   [ML_NNFW_TYPE_ARMNN] = "armnn",
   [ML_NNFW_TYPE_SNPE] = "snpe",
   [ML_NNFW_TYPE_PYTORCH] = "pytorch",
+  [ML_NNFW_TYPE_NNTR_INF] = "nntrainer",
   NULL
 };
 


### PR DESCRIPTION
This patch enables singleshot inference from `ML_NNFW_TYPE_NNTR_INF`

I read code throughly to look where to change but it was only one line,

Please review if there are more things to be done.

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
