### PR TITLE
[C-Api/Util] Add ML_NNFW_HW_NPU_SLSI case to converting function @open sesame 07/01 09:28

### DIFF
--- a/c/src/nnstreamer-capi-util.c
+++ b/c/src/nnstreamer-capi-util.c
@@ -1252,6 +1252,8 @@ ml_nnfw_to_accl_hw (const ml_nnfw_hw_e hw)
       return ACCL_NPU_EDGE_TPU;
     case ML_NNFW_HW_NPU_VIVANTE:
       return ACCL_NPU_VIVANTE;
+    case ML_NNFW_HW_NPU_SLSI:
+      return ACCL_NPU_SLSI;
     case ML_NNFW_HW_NPU_SR:
       /** @todo how to get srcn npu */
       return ACCL_NPU_SR;


### PR DESCRIPTION
To support VD product, this patch adds the ML_NNFW_HW_NPU_SLSI case
to ml_nnfw_to_accl_hw() function.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>