### PR TITLE
[Spec] Move libcapi-nnstreamer.so to capi-machine-learning-inference package

### DIFF
--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -274,12 +274,11 @@ cp -r result %{buildroot}%{_datadir}/ml-api/unittest/
 %manifest capi-machine-learning-inference.manifest
 %defattr(-,root,root,-)
 %license LICENSE
-%{_libdir}/libcapi-nnstreamer.so.*
+%{_libdir}/libcapi-nnstreamer.so*
 
 %files devel
 %{_includedir}/nnstreamer/nnstreamer.h
 %{_includedir}/nnstreamer/nnstreamer-single.h
-%{_libdir}/libcapi-nnstreamer.so
 %{_libdir}/pkgconfig/capi-ml-inference.pc
 
 %files devel-static


### PR DESCRIPTION
To support the backward compatibility of Tizen 6.0,
libcapi-nnstreamer.so is moved to capi-machine-learning-inference
package.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>