### PR TITLE
[Log] divide a log message

### DIFF
--- a/c/src/nnstreamer-capi-pipeline.c
+++ b/c/src/nnstreamer-capi-pipeline.c
@@ -808,8 +808,9 @@ construct_pipeline_internal (const char *pipeline_description,
   g_free (description);
 
   if (pipeline == NULL || err) {
-    ml_loge ("Cannot parse and launch the given pipeline = [%s], %s",
-        pipeline_description, (err) ? err->message : "unknown reason");
+    ml_loge ("Cannot parse and launch the given pipeline = [%s]",
+        pipeline_description);
+    ml_loge ("  - Error Message: %s", (err) ? err->message : "unknown reason");
     g_clear_error (&err);
 
     if (pipeline)


### PR DESCRIPTION
Since the length of the pipeline string is too long, the error message cannot be checked.
For easier debugging, this log message should be divided.

Signed-off-by: Hyoung Joo Ahn <hello.ahn@samsung.com>