### PR TITLE
[Android] Build GStreamer with tracing 

### DIFF
--- a/java/android/gstreamer_android-1.0.c.in.patch
+++ b/java/android/gstreamer_android-1.0.c.in.patch
@@ -1,0 +1,41 @@
+--- gstreamer_android-1.0.c.in	2021-05-03 17:14:48.421251773 +0900
++++ gstreamer_android-1.0.c.in	2021-05-03 17:18:55.309247942 +0900
+@@ -4,6 +4,8 @@
+ #include <android/log.h>
+ #include <string.h>
+ 
++extern void _priv_gst_tracing_init ();
++
+ /* XXX: Workaround for Android <21 making signal() an inline function
+  * around bsd_signal(), and Android >= 21 not having any bsd_signal()
+  * symbol but only signal().
+@@ -267,7 +269,7 @@
+       android_log_level = ANDROID_LOG_DEBUG;
+       break;
+     default:
+-      android_log_level = ANDROID_LOG_VERBOSE;
++      android_log_level = ANDROID_LOG_INFO;
+       break;
+   }
+ 
+@@ -537,6 +539,10 @@
+   g_free (cache_dir);
+   g_free (files_dir);
+ 
++  /* set env for tracer */
++  g_setenv ("GST_DEBUG", "GST_TRACER:7,default:5,GST_PLUGIN_LOADING:5,GST_INIT:5,GST_REGISTRY:5", TRUE);
++  g_setenv ("GST_TRACERS", "latency(flags=pipeline+element)", TRUE);
++
+   /* Set GLib print handlers */
+   g_set_print_handler (glib_print_handler);
+   g_set_printerr_handler (glib_printerr_handler);
+@@ -563,6 +569,9 @@
+   }
+   gst_android_register_static_plugins ();
+   gst_android_load_gio_modules ();
++
++  _priv_gst_tracing_init ();
++
+   __android_log_print (ANDROID_LOG_INFO, "GStreamer",
+       "GStreamer initialization complete");
+ }


### PR DESCRIPTION
- Add Android GStreamer build option for tracing in build script
- Add patch for file `gstreamer_android-1.0.c.in` to enable this feature

REF: https://gstreamer.freedesktop.org/documentation/additional/design/tracing.html?gi-language=c
Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

With option `--enable_tracing=yes`, latency of each element is logged (in nanoseconds)

example log:
```
I/GStreamer+GST_TRACER: 0:00:04.955265623 0x7d103654a0 :0: element-latency, element-id=(string)0x7d701e81b0, element=(string)tensoraggregator1, src=(string)src, time=(guint64)27917, ts=(guint64)4955157082;
I/GStreamer+GST_TRACER: 0:00:04.955327707 0x7d10365630 :0: element-latency, element-id=(string)0x7da0258030, element=(string)queue0, src=(string)src, time=(guint64)182607135, ts=(guint64)4955210571;
I/GStreamer+GST_TRACER: 0:00:04.955265050 0x7d10365540 :0: element-latency, element-id=(string)0x7da0258630, element=(string)queue2, src=(string)src, time=(guint64)182444375, ts=(guint64)4955147186;
I/GStreamer+GST_TRACER: 0:00:04.955493332 0x7d103654a0 :0: element-latency, element-id=(string)0x7d1036eed0, element=(string)tensortransform2, src=(string)src, time=(guint64)219375, ts=(guint64)4955376457;
I/GStreamer+GST_TRACER: 0:00:04.955539530 0x7d10365450 :0: element-latency, element-id=(string)0x7da0258330, element=(string)queue1, src=(string)src, time=(guint64)182765937, ts=(guint64)4955421769;
I/GStreamer+GST_TRACER: 0:00:04.955675050 0x7d10365450 :0: element-latency, element-id=(string)0x7da0268040, element=(string)mux, src=(string)src, time=(guint64)141563, ts=(guint64)4955563332;
I/GStreamer+GST_TRACER: 0:00:04.986640050 0x7d10365450 :0: element-latency, element-id=(string)0x7d406359c0, element=(string)tensorfilter0, src=(string)src, time=(guint64)30919583, ts=(guint64)4986482915;
I/GStreamer+GST_TRACER: 0:00:04.986732186 0x7d10365450 :0: element-latency, element-id=(string)0x7d701f5150, element=(string)sensor_model_output, src=(string)src_0, time=(guint64)135260, ts=(guint64)4986618175;
```