### PR TITLE
[Singleshot] Enhance dim inference for nntrainer

### DIFF
--- a/c/src/ml-api-inference-single.c
+++ b/c/src/ml-api-inference-single.c
@@ -830,6 +830,30 @@ ml_single_open_custom (ml_single_h * single, ml_single_preset * info)
     goto error;
   }
 
+  if (nnfw == ML_NNFW_TYPE_NNTR_INF) {
+    if (!in_tensors_info || !out_tensors_info) {
+      if (!in_tensors_info) {
+        ml_tensors_info_h in_info;
+        status = ml_tensors_info_create (&in_info);
+        if (status != ML_ERROR_NONE) {
+          goto error;
+        }
+
+        /* ml_single_set_input_info() can't be done as it checks num_tensors */
+        status = ml_single_set_gst_info (single_h, in_info);
+        ml_tensors_info_destroy (in_info);
+        if (status != ML_ERROR_NONE) {
+          goto error;
+        }
+      } else {
+        status = ml_single_set_input_info (single_h, in_tensors_info);
+        if (status != ML_ERROR_NONE) {
+          goto error;
+        }
+      }
+    }
+  }
+
   /* 5. Set in/out configs and metadata */
   if (!ml_single_set_info_in_handle (single_h, TRUE, in_tensors_info)) {
     _ml_loge ("The input tensor info is invalid.");


### PR DESCRIPTION
## Commits to be reviewed in this PR


<details><summary>[Singleshot] Enhance dim inference for nntrainer</summary><br />

There was a voc that `ml_single_open(&single, 'model.ini', NULL, NULL,
ML_NNFW_TYPE_NNTR_INF, ML_NNFW_HW_ANY);` should work.

This was not feasible because the nntrainer inference filter is not
defining `getInputDim()`, `getOutputDim()` on purpose to make it able to
infer output dimension from input dimension in pipeline scenario.

This patch introduce the dimension inferencing mechanism for nntrainer
to make it coherent with the pipeline api.

Below rules apply when input_info or output_info is nullptr for
nntrainer.

1. After opening the framework, allow calling set_input_dim with input_info with
count==0 in case of nntrainer.
2. nntrainer checks if input_info->count==0, if true, nntrainer assums
it should be default dimension and set input/output dimension accordingly.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

