### PR TITLE
[C-Api] handle flexible tensor

### DIFF
--- a/c/include/nnstreamer-capi-private.h
+++ b/c/include/nnstreamer-capi-private.h
@@ -256,6 +256,7 @@ typedef struct _ml_pipeline_element {
 
   GMutex lock; /**< Lock for internal values */
   gboolean is_media_stream;
+  gboolean is_flexible_tensor;
 
   ml_handle_destroy_cb custom_destroy;
   gpointer custom_data;


### PR DESCRIPTION
In flexible tensor stream, sink and src handle cannot set exact tensor info from pad caps.
To handle flex-tensor, ignore tensor info while configuring the element handle.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
