### PR TITLE
[C-Api] Fix the omitted Requires section in capi-ml-inference.pc

### DIFF
--- a/c/meson.build
+++ b/c/meson.build
@@ -117,7 +117,7 @@ ml_inf_conf.merge_from(api_conf)
 ml_inf_conf.set('ML_INFERENCE_REQUIRE', 'capi-ml-common')
 configure_file(input: 'capi-ml-inference.pc.in', output: 'capi-ml-inference.pc',
   install_dir: join_paths(api_install_libdir, 'pkgconfig'),
-  configuration: api_conf
+  configuration: ml_inf_conf
 )
 
 ml_common_api_conf = configuration_data()


### PR DESCRIPTION
Because of the bug in the meson file, Requires section in
capi-ml-inference.pc is empty. It causes the compile-time error when
using ML APIs. This patch fixes this bug.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

### Before ###
```bash
$ cat ./usr/lib/pkgconfig/capi-ml-inference.pc
...
Name: tizen-api-ml-inference
Description: ML inference API for Tizen
Version: 1.8.0
Requires: 
Libs: -L${libdir} -lcapi-nnstreamer
...
```

### After ###
```bash
$ cat ./usr/lib/pkgconfig/capi-ml-inference.pc
...
Name: tizen-api-ml-inference
Description: ML inference API for Tizen
Version: 1.8.0
Requires: capi-ml-common
Libs: -L${libdir} -lcapi-nnstreamer
...
```