### PR TITLE
C-API/Common: add _ prefix for internal functions. @open sesame 10/27 13:22

### DIFF
--- a/c/src/ml-api-common-tizen-feature-check.c
+++ b/c/src/ml-api-common-tizen-feature-check.c
@@ -55,7 +55,7 @@ ml_tizen_initialize_feature_state (void)
  * @brief Set the feature status of machine_learning.inference.
  */
 int
-ml_tizen_set_feature_state (int state)
+_ml_tizen_set_feature_state (int state)
 {
   ml_tizen_initialize_feature_state ();
   g_mutex_lock (&feature_info->mutex);
@@ -74,7 +74,7 @@ ml_tizen_set_feature_state (int state)
  * @brief Checks whether machine_learning.inference feature is enabled or not.
  */
 int
-ml_tizen_get_feature_enabled (void)
+_ml_tizen_get_feature_enabled (void)
 {
   int ret;
   int feature_enabled;
@@ -95,11 +95,11 @@ ml_tizen_get_feature_enabled (void)
     if (0 == ret) {
       if (false == ml_inf_supported) {
         _ml_loge ("machine_learning.inference NOT supported");
-        ml_tizen_set_feature_state (NOT_SUPPORTED);
+        _ml_tizen_set_feature_state (NOT_SUPPORTED);
         return ML_ERROR_NOT_SUPPORTED;
       }
 
-      ml_tizen_set_feature_state (SUPPORTED);
+      _ml_tizen_set_feature_state (SUPPORTED);
     } else {
       switch (ret) {
         case SYSTEM_INFO_ERROR_INVALID_PARAMETER:

--- a/c/src/ml-api-common.c
+++ b/c/src/ml-api-common.c
@@ -37,7 +37,7 @@ ml_tensors_info_create (ml_tensors_info_h * info)
   g_mutex_init (&tensors_info->lock);
 
   /* init tensors info struct */
-  return ml_tensors_info_initialize (tensors_info);
+  return _ml_tensors_info_initialize (tensors_info);
 }
 
 /**
@@ -57,7 +57,7 @@ ml_tensors_info_destroy (ml_tensors_info_h info)
 
   G_LOCK_UNLESS_NOLOCK (*tensors_info);
 
-  ml_tensors_info_free (tensors_info);
+  _ml_tensors_info_free (tensors_info);
   G_UNLOCK_UNLESS_NOLOCK (*tensors_info);
   g_mutex_clear (&tensors_info->lock);
   g_free (tensors_info);
@@ -69,7 +69,7 @@ ml_tensors_info_destroy (ml_tensors_info_h info)
  * @brief Initializes the tensors information with default value.
  */
 int
-ml_tensors_info_initialize (ml_tensors_info_s * info)
+_ml_tensors_info_initialize (ml_tensors_info_s * info)
 {
   guint i, j;
 
@@ -197,7 +197,7 @@ ml_tensors_info_validate (const ml_tensors_info_h info, bool *valid)
  * @brief Compares the given tensors information.
  */
 int
-ml_tensors_info_compare (const ml_tensors_info_h info1,
+_ml_tensors_info_compare (const ml_tensors_info_h info1,
     const ml_tensors_info_h info2, bool *equal)
 {
   ml_tensors_info_s *i1, *i2;
@@ -460,7 +460,7 @@ ml_tensors_info_get_tensor_dimension (ml_tensors_info_h info,
  * @brief Gets the byte size of the given tensor info.
  */
 size_t
-ml_tensor_info_get_size (const ml_tensor_info_s * info)
+_ml_tensor_info_get_size (const ml_tensor_info_s * info)
 {
   size_t tensor_size;
   gint i;
@@ -524,7 +524,7 @@ ml_tensors_info_get_tensor_size (ml_tensors_info_h info,
 
     /* get total byte size */
     for (i = 0; i < tensors_info->num_tensors; i++) {
-      *data_size += ml_tensor_info_get_size (&tensors_info->info[i]);
+      *data_size += _ml_tensor_info_get_size (&tensors_info->info[i]);
     }
   } else {
     if (tensors_info->num_tensors <= index) {
@@ -532,7 +532,7 @@ ml_tensors_info_get_tensor_size (ml_tensors_info_h info,
       return ML_ERROR_INVALID_PARAMETER;
     }
 
-    *data_size = ml_tensor_info_get_size (&tensors_info->info[index]);
+    *data_size = _ml_tensor_info_get_size (&tensors_info->info[index]);
   }
 
   G_UNLOCK_UNLESS_NOLOCK (*tensors_info);
@@ -544,7 +544,7 @@ ml_tensors_info_get_tensor_size (ml_tensors_info_h info,
  * @note This does not touch the lock
  */
 void
-ml_tensors_info_free (ml_tensors_info_s * info)
+_ml_tensors_info_free (ml_tensors_info_s * info)
 {
   gint i;
 
@@ -558,7 +558,7 @@ ml_tensors_info_free (ml_tensors_info_s * info)
     }
   }
 
-  ml_tensors_info_initialize (info);
+  _ml_tensors_info_initialize (info);
 }
 
 /**
@@ -568,7 +568,7 @@ ml_tensors_info_free (ml_tensors_info_s * info)
  * @return @c 0 on success. Otherwise a negative error value.
  */
 int
-ml_tensors_data_destroy_internal (ml_tensors_data_h data, gboolean free_data)
+_ml_tensors_data_destroy_internal (ml_tensors_data_h data, gboolean free_data)
 {
   int status = ML_ERROR_NONE;
   ml_tensors_data_s *_data;
@@ -609,7 +609,7 @@ int
 ml_tensors_data_destroy (ml_tensors_data_h data)
 {
   check_feature_state ();
-  return ml_tensors_data_destroy_internal (data, TRUE);
+  return _ml_tensors_data_destroy_internal (data, TRUE);
 }
 
 /**
@@ -617,7 +617,7 @@ ml_tensors_data_destroy (ml_tensors_data_h data)
  * @note Memory for data buffer is not allocated.
  */
 int
-ml_tensors_data_create_no_alloc (const ml_tensors_info_h info,
+_ml_tensors_data_create_no_alloc (const ml_tensors_info_h info,
     ml_tensors_data_h * data)
 {
   ml_tensors_data_s *_data;
@@ -647,7 +647,7 @@ ml_tensors_data_create_no_alloc (const ml_tensors_info_h info,
     G_LOCK_UNLESS_NOLOCK (*_info);
     _data->num_tensors = _info->num_tensors;
     for (i = 0; i < _data->num_tensors; i++) {
-      _data->tensors[i].size = ml_tensor_info_get_size (&_info->info[i]);
+      _data->tensors[i].size = _ml_tensor_info_get_size (&_info->info[i]);
       _data->tensors[i].tensor = NULL;
     }
     G_UNLOCK_UNLESS_NOLOCK (*_info);
@@ -662,7 +662,7 @@ ml_tensors_data_create_no_alloc (const ml_tensors_info_h info,
  * @note Memory ptr for data buffer is copied. No new memory for data buffer is allocated.
  */
 int
-ml_tensors_data_clone_no_alloc (const ml_tensors_data_s * data_src,
+_ml_tensors_data_clone_no_alloc (const ml_tensors_data_s * data_src,
     ml_tensors_data_h * data)
 {
   int status;
@@ -673,7 +673,7 @@ ml_tensors_data_clone_no_alloc (const ml_tensors_data_s * data_src,
   if (data == NULL || data_src == NULL)
     return ML_ERROR_INVALID_PARAMETER;
 
-  status = ml_tensors_data_create_no_alloc (data_src->info,
+  status = _ml_tensors_data_create_no_alloc (data_src->info,
       (ml_tensors_data_h *) & _data);
   if (status != ML_ERROR_NONE)
     return status;
@@ -710,7 +710,7 @@ ml_tensors_data_create (const ml_tensors_info_h info, ml_tensors_data_h * data)
   }
 
   status =
-      ml_tensors_data_create_no_alloc (info, (ml_tensors_data_h *) & _data);
+      _ml_tensors_data_create_no_alloc (info, (ml_tensors_data_h *) & _data);
 
   if (status != ML_ERROR_NONE) {
     return status;
@@ -830,7 +830,7 @@ ml_tensors_info_clone (ml_tensors_info_h dest, const ml_tensors_info_h src)
   if (status != ML_ERROR_NONE || !valid)
     goto done;
 
-  ml_tensors_info_initialize (dest_info);
+  _ml_tensors_info_initialize (dest_info);
 
   dest_info->num_tensors = src_info->num_tensors;
 
@@ -862,7 +862,7 @@ done:
  * @return Newly allocated string. The returned string should be freed with g_free().
  */
 gchar *
-ml_replace_string (gchar * source, const gchar * what, const gchar * to,
+_ml_replace_string (gchar * source, const gchar * what, const gchar * to,
     const gchar * delimiters, guint * count)
 {
   GString *builder;

--- a/c/src/ml-api-inference-internal.c
+++ b/c/src/ml-api-inference-internal.c
@@ -47,7 +47,7 @@ static const char *ml_nnfw_subplugin_name[] = {
  * @brief Internal function to get the sub-plugin name.
  */
 const char *
-ml_get_nnfw_subplugin_name (ml_nnfw_type_e nnfw)
+_ml_get_nnfw_subplugin_name (ml_nnfw_type_e nnfw)
 {
   /* check sub-plugin for android */
   if (nnfw == ML_NNFW_TYPE_SNAP)
@@ -60,7 +60,7 @@ ml_get_nnfw_subplugin_name (ml_nnfw_type_e nnfw)
  * @brief Allocates a tensors information handle from gst info.
  */
 int
-ml_tensors_info_create_from_gst (ml_tensors_info_h * ml_info,
+_ml_tensors_info_create_from_gst (ml_tensors_info_h * ml_info,
     GstTensorsInfo * gst_info)
 {
   int status;
@@ -72,7 +72,7 @@ ml_tensors_info_create_from_gst (ml_tensors_info_h * ml_info,
   if (status != ML_ERROR_NONE)
     return status;
 
-  ml_tensors_info_copy_from_gst (*ml_info, gst_info);
+  _ml_tensors_info_copy_from_gst (*ml_info, gst_info);
   return ML_ERROR_NONE;
 }
 
@@ -81,7 +81,7 @@ ml_tensors_info_create_from_gst (ml_tensors_info_h * ml_info,
  * @bug Thread safety required. Check its internal users first!
  */
 void
-ml_tensors_info_copy_from_gst (ml_tensors_info_s * ml_info,
+_ml_tensors_info_copy_from_gst (ml_tensors_info_s * ml_info,
     const GstTensorsInfo * gst_info)
 {
   guint i, j;
@@ -90,7 +90,7 @@ ml_tensors_info_copy_from_gst (ml_tensors_info_s * ml_info,
   if (!ml_info || !gst_info)
     return;
 
-  ml_tensors_info_initialize (ml_info);
+  _ml_tensors_info_initialize (ml_info);
   max_dim = MIN (ML_TENSOR_RANK_LIMIT, NNS_TENSOR_RANK_LIMIT);
 
   ml_info->num_tensors = gst_info->num_tensors;
@@ -154,7 +154,7 @@ ml_tensors_info_copy_from_gst (ml_tensors_info_s * ml_info,
  * @bug Thread safety required. Check its internal users first!
  */
 void
-ml_tensors_info_copy_from_ml (GstTensorsInfo * gst_info,
+_ml_tensors_info_copy_from_ml (GstTensorsInfo * gst_info,
     const ml_tensors_info_s * ml_info)
 {
   guint i, j;
@@ -229,7 +229,7 @@ ml_tensors_info_copy_from_ml (GstTensorsInfo * gst_info,
  * @brief Initializes the GStreamer library. This is internal function.
  */
 int
-ml_initialize_gstreamer (void)
+_ml_initialize_gstreamer (void)
 {
   GError *err = NULL;
 
@@ -251,7 +251,7 @@ ml_initialize_gstreamer (void)
  * @brief Internal helper function to validate model files.
  */
 static int
-_ml_validate_model_file (const char *const *model,
+__ml_validate_model_file (const char *const *model,
     const unsigned int num_models, gboolean * is_dir)
 {
   guint i;
@@ -281,7 +281,7 @@ _ml_validate_model_file (const char *const *model,
  * @brief Internal function to get the nnfw type.
  */
 ml_nnfw_type_e
-ml_get_nnfw_type_by_subplugin_name (const char *name)
+_ml_get_nnfw_type_by_subplugin_name (const char *name)
 {
   ml_nnfw_type_e nnfw_type = ML_NNFW_TYPE_ANY;
   int idx = -1;
@@ -314,7 +314,7 @@ ml_get_nnfw_type_by_subplugin_name (const char *name)
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int
-ml_validate_model_file (const char *const *model,
+_ml_validate_model_file (const char *const *model,
     const unsigned int num_models, ml_nnfw_type_e * nnfw)
 {
   int status = ML_ERROR_NONE;
@@ -327,7 +327,7 @@ ml_validate_model_file (const char *const *model,
   if (!nnfw)
     return ML_ERROR_INVALID_PARAMETER;
 
-  status = _ml_validate_model_file (model, num_models, &is_dir);
+  status = __ml_validate_model_file (model, num_models, &is_dir);
   if (status != ML_ERROR_NONE)
     return status;
 
@@ -337,7 +337,7 @@ ml_validate_model_file (const char *const *model,
    * If any condition for auto detection is added later, below code also should be updated.
    */
   fw_name = gst_tensor_filter_detect_framework (model, num_models, TRUE);
-  detected = ml_get_nnfw_type_by_subplugin_name (fw_name);
+  detected = _ml_get_nnfw_type_by_subplugin_name (fw_name);
   g_free (fw_name);
 
   if (*nnfw == ML_NNFW_TYPE_ANY) {
@@ -346,7 +346,7 @@ ml_validate_model_file (const char *const *model,
       status = ML_ERROR_INVALID_PARAMETER;
     } else {
       _ml_logi ("The given model is supposed a %s model.",
-          ml_get_nnfw_subplugin_name (detected));
+          _ml_get_nnfw_subplugin_name (detected));
       *nnfw = detected;
     }
 
@@ -417,8 +417,8 @@ ml_validate_model_file (const char *const *model,
 
 done:
   if (status == ML_ERROR_NONE) {
-    if (!ml_nnfw_is_available (*nnfw, ML_NNFW_HW_ANY)) {
-      _ml_loge ("%s is not available.", ml_get_nnfw_subplugin_name (*nnfw));
+    if (!_ml_nnfw_is_available (*nnfw, ML_NNFW_HW_ANY)) {
+      _ml_loge ("%s is not available.", _ml_get_nnfw_subplugin_name (*nnfw));
       status = ML_ERROR_NOT_SUPPORTED;
     }
   } else {
@@ -433,7 +433,7 @@ done:
  * @brief Convert c-api based hw to internal representation
  */
 accl_hw
-ml_nnfw_to_accl_hw (const ml_nnfw_hw_e hw)
+_ml_nnfw_to_accl_hw (const ml_nnfw_hw_e hw)
 {
   switch (hw) {
     case ML_NNFW_HW_ANY:
@@ -475,13 +475,13 @@ ml_nnfw_to_accl_hw (const ml_nnfw_hw_e hw)
  * @note More details on format can be found in gst_tensor_filter_install_properties() in tensor_filter_common.c.
  */
 char *
-ml_nnfw_to_str_prop (const ml_nnfw_hw_e hw)
+_ml_nnfw_to_str_prop (const ml_nnfw_hw_e hw)
 {
   const gchar *hw_name;
   const gchar *use_accl = "true:";
   gchar *str_prop = NULL;
 
-  hw_name = get_accl_hw_str (ml_nnfw_to_accl_hw (hw));
+  hw_name = get_accl_hw_str (_ml_nnfw_to_accl_hw (hw));
   str_prop = g_strdup_printf ("%s%s", use_accl, hw_name);
 
   return str_prop;
@@ -501,7 +501,7 @@ ml_check_element_availability (const char *element_name, bool *available)
   if (!element_name || !available)
     return ML_ERROR_INVALID_PARAMETER;
 
-  status = ml_initialize_gstreamer ();
+  status = _ml_initialize_gstreamer ();
   if (status != ML_ERROR_NONE)
     return status;
 
@@ -514,7 +514,7 @@ ml_check_element_availability (const char *element_name, bool *available)
     const gchar *plugin_name = gst_plugin_feature_get_plugin_name (feature);
 
     /* check restricted element */
-    status = ml_check_plugin_availability (plugin_name, element_name);
+    status = _ml_check_plugin_availability (plugin_name, element_name);
     if (status == ML_ERROR_NONE)
       *available = true;
 
@@ -528,7 +528,8 @@ ml_check_element_availability (const char *element_name, bool *available)
  * @brief Checks the availability of the plugin.
  */
 int
-ml_check_plugin_availability (const char *plugin_name, const char *element_name)
+_ml_check_plugin_availability (const char *plugin_name,
+    const char *element_name)
 {
   static gboolean list_loaded = FALSE;
   static gchar **restricted_elements = NULL;

--- a/c/src/ml-api-inference-internal.h
+++ b/c/src/ml-api-inference-internal.h
@@ -32,11 +32,11 @@ extern "C" {
 #if defined (__TIZEN__)
 #if defined (__PRIVILEGE_CHECK_SUPPORT__)
 
-#define convert_tizen_element(...) ml_tizen_convert_element(__VA_ARGS__)
+#define convert_tizen_element(...) _ml_tizen_convert_element(__VA_ARGS__)
 
 #if (TIZENVERSION >= 5) && (TIZENVERSION < 9999)
-#define get_tizen_resource(...) ml_tizen_get_resource(__VA_ARGS__)
-#define release_tizen_resource(...) ml_tizen_release_resource(__VA_ARGS__)
+#define get_tizen_resource(...) _ml_tizen_get_resource(__VA_ARGS__)
+#define release_tizen_resource(...) _ml_tizen_release_resource(__VA_ARGS__)
 
 #elif (TIZENVERSION < 5)
 #define get_tizen_resource(...) (0)
@@ -189,47 +189,47 @@ typedef struct _ml_pipeline_common_elem {
 /**
  * @brief Macro to check the availability of given NNFW.
  */
-#define ml_nnfw_is_available(f,h) ({bool a; (ml_check_nnfw_availability ((f), (h), &a) == ML_ERROR_NONE && a);})
+#define _ml_nnfw_is_available(f,h) ({bool a; (ml_check_nnfw_availability ((f), (h), &a) == ML_ERROR_NONE && a);})
 
 /**
  * @brief Macro to check the availability of given element.
  */
-#define ml_element_is_available(e) ({bool a; (ml_check_element_availability ((e), &a) == ML_ERROR_NONE && a);})
+#define _ml_element_is_available(e) ({bool a; (ml_check_element_availability ((e), &a) == ML_ERROR_NONE && a);})
 
 /**
  * @brief Allocates a tensors information handle from gst info.
  */
-int ml_tensors_info_create_from_gst (ml_tensors_info_h *ml_info, GstTensorsInfo *gst_info);
+int _ml_tensors_info_create_from_gst (ml_tensors_info_h *ml_info, GstTensorsInfo *gst_info);
 
 /**
  * @brief Copies tensor metadata from gst tensors info.
  */
-void ml_tensors_info_copy_from_gst (ml_tensors_info_s *ml_info, const GstTensorsInfo *gst_info);
+void _ml_tensors_info_copy_from_gst (ml_tensors_info_s *ml_info, const GstTensorsInfo *gst_info);
 
 /**
  * @brief Copies tensor metadata from ml tensors info.
  */
-void ml_tensors_info_copy_from_ml (GstTensorsInfo *gst_info, const ml_tensors_info_s *ml_info);
+void _ml_tensors_info_copy_from_ml (GstTensorsInfo *gst_info, const ml_tensors_info_s *ml_info);
 
 /**
  * @brief Internal function to get the sub-plugin name.
  */
-const char * ml_get_nnfw_subplugin_name (ml_nnfw_type_e nnfw);
+const char * _ml_get_nnfw_subplugin_name (ml_nnfw_type_e nnfw);
 
 /**
  * @brief Convert c-api based hw to internal representation
  */
-accl_hw ml_nnfw_to_accl_hw (const ml_nnfw_hw_e hw);
+accl_hw _ml_nnfw_to_accl_hw (const ml_nnfw_hw_e hw);
 
 /**
  * @brief Internal function to get the nnfw type.
  */
-ml_nnfw_type_e ml_get_nnfw_type_by_subplugin_name (const char *name);
+ml_nnfw_type_e _ml_get_nnfw_type_by_subplugin_name (const char *name);
 
 /**
  * @brief Initializes the GStreamer library. This is internal function.
  */
-int ml_initialize_gstreamer (void);
+int _ml_initialize_gstreamer (void);
 
 /**
  * @brief Validates the nnfw model file. (Internal only)
@@ -242,18 +242,18 @@ int ml_initialize_gstreamer (void);
  * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_validate_model_file (const char * const *model, const unsigned int num_models, ml_nnfw_type_e * nnfw);
+int _ml_validate_model_file (const char * const *model, const unsigned int num_models, ml_nnfw_type_e * nnfw);
 
 /**
  * @brief Checks the availability of the plugin.
  */
-int ml_check_plugin_availability (const char *plugin_name, const char *element_name);
+int _ml_check_plugin_availability (const char *plugin_name, const char *element_name);
 
 /**
  * @brief Internal function to convert accelerator as tensor_filter property format.
  * @note returned value must be freed by the caller
  */
-char* ml_nnfw_to_str_prop (ml_nnfw_hw_e hw);
+char* _ml_nnfw_to_str_prop (ml_nnfw_hw_e hw);
 
 /**
  * @brief Gets the element of pipeline itself (GstElement).
@@ -261,24 +261,24 @@ char* ml_nnfw_to_str_prop (ml_nnfw_hw_e hw);
  *          Note that caller should release the returned reference using gst_object_unref().
  * @return The reference of pipeline itself. Null if the pipeline is not constructed or closed.
  */
-GstElement* ml_pipeline_get_gst_element (ml_pipeline_h pipe);
+GstElement* _ml_pipeline_get_gst_element (ml_pipeline_h pipe);
 
 #if defined (__TIZEN__)
 /****** TIZEN PRIVILEGE CHECK BEGINS ******/
 /**
  * @brief Releases the resource handle of Tizen.
  */
-void ml_tizen_release_resource (gpointer handle, const gchar * res_type);
+void _ml_tizen_release_resource (gpointer handle, const gchar * res_type);
 
 /**
  * @brief Gets the resource handle of Tizen.
  */
-int ml_tizen_get_resource (ml_pipeline_h pipe, const gchar * res_type);
+int _ml_tizen_get_resource (ml_pipeline_h pipe, const gchar * res_type);
 
 /**
  * @brief Converts predefined element for Tizen.
  */
-int ml_tizen_convert_element (ml_pipeline_h pipe, gchar ** result, gboolean is_internal);
+int _ml_tizen_convert_element (ml_pipeline_h pipe, gchar ** result, gboolean is_internal);
 /****** TIZEN PRIVILEGE CHECK ENDS ******/
 #endif /* __TIZEN */
 #ifdef __cplusplus

--- a/c/src/ml-api-inference-tizen-privilege-check.c
+++ b/c/src/ml-api-inference-tizen-privilege-check.c
@@ -655,7 +655,7 @@ ml_tizen_mm_replace_element (MMHandleType * handle, camera_conf * conf,
   }
 
   *description =
-      ml_replace_string (*description, what, src_name, " !", &changed);
+      _ml_replace_string (*description, what, src_name, " !", &changed);
   if (changed > 1) {
     /* allow one src in the pipeline */
     _ml_loge ("Cannot parse duplicated src node.");
@@ -730,7 +730,7 @@ ml_tizen_mm_convert_element (ml_pipeline_h pipe, gchar ** result,
         status = ML_ERROR_NOT_SUPPORTED;
         goto mm_error;
       }
-      *result = ml_replace_string (*result, ML_TIZEN_CAM_VIDEO_SRC, src_name,
+      *result = _ml_replace_string (*result, ML_TIZEN_CAM_VIDEO_SRC, src_name,
           " !", &changed);
       if (changed > 1) {
         /* Allow one src only in a pipeline */
@@ -751,7 +751,7 @@ ml_tizen_mm_convert_element (ml_pipeline_h pipe, gchar ** result,
         status = ML_ERROR_NOT_SUPPORTED;
         goto mm_error;
       }
-      *result = ml_replace_string (*result, ML_TIZEN_CAM_AUDIO_SRC, src_name,
+      *result = _ml_replace_string (*result, ML_TIZEN_CAM_AUDIO_SRC, src_name,
           " !", &changed);
       if (changed > 1) {
         /* Allow one src only in a pipeline */
@@ -851,7 +851,7 @@ ml_tizen_mm_convert_element (ml_pipeline_h pipe, gchar ** result,
  * @brief Releases the resource handle of Tizen.
  */
 void
-ml_tizen_release_resource (gpointer handle, const gchar * res_type)
+_ml_tizen_release_resource (gpointer handle, const gchar * res_type)
 {
   if (g_str_equal (res_type, TIZEN_RES_MM)) {
     ml_tizen_mm_res_release (handle, TRUE);
@@ -862,7 +862,7 @@ ml_tizen_release_resource (gpointer handle, const gchar * res_type)
  * @brief Gets the resource handle of Tizen.
  */
 int
-ml_tizen_get_resource (ml_pipeline_h pipe, const gchar * res_type)
+_ml_tizen_get_resource (ml_pipeline_h pipe, const gchar * res_type)
 {
   int status = ML_ERROR_NONE;
 
@@ -878,7 +878,7 @@ ml_tizen_get_resource (ml_pipeline_h pipe, const gchar * res_type)
  * @brief Converts predefined element for Tizen.
  */
 int
-ml_tizen_convert_element (ml_pipeline_h pipe, gchar ** result,
+_ml_tizen_convert_element (ml_pipeline_h pipe, gchar ** result,
     gboolean is_internal)
 {
   int status;

--- a/c/src/ml-api-internal.h
+++ b/c/src/ml-api-internal.h
@@ -65,12 +65,12 @@ typedef enum
 #if defined (__FEATURE_CHECK_SUPPORT__)
 #define check_feature_state() \
   do { \
-    int feature_ret = ml_tizen_get_feature_enabled (); \
+    int feature_ret = _ml_tizen_get_feature_enabled (); \
     if (ML_ERROR_NONE != feature_ret) \
       return feature_ret; \
   } while (0);
 
-#define set_feature_state(...) ml_tizen_set_feature_state(__VA_ARGS__)
+#define set_feature_state(...) _ml_tizen_set_feature_state(__VA_ARGS__)
 #else /* __FEATURE_CHECK_SUPPORT__ */
 #define check_feature_state()
 #define set_feature_state(...)
@@ -164,7 +164,7 @@ typedef struct {
 /**
  * @brief Macro to compare the tensors info.
  */
-#define ml_tensors_info_is_equal(i1,i2) ({bool e; (ml_tensors_info_compare ((i1), (i2), &e) == ML_ERROR_NONE && e);})
+#define ml_tensors_info_is_equal(i1,i2) ({bool e; (_ml_tensors_info_compare ((i1), (i2), &e) == ML_ERROR_NONE && e);})
 
 /**
  * @brief The function to be called when destroying the allocated handle.
@@ -204,7 +204,7 @@ typedef struct {
  * @brief Gets the byte size of the given tensor info.
  * @note This is not thread safe.
  */
-size_t ml_tensor_info_get_size (const ml_tensor_info_s *info);
+size_t _ml_tensor_info_get_size (const ml_tensor_info_s *info);
 
 /**
  * @brief Initializes the tensors information with default value.
@@ -214,14 +214,14 @@ size_t ml_tensor_info_get_size (const ml_tensor_info_s *info);
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_tensors_info_initialize (ml_tensors_info_s *info);
+int _ml_tensors_info_initialize (ml_tensors_info_s *info);
 
 /**
  * @brief Frees and initialize the data in tensors info.
  * @since_tizen 5.5
  * @param[in] info The tensors info pointer to be freed.
  */
-void ml_tensors_info_free (ml_tensors_info_s *info);
+void _ml_tensors_info_free (ml_tensors_info_s *info);
 
 /**
  * @brief Creates a tensor data frame without allocating new buffer cloning the given tensors data.
@@ -233,7 +233,7 @@ void ml_tensors_info_free (ml_tensors_info_s *info);
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  * @retval #ML_ERROR_OUT_OF_MEMORY Failed to allocate required memory.
  */
-int ml_tensors_data_clone_no_alloc (const ml_tensors_data_s * data_src, ml_tensors_data_h * data);
+int _ml_tensors_data_clone_no_alloc (const ml_tensors_data_s * data_src, ml_tensors_data_h * data);
 
 /**
  * @brief Replaces string.
@@ -246,7 +246,7 @@ int ml_tensors_data_clone_no_alloc (const ml_tensors_data_s * data_src, ml_tenso
  * @param[out] count The count of replaced. Set NULL if it is unnecessary.
  * @return Newly allocated string. The returned string should be freed with g_free().
  */
-gchar * ml_replace_string (gchar * source, const gchar * what, const gchar * to, const gchar * delimiters, guint * count);
+gchar * _ml_replace_string (gchar * source, const gchar * what, const gchar * to, const gchar * delimiters, guint * count);
 
 /**
  * @brief Compares the given tensors information.
@@ -260,7 +260,7 @@ gchar * ml_replace_string (gchar * source, const gchar * what, const gchar * to,
  * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_tensors_info_compare (const ml_tensors_info_h info1, const ml_tensors_info_h info2, bool *equal);
+int _ml_tensors_info_compare (const ml_tensors_info_h info1, const ml_tensors_info_h info2, bool *equal);
 
 /**
  * @brief Frees the tensors data handle and its data.
@@ -268,7 +268,7 @@ int ml_tensors_info_compare (const ml_tensors_info_h info1, const ml_tensors_inf
  * @param[in] free_data The flag to free the buffers in handle.
  * @return @c 0 on success. Otherwise a negative error value.
  */
-int ml_tensors_data_destroy_internal (ml_tensors_data_h data, gboolean free_data);
+int _ml_tensors_data_destroy_internal (ml_tensors_data_h data, gboolean free_data);
 
 /**
  * @brief Creates a tensor data frame without buffer with the given tensors information.
@@ -277,20 +277,20 @@ int ml_tensors_data_destroy_internal (ml_tensors_data_h data, gboolean free_data
  * @param[out] data The handle of tensors data.
  * @return @c 0 on success. Otherwise a negative error value.
  */
-int ml_tensors_data_create_no_alloc (const ml_tensors_info_h info, ml_tensors_data_h *data);
+int _ml_tensors_data_create_no_alloc (const ml_tensors_info_h info, ml_tensors_data_h *data);
 
 #if defined (__TIZEN__)
 /****** TIZEN CHECK FEATURE BEGINS *****/
 /**
  * @brief Checks whether machine_learning.inference feature is enabled or not.
  */
-int ml_tizen_get_feature_enabled (void);
+int _ml_tizen_get_feature_enabled (void);
 
 /**
  * @brief Set the feature status of machine_learning.inference.
  * This is only used for Unit test.
  */
-int ml_tizen_set_feature_state (int state);
+int _ml_tizen_set_feature_state (int state);
 /****** TIZEN CHECK FEATURE ENDS *****/
 #endif /* __TIZEN__ */
 

--- a/java/android/nnstreamer/src/main/jni/nnstreamer-native-api.c
+++ b/java/android/nnstreamer/src/main/jni/nnstreamer-native-api.c
@@ -511,7 +511,7 @@ nns_parse_tensors_data (pipeline_info_s * pipe_info, JNIEnv * env,
       }
     }
 
-    status = ml_tensors_data_create_no_alloc (_info, data_h);
+    status = _ml_tensors_data_create_no_alloc (_info, data_h);
     if (_info != info_h)
       ml_tensors_info_destroy (_info);
 
@@ -718,7 +718,7 @@ nns_get_nnfw_type (jint fw_type, ml_nnfw_type_e * nnfw)
       return FALSE;
   }
 
-  return ml_nnfw_is_available (*nnfw, ML_NNFW_HW_ANY);
+  return _ml_nnfw_is_available (*nnfw, ML_NNFW_HW_ANY);
 }
 
 /**
@@ -743,7 +743,7 @@ nnstreamer_native_initialize (JNIEnv * env, jobject context)
       gst_android_init (env, context);
     } else {
 #else
-    if (ml_initialize_gstreamer () != ML_ERROR_NONE) {
+    if (_ml_initialize_gstreamer () != ML_ERROR_NONE) {
 #endif
       nns_loge ("Invalid params, cannot initialize GStreamer.");
       goto done;

--- a/java/android/nnstreamer/src/main/jni/nnstreamer-native-customfilter.c
+++ b/java/android/nnstreamer/src/main/jni/nnstreamer-native-customfilter.c
@@ -58,7 +58,7 @@ nns_customfilter_priv_set_info (pipeline_info_s * pipe_info, JNIEnv * env,
       return FALSE;
     }
 
-    ml_tensors_info_free (priv->in_info);
+    _ml_tensors_info_free (priv->in_info);
     ml_tensors_info_clone (priv->in_info, in_info);
 
     if (priv->in_info_obj)
@@ -68,7 +68,7 @@ nns_customfilter_priv_set_info (pipeline_info_s * pipe_info, JNIEnv * env,
   }
 
   if (!ml_tensors_info_is_equal (out_info, priv->out_info)) {
-    ml_tensors_info_free (priv->out_info);
+    _ml_tensors_info_free (priv->out_info);
     ml_tensors_info_clone (priv->out_info, out_info);
   }
 

--- a/java/android/nnstreamer/src/main/jni/nnstreamer-native-pipeline.c
+++ b/java/android/nnstreamer/src/main/jni/nnstreamer-native-pipeline.c
@@ -128,7 +128,7 @@ nns_pipeline_sink_priv_set_out_info (element_data_s * item, JNIEnv * env,
     return FALSE;
   }
 
-  ml_tensors_info_free (priv->out_info);
+  _ml_tensors_info_free (priv->out_info);
   ml_tensors_info_clone (priv->out_info, out_info);
 
   if (priv->out_info_obj)
@@ -939,7 +939,7 @@ static jboolean
 nns_native_check_element_availability (JNIEnv * env, jclass clazz, jstring name)
 {
   const char *element_name = (*env)->GetStringUTFChars (env, name, NULL);
-  jboolean res = ml_element_is_available (element_name) ? JNI_TRUE : JNI_FALSE;
+  jboolean res = _ml_element_is_available (element_name) ? JNI_TRUE : JNI_FALSE;
 
   (*env)->ReleaseStringUTFChars (env, name, element_name);
   return res;

--- a/java/android/nnstreamer/src/main/jni/nnstreamer-native-singleshot.c
+++ b/java/android/nnstreamer/src/main/jni/nnstreamer-native-singleshot.c
@@ -65,7 +65,7 @@ nns_singleshot_priv_set_info (pipeline_info_s * pipe_info, JNIEnv * env)
   }
 
   if (!ml_tensors_info_is_equal (in_info, priv->in_info)) {
-    ml_tensors_info_free (priv->in_info);
+    _ml_tensors_info_free (priv->in_info);
     ml_tensors_info_clone (priv->in_info, in_info);
   }
 
@@ -75,7 +75,7 @@ nns_singleshot_priv_set_info (pipeline_info_s * pipe_info, JNIEnv * env)
       goto done;
     }
 
-    ml_tensors_info_free (priv->out_info);
+    _ml_tensors_info_free (priv->out_info);
     ml_tensors_info_clone (priv->out_info, out_info);
 
     if (priv->out_info_obj)

--- a/tests/capi/unittest_capi_inference.cc
+++ b/tests/capi/unittest_capi_inference.cc
@@ -1870,7 +1870,7 @@ TEST (nnstreamer_capi_util, plugin_availability_fail_invalid_01_n)
 {
   int status;
 
-  status = ml_check_plugin_availability (NULL, "tensor_filter");
+  status = _ml_check_plugin_availability (NULL, "tensor_filter");
   EXPECT_NE (status, ML_ERROR_NONE);
 }
 
@@ -1881,7 +1881,7 @@ TEST (nnstreamer_capi_util, plugin_availability_fail_invalid_02_n)
 {
   int status;
 
-  status = ml_check_plugin_availability (NULL, "tensor_filter");
+  status = _ml_check_plugin_availability (NULL, "tensor_filter");
   EXPECT_NE (status, ML_ERROR_NONE);
 }
 
@@ -2455,7 +2455,7 @@ TEST (nnstreamer_capi_util, info_create_1_n)
 TEST (nnstreamer_capi_util, info_create_2_n)
 {
   ml_tensors_info_h i;
-  int status = ml_tensors_info_create_from_gst (&i, nullptr);
+  int status = _ml_tensors_info_create_from_gst (&i, nullptr);
   ASSERT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 }
 
@@ -2465,7 +2465,7 @@ TEST (nnstreamer_capi_util, info_create_2_n)
 TEST (nnstreamer_capi_util, info_create_3_n)
 {
   GstTensorsInfo gi;
-  int status = ml_tensors_info_create_from_gst (nullptr, &gi);
+  int status = _ml_tensors_info_create_from_gst (nullptr, &gi);
   ASSERT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 }
 
@@ -2483,7 +2483,7 @@ TEST (nnstreamer_capi_util, info_destroy_n)
  */
 TEST (nnstreamer_capi_util, info_init_n)
 {
-  int status = ml_tensors_info_initialize (nullptr);
+  int status = _ml_tensors_info_initialize (nullptr);
   ASSERT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 }
 
@@ -2537,7 +2537,7 @@ TEST (nnstreamer_capi_util, info_comp_01_n)
   ml_tensors_info_set_tensor_type (info, 0, ML_TENSOR_TYPE_UINT8);
   ml_tensors_info_set_tensor_dimension (info, 0, dim);
 
-  status = ml_tensors_info_compare (nullptr, info, &equal);
+  status = _ml_tensors_info_compare (nullptr, info, &equal);
   ASSERT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 
   status = ml_tensors_info_destroy (info);
@@ -2562,7 +2562,7 @@ TEST (nnstreamer_capi_util, info_comp_02_n)
   ml_tensors_info_set_tensor_type (info, 0, ML_TENSOR_TYPE_UINT8);
   ml_tensors_info_set_tensor_dimension (info, 0, dim);
 
-  status = ml_tensors_info_compare (info, nullptr, &equal);
+  status = _ml_tensors_info_compare (info, nullptr, &equal);
   ASSERT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 
   status = ml_tensors_info_destroy (info);
@@ -2592,7 +2592,7 @@ TEST (nnstreamer_capi_util, info_comp_03_n)
   ml_tensors_info_set_tensor_type (info2, 0, ML_TENSOR_TYPE_UINT8);
   ml_tensors_info_set_tensor_dimension (info2, 0, dim);
 
-  status = ml_tensors_info_compare (info1, info2, nullptr);
+  status = _ml_tensors_info_compare (info1, info2, nullptr);
   ASSERT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 
   status = ml_tensors_info_destroy (info1);
@@ -2620,7 +2620,7 @@ TEST (nnstreamer_capi_util, info_comp_0)
   is = (ml_tensors_info_s *)info2;
   is->num_tensors = 2;
 
-  status = ml_tensors_info_compare (info1, info2, &equal);
+  status = _ml_tensors_info_compare (info1, info2, &equal);
   ASSERT_EQ (status, ML_ERROR_NONE);
   ASSERT_FALSE (equal);
 
@@ -3131,7 +3131,7 @@ TEST (nnstreamer_capi_util, data_create_internal_n)
 {
   int status;
 
-  status = ml_tensors_data_create_no_alloc (NULL, NULL);
+  status = _ml_tensors_data_create_no_alloc (NULL, NULL);
   EXPECT_NE (status, ML_ERROR_NONE);
 }
 
@@ -3396,16 +3396,16 @@ TEST (nnstreamer_capi_util, data_set_tdata_05_n)
  */
 TEST (nnstreamer_capi_util, nnfw_name_01_p)
 {
-  EXPECT_STREQ (ml_get_nnfw_subplugin_name (ML_NNFW_TYPE_TENSORFLOW_LITE), "tensorflow-lite");
-  EXPECT_EQ (ml_get_nnfw_type_by_subplugin_name ("tensorflow-lite"), ML_NNFW_TYPE_TENSORFLOW_LITE);
-  EXPECT_STREQ (ml_get_nnfw_subplugin_name (ML_NNFW_TYPE_TENSORFLOW), "tensorflow");
-  EXPECT_EQ (ml_get_nnfw_type_by_subplugin_name ("tensorflow"), ML_NNFW_TYPE_TENSORFLOW);
-  EXPECT_STREQ (ml_get_nnfw_subplugin_name (ML_NNFW_TYPE_NNFW), "nnfw");
-  EXPECT_EQ (ml_get_nnfw_type_by_subplugin_name ("nnfw"), ML_NNFW_TYPE_NNFW);
-  EXPECT_STREQ (ml_get_nnfw_subplugin_name (ML_NNFW_TYPE_VIVANTE), "vivante");
-  EXPECT_EQ (ml_get_nnfw_type_by_subplugin_name ("vivante"), ML_NNFW_TYPE_VIVANTE);
-  EXPECT_STREQ (ml_get_nnfw_subplugin_name (ML_NNFW_TYPE_SNAP), "snap");
-  EXPECT_EQ (ml_get_nnfw_type_by_subplugin_name ("snap"), ML_NNFW_TYPE_SNAP);
+  EXPECT_STREQ (_ml_get_nnfw_subplugin_name (ML_NNFW_TYPE_TENSORFLOW_LITE), "tensorflow-lite");
+  EXPECT_EQ (_ml_get_nnfw_type_by_subplugin_name ("tensorflow-lite"), ML_NNFW_TYPE_TENSORFLOW_LITE);
+  EXPECT_STREQ (_ml_get_nnfw_subplugin_name (ML_NNFW_TYPE_TENSORFLOW), "tensorflow");
+  EXPECT_EQ (_ml_get_nnfw_type_by_subplugin_name ("tensorflow"), ML_NNFW_TYPE_TENSORFLOW);
+  EXPECT_STREQ (_ml_get_nnfw_subplugin_name (ML_NNFW_TYPE_NNFW), "nnfw");
+  EXPECT_EQ (_ml_get_nnfw_type_by_subplugin_name ("nnfw"), ML_NNFW_TYPE_NNFW);
+  EXPECT_STREQ (_ml_get_nnfw_subplugin_name (ML_NNFW_TYPE_VIVANTE), "vivante");
+  EXPECT_EQ (_ml_get_nnfw_type_by_subplugin_name ("vivante"), ML_NNFW_TYPE_VIVANTE);
+  EXPECT_STREQ (_ml_get_nnfw_subplugin_name (ML_NNFW_TYPE_SNAP), "snap");
+  EXPECT_EQ (_ml_get_nnfw_type_by_subplugin_name ("snap"), ML_NNFW_TYPE_SNAP);
 }
 
 /**
@@ -3414,8 +3414,8 @@ TEST (nnstreamer_capi_util, nnfw_name_01_p)
  */
 TEST (nnstreamer_capi_util, nnfw_name_02_n)
 {
-  EXPECT_EQ (ml_get_nnfw_type_by_subplugin_name ("invalid-fw"), ML_NNFW_TYPE_ANY);
-  EXPECT_EQ (ml_get_nnfw_type_by_subplugin_name (NULL), ML_NNFW_TYPE_ANY);
+  EXPECT_EQ (_ml_get_nnfw_type_by_subplugin_name ("invalid-fw"), ML_NNFW_TYPE_ANY);
+  EXPECT_EQ (_ml_get_nnfw_type_by_subplugin_name (NULL), ML_NNFW_TYPE_ANY);
 }
 
 /**
@@ -3515,7 +3515,7 @@ TEST (nnstreamer_capi_singleshot, invoke_invalid_param_02_n)
   ml_tensors_info_set_tensor_dimension (in_info, 0, in_dim);
 
   /* handle null data */
-  status = ml_tensors_data_create_no_alloc (in_info, &input);
+  status = _ml_tensors_data_create_no_alloc (in_info, &input);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_single_invoke (single, input, &output);
@@ -9632,7 +9632,7 @@ TEST (nnstreamer_capi_element, scenario_02_p)
 }
 
 /**
- * @brief Test for internal function 'ml_tensors_info_copy_from_gst'.
+ * @brief Test for internal function '_ml_tensors_info_copy_from_gst'.
  */
 TEST (nnstreamer_capi_internal, copy_from_gst)
 {
@@ -9655,7 +9655,7 @@ TEST (nnstreamer_capi_internal, copy_from_gst)
   status = ml_tensors_info_create (&ml_info);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
+  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
   status = ml_tensors_info_get_count (ml_info, &count);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (count, 2U);
@@ -9668,7 +9668,7 @@ TEST (nnstreamer_capi_internal, copy_from_gst)
 
   gst_info.info[0].type = _NNS_INT32;
   gst_info.info[1].type = _NNS_UINT32;
-  ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
+  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
   status = ml_tensors_info_get_tensor_type (ml_info, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (type, ML_TENSOR_TYPE_INT32);
@@ -9678,7 +9678,7 @@ TEST (nnstreamer_capi_internal, copy_from_gst)
 
   gst_info.info[0].type = _NNS_INT16;
   gst_info.info[1].type = _NNS_UINT16;
-  ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
+  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
   status = ml_tensors_info_get_tensor_type (ml_info, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (type, ML_TENSOR_TYPE_INT16);
@@ -9688,7 +9688,7 @@ TEST (nnstreamer_capi_internal, copy_from_gst)
 
   gst_info.info[0].type = _NNS_INT8;
   gst_info.info[1].type = _NNS_UINT8;
-  ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
+  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
   status = ml_tensors_info_get_tensor_type (ml_info, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (type, ML_TENSOR_TYPE_INT8);
@@ -9698,7 +9698,7 @@ TEST (nnstreamer_capi_internal, copy_from_gst)
 
   gst_info.info[0].type = _NNS_INT64;
   gst_info.info[1].type = _NNS_UINT64;
-  ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
+  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
   status = ml_tensors_info_get_tensor_type (ml_info, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (type, ML_TENSOR_TYPE_INT64);
@@ -9708,7 +9708,7 @@ TEST (nnstreamer_capi_internal, copy_from_gst)
 
   gst_info.info[0].type = _NNS_FLOAT64;
   gst_info.info[1].type = _NNS_FLOAT32;
-  ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
+  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
   status = ml_tensors_info_get_tensor_type (ml_info, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (type, ML_TENSOR_TYPE_FLOAT64);
@@ -9718,7 +9718,7 @@ TEST (nnstreamer_capi_internal, copy_from_gst)
 
   gst_info.info[0].name = g_strdup ("tn1");
   gst_info.info[1].name = g_strdup ("tn2");
-  ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
+  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
   status = ml_tensors_info_get_tensor_name (ml_info, 0, &name);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_STREQ (name, "tn1");
@@ -9735,7 +9735,7 @@ TEST (nnstreamer_capi_internal, copy_from_gst)
 }
 
 /**
- * @brief Test for internal function 'ml_tensors_info_copy_from_ml'.
+ * @brief Test for internal function '_ml_tensors_info_copy_from_ml'.
  */
 TEST (nnstreamer_capi_internal, copy_from_ml)
 {
@@ -9755,7 +9755,7 @@ TEST (nnstreamer_capi_internal, copy_from_ml)
   status = ml_tensors_info_set_tensor_dimension (ml_info, 1, dim);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
+  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
   EXPECT_EQ (gst_info.num_tensors, 2U);
   EXPECT_EQ (gst_info.info[0].dimension[0], 1U);
   EXPECT_EQ (gst_info.info[0].dimension[1], 2U);
@@ -9766,7 +9766,7 @@ TEST (nnstreamer_capi_internal, copy_from_ml)
   EXPECT_EQ (status, ML_ERROR_NONE);
   status = ml_tensors_info_set_tensor_type (ml_info, 1, ML_TENSOR_TYPE_UINT32);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
+  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
   EXPECT_EQ (gst_info.info[0].type, _NNS_INT32);
   EXPECT_EQ (gst_info.info[1].type, _NNS_UINT32);
 
@@ -9774,7 +9774,7 @@ TEST (nnstreamer_capi_internal, copy_from_ml)
   EXPECT_EQ (status, ML_ERROR_NONE);
   status = ml_tensors_info_set_tensor_type (ml_info, 1, ML_TENSOR_TYPE_UINT16);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
+  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
   EXPECT_EQ (gst_info.info[0].type, _NNS_INT16);
   EXPECT_EQ (gst_info.info[1].type, _NNS_UINT16);
 
@@ -9782,7 +9782,7 @@ TEST (nnstreamer_capi_internal, copy_from_ml)
   EXPECT_EQ (status, ML_ERROR_NONE);
   status = ml_tensors_info_set_tensor_type (ml_info, 1, ML_TENSOR_TYPE_UINT8);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
+  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
   EXPECT_EQ (gst_info.info[0].type, _NNS_INT8);
   EXPECT_EQ (gst_info.info[1].type, _NNS_UINT8);
 
@@ -9790,7 +9790,7 @@ TEST (nnstreamer_capi_internal, copy_from_ml)
   EXPECT_EQ (status, ML_ERROR_NONE);
   status = ml_tensors_info_set_tensor_type (ml_info, 1, ML_TENSOR_TYPE_UINT64);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
+  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
   EXPECT_EQ (gst_info.info[0].type, _NNS_INT64);
   EXPECT_EQ (gst_info.info[1].type, _NNS_UINT64);
 
@@ -9798,7 +9798,7 @@ TEST (nnstreamer_capi_internal, copy_from_ml)
   EXPECT_EQ (status, ML_ERROR_NONE);
   status = ml_tensors_info_set_tensor_type (ml_info, 1, ML_TENSOR_TYPE_FLOAT32);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
+  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
   EXPECT_EQ (gst_info.info[0].type, _NNS_FLOAT64);
   EXPECT_EQ (gst_info.info[1].type, _NNS_FLOAT32);
 
@@ -9806,7 +9806,7 @@ TEST (nnstreamer_capi_internal, copy_from_ml)
   EXPECT_EQ (status, ML_ERROR_NONE);
   status = ml_tensors_info_set_tensor_name (ml_info, 1, "tn2");
   EXPECT_EQ (status, ML_ERROR_NONE);
-  ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
+  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
   EXPECT_STREQ (gst_info.info[0].name, "tn1");
   EXPECT_STREQ (gst_info.info[1].name, "tn2");
 
@@ -9817,7 +9817,7 @@ TEST (nnstreamer_capi_internal, copy_from_ml)
 }
 
 /**
- * @brief Test for internal function 'ml_validate_model_file'.
+ * @brief Test for internal function '_ml_validate_model_file'.
  * @detail Invalid params.
  */
 TEST (nnstreamer_capi_internal, validate_model_file_01_n)
@@ -9839,13 +9839,13 @@ TEST (nnstreamer_capi_internal, validate_model_file_01_n)
     goto skip_test;
   }
 
-  status = ml_validate_model_file (NULL, 1, &nnfw);
+  status = _ml_validate_model_file (NULL, 1, &nnfw);
   EXPECT_NE (status, ML_ERROR_NONE);
 
-  status = ml_validate_model_file (&test_model, 0, &nnfw);
+  status = _ml_validate_model_file (&test_model, 0, &nnfw);
   EXPECT_NE (status, ML_ERROR_NONE);
 
-  status = ml_validate_model_file (&test_model, 1, NULL);
+  status = _ml_validate_model_file (&test_model, 1, NULL);
   EXPECT_NE (status, ML_ERROR_NONE);
 
 skip_test:
@@ -9854,7 +9854,7 @@ skip_test:
 }
 
 /**
- * @brief Test for internal function 'ml_validate_model_file'.
+ * @brief Test for internal function '_ml_validate_model_file'.
  * @detail Invalid file extension.
  */
 TEST (nnstreamer_capi_internal, validate_model_file_02_n)
@@ -9891,41 +9891,41 @@ TEST (nnstreamer_capi_internal, validate_model_file_02_n)
   test_models[1] = test_model2;
 
   nnfw = ML_NNFW_TYPE_CUSTOM_FILTER;
-  status = ml_validate_model_file (&test_model2, 1, &nnfw);
+  status = _ml_validate_model_file (&test_model2, 1, &nnfw);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   nnfw = ML_NNFW_TYPE_TENSORFLOW_LITE;
-  status = ml_validate_model_file (&test_model1, 1, &nnfw);
+  status = _ml_validate_model_file (&test_model1, 1, &nnfw);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   nnfw = ML_NNFW_TYPE_TENSORFLOW;
-  status = ml_validate_model_file (&test_model2, 1, &nnfw);
+  status = _ml_validate_model_file (&test_model2, 1, &nnfw);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   /* snap only for android */
   nnfw = ML_NNFW_TYPE_SNAP;
-  status = ml_validate_model_file (&test_model1, 1, &nnfw);
+  status = _ml_validate_model_file (&test_model1, 1, &nnfw);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   nnfw = ML_NNFW_TYPE_VIVANTE;
-  status = ml_validate_model_file (test_models, 1, &nnfw);
+  status = _ml_validate_model_file (test_models, 1, &nnfw);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   /** @todo currently mvnc, openvino and edgetpu always return failure */
   nnfw = ML_NNFW_TYPE_MVNC;
-  status = ml_validate_model_file (&test_model1, 1, &nnfw);
+  status = _ml_validate_model_file (&test_model1, 1, &nnfw);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   nnfw = ML_NNFW_TYPE_OPENVINO;
-  status = ml_validate_model_file (&test_model1, 1, &nnfw);
+  status = _ml_validate_model_file (&test_model1, 1, &nnfw);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   nnfw = ML_NNFW_TYPE_EDGE_TPU;
-  status = ml_validate_model_file (&test_model1, 1, &nnfw);
+  status = _ml_validate_model_file (&test_model1, 1, &nnfw);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   nnfw = ML_NNFW_TYPE_ARMNN;
-  status = ml_validate_model_file (&test_model1, 1, &nnfw);
+  status = _ml_validate_model_file (&test_model1, 1, &nnfw);
   EXPECT_NE (status, ML_ERROR_NONE);
 
 skip_test:
@@ -9935,7 +9935,7 @@ skip_test:
 }
 
 /**
- * @brief Test for internal function 'ml_validate_model_file'.
+ * @brief Test for internal function '_ml_validate_model_file'.
  * @detail Invalid model path.
  */
 TEST (nnstreamer_capi_internal, validate_model_file_03_n)
@@ -9956,21 +9956,21 @@ TEST (nnstreamer_capi_internal, validate_model_file_03_n)
   test_dir2 = g_build_filename (test_dir1, "invaliddir", NULL);
 
   nnfw = ML_NNFW_TYPE_TENSORFLOW_LITE;
-  status = ml_validate_model_file (&test_dir1, 1, &nnfw);
+  status = _ml_validate_model_file (&test_dir1, 1, &nnfw);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   nnfw = ML_NNFW_TYPE_TENSORFLOW;
-  status = ml_validate_model_file (&test_dir1, 1, &nnfw);
+  status = _ml_validate_model_file (&test_dir1, 1, &nnfw);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   nnfw = ML_NNFW_TYPE_NNFW;
-  status = ml_validate_model_file (&test_dir2, 1, &nnfw);
+  status = _ml_validate_model_file (&test_dir2, 1, &nnfw);
   EXPECT_NE (status, ML_ERROR_NONE);
 
 #ifdef ENABLE_NNFW_RUNTIME
   /* only NNFW supports dir path */
   nnfw = ML_NNFW_TYPE_NNFW;
-  status = ml_validate_model_file (&test_dir1, 1, &nnfw);
+  status = _ml_validate_model_file (&test_dir1, 1, &nnfw);
   EXPECT_EQ (status, ML_ERROR_NONE);
 #endif
 


### PR DESCRIPTION
Add _ prefix for all internal functions
so that developers can distinguish external (API) functions
and internal functions easily.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>