### PR TITLE
C-API/Common: error reporting function skeleton.

### DIFF
--- a/c/include/ml-api-common.h
+++ b/c/include/ml-api-common.h
@@ -321,6 +321,30 @@ int ml_tensors_data_get_tensor_data (ml_tensors_data_h data, unsigned int index,
  */
 int ml_tensors_data_set_tensor_data (ml_tensors_data_h data, unsigned int index, const void *raw_data, const size_t data_size);
 
+
+/**
+ * @brief Returns a human-readable string describing the last error.
+ * @details This returns a human-readable, null-terminated string describing
+ *         the most recent error that occured from a call to one of the
+ *         funcctions in the Machine Learning API since the last call to
+ *         ml_error(). The returned string should *not* be freed or
+ *         overwritten by the caller.
+ * @since_tizen 7.0
+ * @return @c Null if no error to be reported. Otherwise the error description.
+ */
+const char * ml_error (void);
+
+/**
+ * @brief Returns a human-readable string describing for a error code
+ * @details This returns a human-readable, null-terminated string describing
+ *         the error code of machine learning APIs.
+ *         The returned string should *not* be freed or
+ *         overwritten by the caller.
+ * @since_tizen 7.0
+ * @return @c Null for invalid error code. Otherwise the error description.
+ */
+const char * ml_strerror (int errnum);
+
 /**
  * @}
  */

--- a/c/src/ml-api-common.c
+++ b/c/src/ml-api-common.c
@@ -928,3 +928,23 @@ ml_replace_string (gchar * source, const gchar * what, const gchar * to,
   g_free (source);
   return result;
 }
+
+/**
+ * @brief public API function of error reporting.
+ */
+const char *
+ml_error (void)
+{
+  /** @todo NYI **/
+  return NULL;
+}
+
+/**
+ * @brief public API function of error code descriptions
+ */
+const char *
+ml_strerror (int errnum)
+{
+  /** @todo NYI **/
+  return NULL;
+}


### PR DESCRIPTION
dlerror()-like function that can provide error descriptions.

This is to review its format and behavior.
The contents and internal APIs for API implementation will
follow after this API is approved.

This addresses (starts addressing) https://github.com/nnstreamer/nnstreamer/issues/3528

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>