### PR TITLE
[C-API] Fix Pipekline Flush API

### DIFF
--- a/c/src/nnstreamer-capi-pipeline.c
+++ b/c/src/nnstreamer-capi-pipeline.c
@@ -1098,9 +1098,12 @@ ml_pipeline_flush (ml_pipeline_h pipe, bool start)
 
   /* send flush event to pipeline */
   g_mutex_lock (&p->lock);
-  if (!gst_element_send_event (p->element, gst_event_new_flush_start ()) ||
-      !gst_element_send_event (p->element, gst_event_new_flush_stop (TRUE))) {
-    ml_logw ("Error occurs while sending flush event.");
+  if (!gst_element_send_event (p->element, gst_event_new_flush_start ())) {
+    ml_logw ("Error occurs while sending flush_start event.");
+  }
+
+  if (!gst_element_send_event (p->element, gst_event_new_flush_stop (TRUE))) {
+    ml_logw ("Error occurs while sending flush_stop event.");
   }
   g_mutex_unlock (&p->lock);
 


### PR DESCRIPTION
- Some gstreamer elements fail to send `gst_event_new_flush_start`
- Spilt `_flush_start` and `_flush_stop` to call `_flush_stop`

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>