### PR TITLE
[Spec] Use tar archiving instead of tar.gz

### DIFF
--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -62,7 +62,7 @@ Release:	0
 Group:		Machine Learning/ML Framework
 Packager:	MyungJoo Ham <myungjoo.ham@samsung.com>
 License:	Apache-2.0
-Source0:	machine-learning-api-%{version}.tar.gz
+Source0:	machine-learning-api-%{version}.tar
 Source1001:	capi-machine-learning-inference.manifest
 
 ## Define build requirements ##


### PR DESCRIPTION
This patch uses tar archiving instead of tar.gz instead of VD QBuild
system.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
