### PR TITLE
[C-API] Rename srnpu to trixengine

### DIFF
--- a/c/include/nnstreamer.h
+++ b/c/include/nnstreamer.h
@@ -141,7 +141,7 @@ typedef enum {
   ML_NNFW_TYPE_PYTORCH = 11,          /**< PyTorch (.pt). (Since 6.5) */
   ML_NNFW_TYPE_NNTR_INF = 12,         /**< Inference supported from NNTrainer, SR On-device Training Framework (Since 6.5) */
   ML_NNFW_TYPE_VD_AIFW = 13,          /**< Inference framework for Samsung Tizen TV (Since 6.5) */
-  ML_NNFW_TYPE_SRNPU = 14,            /**< SR (Samsung Research) made NPU (.tvn). (Since 6.5) */
+  ML_NNFW_TYPE_TRIx_ENGINE = 14,      /**< TRIxENGINE accesses TRIV/TRIA NPU low-level drivers directly (.tvn). (Since 6.5) You may need to use high-level drivers wrapping this low-level driver in some devices: e.g., AIFW */
   ML_NNFW_TYPE_SNAP = 0x2001,         /**< SNAP (Samsung Neural Acceleration Platform), only for Android. (Since 6.0) */
 } ml_nnfw_type_e;
 

--- a/c/src/nnstreamer-capi-single.c
+++ b/c/src/nnstreamer-capi-single.c
@@ -718,7 +718,7 @@ ml_single_open_custom (ml_single_h * single, ml_single_preset * info)
    * Set the pipeline desc with nnfw.
    */
   if (nnfw == ML_NNFW_TYPE_TENSORFLOW || nnfw == ML_NNFW_TYPE_SNAP ||
-      nnfw == ML_NNFW_TYPE_PYTORCH || nnfw == ML_NNFW_TYPE_SRNPU) {
+      nnfw == ML_NNFW_TYPE_PYTORCH || nnfw == ML_NNFW_TYPE_TRIx_ENGINE) {
     /* set input and output tensors information */
     if (in_tensors_info && out_tensors_info) {
       status =

--- a/c/src/nnstreamer-capi-util.c
+++ b/c/src/nnstreamer-capi-util.c
@@ -37,7 +37,7 @@ static const char *ml_nnfw_subplugin_name[] = {
   [ML_NNFW_TYPE_PYTORCH] = "pytorch",
   [ML_NNFW_TYPE_NNTR_INF] = "nntrainer",
   [ML_NNFW_TYPE_VD_AIFW] = "vd_aifw",
-  [ML_NNFW_TYPE_SRNPU] = "srnpu",
+  [ML_NNFW_TYPE_TRIx_ENGINE] = "trix-engine",
   NULL
 };
 


### PR DESCRIPTION
The patch updates the name 'srnpu' to 'trixengine'.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped