### PR TITLE
[C-API] Change src-callback name @open sesame 8/18 09:57

### DIFF
--- a/c/include/nnstreamer.h
+++ b/c/include/nnstreamer.h
@@ -461,7 +461,7 @@ int ml_pipeline_src_input_data (ml_pipeline_src_h src_handle, ml_tensors_data_h 
 
 /**
  * @brief Callbacks for src input events.
- * @details A set of callbacks that can be installed on the appsrc with ml_pipeline_src_set_callback().
+ * @details A set of callbacks that can be installed on the appsrc with ml_pipeline_src_set_event_cb().
  * @since_tizen 6.5
  */
 typedef struct {
@@ -483,7 +483,7 @@ typedef struct {
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  * @retval #ML_ERROR_OUT_OF_MEMORY Failed to allocate required memory.
  */
-int ml_pipeline_src_set_callback (ml_pipeline_src_h src_handle, ml_pipeline_src_callbacks_s *cb, void *user_data);
+int ml_pipeline_src_set_event_cb (ml_pipeline_src_h src_handle, ml_pipeline_src_callbacks_s *cb, void *user_data);
 
 /**
  * @brief Gets a handle for the tensors information of given src node.

--- a/c/src/nnstreamer-capi-pipeline.c
+++ b/c/src/nnstreamer-capi-pipeline.c
@@ -1662,7 +1662,7 @@ _pipe_src_cb_seek_data (GstAppSrc * src, guint64 offset, gpointer user_data)
  * @brief Register callbacks for src events (more info in nnstreamer.h)
  */
 int
-ml_pipeline_src_set_callback (ml_pipeline_src_h src_handle,
+ml_pipeline_src_set_event_cb (ml_pipeline_src_h src_handle,
     ml_pipeline_src_callbacks_s * cb, void *user_data)
 {
   GstAppSrcCallbacks appsrc_cb = { 0, };

--- a/tests/capi/unittest_capi_inference.cc
+++ b/tests/capi/unittest_capi_inference.cc
@@ -1343,7 +1343,7 @@ TEST (nnstreamer_capi_src, callback_replace)
   status = ml_pipeline_src_get_handle (handle, "srcx", &srchandle1);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_src_set_callback (srchandle1, &callback, srchandle1);
+  status = ml_pipeline_src_set_event_cb (srchandle1, &callback, srchandle1);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_pipeline_sink_register (
@@ -1366,7 +1366,7 @@ TEST (nnstreamer_capi_src, callback_replace)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* New callback will not push dummy. */
-  status = ml_pipeline_src_set_callback (srchandle2, &callback, srchandle1);
+  status = ml_pipeline_src_set_event_cb (srchandle2, &callback, srchandle1);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_pipeline_start (handle);
@@ -1404,7 +1404,7 @@ TEST (nnstreamer_capi_src, callback_invalid_param_01_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* invalid param */
-  status = ml_pipeline_src_set_callback (NULL, &callback, NULL);
+  status = ml_pipeline_src_set_event_cb (NULL, &callback, NULL);
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 
   status = ml_pipeline_destroy (handle);
@@ -1428,7 +1428,7 @@ TEST (nnstreamer_capi_src, callback_invalid_param_02_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* invalid param */
-  status = ml_pipeline_src_set_callback (srchandle, NULL, NULL);
+  status = ml_pipeline_src_set_event_cb (srchandle, NULL, NULL);
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 
   status = ml_pipeline_destroy (handle);


### PR DESCRIPTION
Change src-callback function name.
 - Names of callback function types should have the '_cb' suffix.
 - A module providing callbacks called on events should support exactly one of two registration schemes.
   > single callback registration: {module}_set_{details}_cb

Signed-off-by: gichan <gichan2.jang@samsung.com>