### PR TITLE
[Build/CodeClean] std headers

### DIFF
--- a/c/include/ml-api-common.h
+++ b/c/include/ml-api-common.h
@@ -18,7 +18,9 @@
 #ifndef __ML_API_COMMON_H__
 #define __ML_API_COMMON_H__
 
-#include <stddef.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <tizen_error.h>
 
 #ifdef __cplusplus

--- a/c/include/nnstreamer.h
+++ b/c/include/nnstreamer.h
@@ -14,9 +14,6 @@
 #ifndef __TIZEN_MACHINELEARNING_NNSTREAMER_H__
 #define __TIZEN_MACHINELEARNING_NNSTREAMER_H__
 
-#include <stddef.h>
-#include <stdbool.h>
-#include <stdint.h>
 #include <ml-api-common.h>
 
 #ifdef __cplusplus

--- a/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestPipeline.java
+++ b/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestPipeline.java
@@ -38,7 +38,7 @@ public class APITestPipeline {
 
             TensorsInfo info = data.getTensorsInfo();
 
-            /* validate received data (unit8 2:10:10:1) */
+            /* validate received data (uint8 2:10:10:1) */
             if (info == null ||
                 info.getTensorsCount() != 1 ||
                 info.getTensorName(0) != null ||


### PR DESCRIPTION
Code clean, it is recommended to not use stddef for NDK build, use stdlib instead.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>