### PR TITLE
[Single] Don't close single handle during invoke process

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ml-api (1.8.0.0) unstable xenial bionic focal; urgency=medium
+
+  * Release of 1.8.0
+
+ -- MyungJoo Ham <myungjoo.ham@samsung.com>  Fri, 24 Sep 2021 15:50:00 +0900
+
 ml-api (1.7.2.0) unstable xenial bionic; urgency=medium
 
   * 1.7.2 development starts

--- a/java/android/nnstreamer/src/main/jni/Android.mk
+++ b/java/android/nnstreamer/src/main/jni/Android.mk
@@ -25,7 +25,7 @@ $(error Target arch ABI not supported: $(TARGET_ARCH_ABI))
 endif
 
 # Set ML API Version
-ML_API_VERSION  := 1.7.2
+ML_API_VERSION  := 1.8.0
 ML_API_VERSION_MAJOR := $(word 1,$(subst ., ,${ML_API_VERSION}))
 ML_API_VERSION_MINOR := $(word 2,$(subst ., ,${ML_API_VERSION}))
 ML_API_VERSION_MICRO := $(word 3,$(subst ., ,${ML_API_VERSION}))

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('ml-api', 'c', 'cpp',
-  version: '1.7.2',
+  version: '1.8.0',
   license: ['Apache-2.0'],
   meson_version: '>=0.50.0',
   default_options: [

--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -54,7 +54,7 @@ Summary:	Tizen native API for NNStreamer
 # 2. Tizen   : ./packaging/machine-learning-api.spec
 # 3. Meson   : ./meson.build
 # 4. Android : ./java/android/nnstreamer/src/main/jni/Android.mk
-Version:	1.7.2
+Version:	1.8.0
 Release:	0
 Group:		Machine Learning/ML Framework
 Packager:	MyungJoo Ham <myungjoo.ham@samsung.com>
@@ -309,5 +309,8 @@ cp -r result %{buildroot}%{_datadir}/ml-api/unittest/
 %endif
 
 %changelog
+* Fri Sep 24 2021 MyungJoo Ham <myungjoo.ham@samsung.com>
+- Release of 1.8.0
+
 * Fri Feb 05 2021 MyungJoo Ham <myungjoo.ham@samsung.com>
 - Started ML API packaging for 1.7.1


### PR DESCRIPTION
Don't close single handle during invoke process.
If single handle is released during invoke prcoess, an interpreter may
access invalid memory.

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>