### PR TITLE
NNStreamer-devel-internal headers are external.

### DIFF
--- a/c/include/nnstreamer-capi-private.h
+++ b/c/include/nnstreamer-capi-private.h
@@ -19,8 +19,8 @@
 
 #include "nnstreamer.h"
 #include "nnstreamer-single.h"
-#include "tensor_typedef.h"
-#include "nnstreamer_log.h"
+#include <tensor_typedef.h>
+#include <nnstreamer_log.h>
 
 /* Tizen ML feature */
 #if defined (__TIZEN__)


### PR DESCRIPTION
Headers supplied by nnstreamer-devel-internal are external headers.
Use < > instead of " ".

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>