### PR TITLE
[API/Skeleton] App Src Callback support

### DIFF
--- a/c/include/nnstreamer.h
+++ b/c/include/nnstreamer.h
@@ -443,6 +443,29 @@ int ml_pipeline_src_release_handle (ml_pipeline_src_h src_handle);
 int ml_pipeline_src_input_data (ml_pipeline_src_h src_handle, ml_tensors_data_h data, ml_pipeline_buf_policy_e policy);
 
 /**
+ * @brief Callbacks for src input events
+ * @details A set of callbacks that can be installed on the appsrc with ml_pipeline_src_input_callback().
+ */
+typedef struct {
+  void (*need_data) (ml_pipeline_src_h src_handle, unsigned int length, void *user_data);   /**< Called when the appsrc needs more data. User may submit a buffer via ml_pipeline_src_input_data() from this thread or another thread. length is just a hint and when it is set to -1, any number of bytes can be pushed into appsrc. */
+  void (*enough_data) (ml_pipeline_src_h src_handle, void *user_data);                      /**< Called when appsrc has enough data. It is recommended that the application stops calling push-buffer until the need_data callback is emitted again to avoid excessive buffer queueing.*/
+  void (*seek_data) (ml_pipeline_src_h src_handle, uint64_t offset, void *user_data);       /**< Called when a seek should be performed to the offset. The next push-buffer should produce buffers from the new offset . This callback is only called for seekable stream types.*/
+} ml_pipeline_src_callbacks;
+
+/**
+ * @brief Invokes the callback when a new input frame may be accepted.
+ * @since_tizen 6.5
+ * @param[in] src_handle The source handle returned by ml_pipeline_src_get_handle().
+ * @param[in] cb The app-src callbacks for event handling.
+ * @param[in] user_data The user's custom data given to callbacks.
+ * @return 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
+ */
+int ml_pipeline_src_input_callback (ml_pipeline_src_h src_handle, ml_pipeline_src_callbacks cb, void *user_data);
+
+/**
  * @brief Gets a handle for the tensors information of given src node.
  * @details If the media type is not other/tensor or other/tensors, @a info handle may not be correct. If want to use other media types, you MUST set the correct properties.
  * @since_tizen 5.5

--- a/c/src/nnstreamer-capi-pipeline.c
+++ b/c/src/nnstreamer-capi-pipeline.c
@@ -1471,6 +1471,16 @@ destroy_data:
 }
 
 /**
+ * @brief Register callbacks for src events (more info in nnstreamer.h)
+ */
+int
+ml_pipeline_src_input_callback (ml_pipeline_src_h src_handle,
+    ml_pipeline_src_callbacks cb, void *user_data)
+{
+  return ML_ERROR_NOT_SUPPORTED; /** @todo NYI */
+}
+
+/**
  * @brief Gets a handle for the tensors metadata of given src node.
  */
 int


### PR DESCRIPTION
Refer: https://github.com/nnstreamer/nnstreamer/issues/2581

This provides API signature and code skeleton for
callback support of app-src elements in ML-API pipelines.

CC: @junmin-kim

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>