### PR TITLE
[C-Api] Fix the omitted Requires section in capi-ml-inference.pc

### DIFF
--- a/c/meson.build
+++ b/c/meson.build
@@ -89,7 +89,7 @@ ml_inf_conf.merge_from(api_conf)
 ml_inf_conf.set('ML_INFERENCE_REQUIRE', 'capi-ml-common')
 configure_file(input: 'capi-ml-inference.pc.in', output: 'capi-ml-inference.pc',
   install_dir: join_paths(api_install_libdir, 'pkgconfig'),
-  configuration: api_conf
+  configuration: ml_inf_conf
 )
 
 ml_common_api_conf = configuration_data()


### PR DESCRIPTION
Because of the bug in the meson file, Requires section in
capi-ml-inference.pc is empty. It causes the compile-time error when
using ML APIs. This patch fixes this bug. 

It is cherry-picking from main branch.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

