### PR TITLE
[Android/Pipeline] clone data from src element

### DIFF
--- a/java/android/nnstreamer/src/main/jni/nnstreamer-native-pipeline.c
+++ b/java/android/nnstreamer/src/main/jni/nnstreamer-native-pipeline.c
@@ -595,13 +595,13 @@ nns_native_pipe_input_data (JNIEnv * env, jobject thiz, jlong handle,
     goto done;
   }
 
-  if (!nns_parse_tensors_data (pipe_info, env, in, FALSE, &in_data, NULL)) {
+  if (!nns_parse_tensors_data (pipe_info, env, in, TRUE, &in_data, NULL)) {
     nns_loge ("Failed to parse input data.");
     goto done;
   }
 
   status = ml_pipeline_src_input_data (src, in_data,
-      ML_PIPELINE_BUF_POLICY_DO_NOT_FREE);
+      ML_PIPELINE_BUF_POLICY_AUTO_FREE);
   if (status != ML_ERROR_NONE) {
     nns_loge ("Failed to input tensors data to source node %s.", element_name);
     goto done;
@@ -611,8 +611,6 @@ nns_native_pipe_input_data (JNIEnv * env, jobject thiz, jlong handle,
 
 done:
   (*env)->ReleaseStringUTFChars (env, name, element_name);
-  /* do not free input tensors (direct access from object) */
-  g_free (in_data);
   return res;
 }
 


### PR DESCRIPTION
We cannot guarantee the data object from java is available while running the pipeline.
Set clone when pushing data to src element.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>