### PR TITLE
[TEST] Add tensor clone test

### DIFF
--- a/tests/capi/unittest_capi_inference.cc
+++ b/tests/capi/unittest_capi_inference.cc
@@ -2815,6 +2815,58 @@ TEST (nnstreamer_capi_util, info_get_tsize_03_n)
 /**
  * @brief Test utility functions (public)
  */
+TEST (nnstreamer_capi_util, info_clone)
+{
+  gint status;
+  guint count = 0;
+  ml_tensors_info_h in_info, out_info;
+  ml_tensor_dimension in_dim, out_dim;
+  ml_tensor_type_e type = ML_TENSOR_TYPE_UNKNOWN;
+
+  status = ml_tensors_info_create (&in_info);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  status = ml_tensors_info_create (&out_info);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  in_dim[0] = 5;
+  in_dim[1] = 1;
+  in_dim[2] = 1;
+  in_dim[3] = 1;
+
+  status = ml_tensors_info_set_count (in_info, 1);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  status = ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_UINT8);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  status = ml_tensors_info_set_tensor_dimension (in_info, 0, in_dim);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_tensors_info_clone (out_info, in_info);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_tensors_info_get_count (out_info, &count);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (count, 1U);
+
+  status = ml_tensors_info_get_tensor_type (out_info, 0, &type);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (type, ML_TENSOR_TYPE_UINT8);
+
+  status = ml_tensors_info_get_tensor_dimension (out_info, 0, out_dim);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_TRUE (in_dim[0] == out_dim[0]);
+  EXPECT_TRUE (in_dim[1] == out_dim[1]);
+  EXPECT_TRUE (in_dim[2] == out_dim[2]);
+  EXPECT_TRUE (in_dim[3] == out_dim[3]);
+
+  status = ml_tensors_info_destroy (in_info);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  status = ml_tensors_info_destroy (out_info);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test utility functions (public)
+ */
 TEST (nnstreamer_capi_util, info_clone_01_n)
 {
   int status;


### PR DESCRIPTION
 - Add tensor clone test
ml_tensor_info_clone function changed to check the number of the
tensors of source info.
So, set the num_tesnors for source info.

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>