### PR TITLE
[Flatbuf] Change version check of the flatc @open sesame 06/09 17:21

### DIFF
--- a/java/android/nnstreamer/src/main/jni/Android-flatbuf.mk
+++ b/java/android/nnstreamer/src/main/jni/Android-flatbuf.mk
@@ -23,7 +23,7 @@ SYS_FLATC_VER := $(word 3, $(shell flatc --version))
 endif
 
 ifneq ($(SYS_FLATC_VER), $(FLATBUF_VER))
-$(error Found 'flatc' v$(SYS_FLATC_VER), but required v$(FLATBUF_VER))
+$(warning  Found 'flatc' v$(SYS_FLATC_VER), but required v$(FLATBUF_VER))
 endif
 
 FLATBUF_DIR := $(LOCAL_PATH)/flatbuffers


### PR DESCRIPTION
Change version check of the flatc from error to warning.
Even if the flatbuffers compiler has different versions, compatibility can be maintained.
Tested with
 - System flatc version: 2.0.0
 - Android flatc version: 1.12.0

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>

Self evaluation:
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped