### PR TITLE
[CAPI/ml-common] Add require to base-common

### DIFF
--- a/c/capi-ml-common.pc.in
+++ b/c/capi-ml-common.pc.in
@@ -8,6 +8,6 @@ includedir=@INCLUDE_INSTALL_DIR@
 Name: tizen-api-ml-common
 Description: ML common API for Tizen
 Version: @VERSION@
-Requires:
+Requires: @ML_COMMON_REQUIRE@
 Libs: -L${libdir}
 Cflags: -I${includedir}/nnstreamer

--- a/c/capi-ml-inference.pc.in
+++ b/c/capi-ml-inference.pc.in
@@ -8,6 +8,6 @@ includedir=@INCLUDE_INSTALL_DIR@
 Name: tizen-api-ml-inference
 Description: ML inference API for Tizen
 Version: @VERSION@
-Requires: capi-ml-common
+Requires: @ML_INFERENCE_REQUIRE@
 Libs: -L${libdir} -lcapi-nnstreamer
 Cflags: -I${includedir}/nnstreamer

--- a/c/meson.build
+++ b/c/meson.build
@@ -40,7 +40,6 @@ if (get_option('enable-tizen'))
   message('C-API is in Tizen mode')
 
   tizen_deps = [
-    dependency('capi-base-common'),
     dependency('capi-system-info'),
     dependency('dlog')
   ]
@@ -85,14 +84,22 @@ nns_capi_dep = declare_dependency(link_with: nns_capi_lib,
   include_directories: nns_capi_include,
 )
 
+ml_inf_conf = configuration_data()
+ml_inf_conf.merge_from(api_conf)
+ml_inf_conf.set('ML_INFERENCE_REQUIRE', 'capi-ml-common')
 configure_file(input: 'capi-ml-inference.pc.in', output: 'capi-ml-inference.pc',
   install_dir: join_paths(api_install_libdir, 'pkgconfig'),
   configuration: api_conf
 )
 
+ml_common_api_conf = configuration_data()
+ml_common_api_conf.merge_from(api_conf)
+if get_option('enable-tizen')
+  ml_common_api_conf.set('ML_COMMON_REQUIRE', 'capi-base-common')
+endif
 configure_file(input: 'capi-ml-common.pc.in', output: 'capi-ml-common.pc',
   install_dir: join_paths(api_install_libdir, 'pkgconfig'),
-  configuration: api_conf
+  configuration: ml_common_api_conf
 )
 
 install_headers(nns_capi_headers,


### PR DESCRIPTION
- [CAPI/ml-common] Add require to base-common

```
When a developer tries to add dependency to `capi-ml-common` they have
to care about adding dependency to `capi-base-common` as well because
`capi-ml-common` is actually depending upon `capi-base-common`

This patch resolves the issue by adding require to `capi-base-common`
in the pc file.

resolves #57

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```

resolves #57 