### PR TITLE
[Spec] Add the provides section to capi-machine-learning-inference package @open sesame 5/06 19:40

### DIFF
--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -64,6 +64,7 @@ Source1001:	capi-machine-learning-inference.manifest
 
 ## Define build requirements ##
 Requires:	nnstreamer
+Provides:	libcapi-nnstreamer.so
 BuildRequires:	nnstreamer-devel
 BuildRequires:	nnstreamer-devel-internal
 BuildRequires:	glib2-devel


### PR DESCRIPTION
Since rpmbuild explicitly exclude the name from the library rpm,
libcapi-nnstreamer.so is not provided as below.

```bash
$ rpm -qp --provides capi-machine-learning-inference-1.7.2-0.armv7l.rpm
capi-machine-learning-inference = 1.7.2-0
capi-machine-learning-inference(armv7l-32) = 1.7.2-0
libcapi-nnstreamer.so.1
```

This patch adds the provides section to capi-machine-learning-inference
package so that capi-machine-learning-inference provides
libcapi-nnstreamer.so.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>