### PR TITLE
[Packaging] api devel requires nnstreamer-devel @open sesame 03/22 16:01

### DIFF
--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -144,8 +144,8 @@ You can construct a data stream pipeline with neural networks easily.
 %package devel
 Summary:	Tizen Native API Devel Kit for NNStreamer
 Group:		Machine Learning/ML Framework
-Requires:	capi-machine-learning-inference = %{version}-%{release}
-Requires:	capi-machine-learning-common-devel
+Requires:	nnstreamer-devel
+Requires:	capi-machine-learning-common-devel = %{version}-%{release}
 %description devel
 Developmental kit for Tizen Native NNStreamer API.
 


### PR DESCRIPTION
This patch fixes api devel to require nnstreamer-devel so that devel
does not depending on nnstreamer which would conflicts with
`nnstreamer-test-devel`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
