### PR TITLE
[capi] Update on thread safety for ml_tensors_info

### DIFF
--- a/c/include/nnstreamer-capi-private.h
+++ b/c/include/nnstreamer-capi-private.h
@@ -156,6 +156,21 @@ typedef struct {
       g_mutex_unlock (l); \
   } while (0)
 
+/**
+ * @brief Macro to verify private lock acquired with nolock condition (lock)
+ * @param sname The name of struct (ml_tensors_info_s or ml_tensors_data_s)
+ */
+#define G_VERIFYLOCK_UNLESS_NOLOCK(sname) \
+  do { \
+    GMutex *l = (GMutex *) &(sname).lock; \
+    if (!(sname).nolock) { \
+      if (g_mutex_trylock(l)) { \
+        g_mutex_unlock(l); \
+        return ML_ERROR_INVALID_PARAMETER; \
+      } \
+    } \
+  } while (0)
+
 
 /**
  * @brief The function to be called when destroying the allocated handle.
@@ -454,6 +469,13 @@ ml_nnfw_type_e ml_get_nnfw_type_by_subplugin_name (const char *name);
  * @return The reference of pipeline itself. Null if the pipeline is not constructed or closed.
  */
 GstElement* ml_pipeline_get_gst_element (ml_pipeline_h pipe);
+
+/**
+ * @brief Validates the given tensors info is valid without acquiring lock
+ * @note This function assumes that lock on ml_tensors_info_s has already been acquired
+ */
+int
+_ml_tensors_info_validate_nolock (const ml_tensors_info_s * info, bool *valid);
 
 #if defined (__TIZEN__)
 /**


### PR DESCRIPTION
This patch fixes the case of Time of Check Time of Use bug in
ml_pipeline_custom_easy_filter_register().
The provided arguments `in` and `out` are first checked for validity
under their locks and then used for clone again under their locks.
However, between the two operations, both the variable are left lock
free, and the two variables can become invalid.
This patch adds the corresponding fix by adding support for
checking validity of ml_tensors_info_s lockfree which is done
under the lock acquired inside ml_tensors_info_clone().

Further, as a minor fix, redundant locking and unlocking
has been removed from ml_pipeline_custom_easy_filter_register().

See also #42 https://github.com/nnstreamer/api/pull/42#issuecomment-840265534
Resolves https://github.com/nnstreamer/nnstreamer/issues/2600

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>