### PR TITLE
[C-Api] new API to flush the pipeline @open sesame 4/29 11:23

### DIFF
--- a/c/include/nnstreamer.h
+++ b/c/include/nnstreamer.h
@@ -362,6 +362,20 @@ int ml_pipeline_start (ml_pipeline_h pipe);
  */
 int ml_pipeline_stop (ml_pipeline_h pipe);
 
+/**
+ * @brief Clears all data and resets the pipeline.
+ * @details During the flush operation, the pipeline is stopped and after the operation is done, the pipeline is resumed and ready to start the data flow.
+ * @since_tizen 6.5
+ * @param[in] pipe The pipeline to be flushed.
+ * @param[in] start @c true to start the pipeline after the flush operation is done.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
+ * @retval #ML_ERROR_STREAMS_PIPE Failed to flush the pipeline.
+ */
+int ml_pipeline_flush (ml_pipeline_h pipe, bool start);
+
 /****************************************************
  ** NNStreamer Pipeline Sink/Src Control           **
  ****************************************************/

--- a/java/android/nnstreamer/src/main/java/org/nnsuite/nnstreamer/Pipeline.java
+++ b/java/android/nnstreamer/src/main/java/org/nnsuite/nnstreamer/Pipeline.java
@@ -34,6 +34,7 @@ public final class Pipeline implements AutoCloseable {
     private native void nativeDestroy(long handle);
     private native boolean nativeStart(long handle);
     private native boolean nativeStop(long handle);
+    private native boolean nativeFlush(long handle, boolean start);
     private native int nativeGetState(long handle);
     private native boolean nativeInputData(long handle, String name, TensorsData data);
     private native String[] nativeGetSwitchPads(long handle, String name);
@@ -199,6 +200,23 @@ public final class Pipeline implements AutoCloseable {
 
         if (!nativeStop(mHandle)) {
             throw new IllegalStateException("Failed to stop the pipeline");
+        }
+    }
+
+    /**
+     * Clears all data and resets the pipeline.
+     * During the flush operation, the pipeline is stopped and after the operation is done,
+     * the pipeline is resumed and ready to start the data flow.
+     *
+     * @param start The flag to start the pipeline after the flush operation is done
+     *
+     * @throws IllegalStateException if failed to flush the pipeline
+     */
+    public void flush(boolean start) {
+        checkPipelineHandle();
+
+        if (!nativeFlush(mHandle, start)) {
+            throw new IllegalStateException("Failed to flush the pipeline");
         }
     }
 

--- a/java/android/nnstreamer/src/main/jni/nnstreamer-native-pipeline.c
+++ b/java/android/nnstreamer/src/main/jni/nnstreamer-native-pipeline.c
@@ -554,6 +554,28 @@ nns_native_pipe_stop (JNIEnv * env, jobject thiz, jlong handle)
 /**
  * @brief Native method for pipeline API.
  */
+static jboolean
+nns_native_pipe_flush (JNIEnv * env, jobject thiz, jlong handle, jboolean start)
+{
+  pipeline_info_s *pipe_info = NULL;
+  ml_pipeline_h pipe;
+  int status;
+
+  pipe_info = CAST_TO_TYPE (handle, pipeline_info_s *);
+  pipe = pipe_info->pipeline_handle;
+
+  status = ml_pipeline_flush (pipe, (start == JNI_TRUE));
+  if (status != ML_ERROR_NONE) {
+    nns_loge ("Failed to flush the pipeline.");
+    return JNI_FALSE;
+  }
+
+  return JNI_TRUE;
+}
+
+/**
+ * @brief Native method for pipeline API.
+ */
 static jint
 nns_native_pipe_get_state (JNIEnv * env, jobject thiz, jlong handle)
 {
@@ -913,6 +935,7 @@ static JNINativeMethod native_methods_pipeline[] = {
   {"nativeDestroy", "(J)V", (void *) nns_native_pipe_destroy},
   {"nativeStart", "(J)Z", (void *) nns_native_pipe_start},
   {"nativeStop", "(J)Z", (void *) nns_native_pipe_stop},
+  {"nativeFlush", "(JZ)Z", (void *) nns_native_pipe_flush},
   {"nativeGetState", "(J)I", (void *) nns_native_pipe_get_state},
   {"nativeInputData", "(JLjava/lang/String;L" NNS_CLS_TDATA ";)Z",
       (void *) nns_native_pipe_input_data},


### PR DESCRIPTION
Add new API to flush the pipeline.
If new input should be run without old data in pipeline, this is necessary to clear all.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
