### PR TITLE
[Spec] Add the Provides option in case of 64bit

### DIFF
--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -64,7 +64,11 @@ Source1001:	capi-machine-learning-inference.manifest
 
 ## Define build requirements ##
 Requires:	nnstreamer
+%ifarch aarch64 x86_64
+Provides:	libcapi-nnstreamer.so(64bit)
+%else
 Provides:	libcapi-nnstreamer.so
+%endif
 BuildRequires:	nnstreamer-devel
 BuildRequires:	nnstreamer-devel-internal
 BuildRequires:	glib2-devel


### PR DESCRIPTION
If architecture is aarch64 or x86_64, the 64bit option should be added.
If not, the wrong so file is provided as below.

$ rpm -qp --provides capi-machine-learning-inference-1.7.2-0.aarch64.rpm
capi-machine-learning-inference = 1.7.2-0
capi-machine-learning-inference(aarch-64) = 1.7.2-0
libcapi-nnstreamer.so
libcapi-nnstreamer.so.1()(64bit)

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>