### PR TITLE
Thread safety for ml_tensors_data APIs @open sesame 5/27 17:10

### DIFF
--- a/c/include/nnstreamer-capi-private.h
+++ b/c/include/nnstreamer-capi-private.h
@@ -186,6 +186,8 @@ typedef struct {
   /* private */
   void *user_data; /**< The user data to pass to the callback function */
   ml_handle_destroy_cb destroy; /**< The function to be called to release the allocated buffer */
+  GMutex lock; /**< Lock for thread safety */
+  int nolock; /**< Set non-zero to avoid using m (giving up thread safety) */
 } ml_tensors_data_s;
 
 /**


### PR DESCRIPTION
Fixes #nnstreamer/2600
Note that locally created-and-freed ml-tensors-data
are not required to be protected.
    
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
