### PR TITLE
[Android] Test SNAP with tensorflow lite model

### DIFF
--- a/java/android/nnstreamer/src/main/java/org/nnsuite/nnstreamer/NNStreamer.java
+++ b/java/android/nnstreamer/src/main/java/org/nnsuite/nnstreamer/NNStreamer.java
@@ -54,7 +54,7 @@ public final class NNStreamer {
          * to specify the neural network and data format.<br>
          * <br>
          * Custom options<br>
-         * - ModelFWType: the type of model (TensorFlow/Caffe)<br>
+         * - ModelFWType: the type of model (TensorFlow Lite/TensorFlow/Caffe)<br>
          * - ExecutionDataType: the execution data type for SNAP (default float32)<br>
          * - ComputingUnit: the computing unit to execute the model (default CPU)<br>
          * - CpuThreadCount: the number of CPU threads to be executed (optional, default 4 if ComputingUnit is CPU)<br>


### PR DESCRIPTION
With https://github.com/nnstreamer/nnstreamer/pull/3433,

- SNAP v3.0 supports tensorflow lite model.
- Add pipeline and singleshot test using it (image classification with mobilenet)

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>