### PR TITLE
[Android] min sdk version to 24

### DIFF
--- a/java/android/nnstreamer/build.gradle
+++ b/java/android/nnstreamer/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdkVersion 28
     buildToolsVersion '28.0.3'
     defaultConfig {
-        minSdkVersion 28
+        minSdkVersion 24
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
For android release, set minimum sdk version to 24.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>