### PR TITLE
[build/android] Fix Pytorch makefile to compatibile with tflite (xnnpack) @open sesame 12/08 16:52

### DIFF
--- a/java/android/nnstreamer/src/main/jni/Android-nnfw.mk
+++ b/java/android/nnstreamer/src/main/jni/Android-nnfw.mk
@@ -4,6 +4,10 @@
 #
 # This mk file defines nnfw module with prebuilt shared library.
 # (nnfw core libraries, arm64-v8a only)
+#
+# You should check your `gradle.properties` to set the variable `NNFW_EXT_LIBRARY_PATH` properly.
+# The variable should be assigend with path for external shared libs.
+# An example: "NNFW_EXT_LIBRARY_PATH=src/main/jni/nnfw/ext"
 #------------------------------------------------------
 LOCAL_PATH := $(call my-dir)
 

--- a/java/android/nnstreamer/src/main/jni/Android-nnstreamer-prebuilt.mk
+++ b/java/android/nnstreamer/src/main/jni/Android-nnstreamer-prebuilt.mk
@@ -2,6 +2,7 @@
 # nnstreamer
 #
 # This mk file defines nnstreamer module with prebuilt shared libraries.
+# For those who want to use native libs, you may use this file in your project.
 # ABI: armeabi-v7a, arm64-v8a
 #------------------------------------------------------
 LOCAL_PATH := $(call my-dir)

--- a/java/android/nnstreamer/src/main/jni/Android-pytorch.mk
+++ b/java/android/nnstreamer/src/main/jni/Android-pytorch.mk
@@ -92,5 +92,6 @@ LOCAL_MODULE := pytorch-subplugin
 LOCAL_SRC_FILES := $(NNSTREAMER_FILTER_PYTORCH_SRCS)
 LOCAL_CXXFLAGS := -O3 -fPIC -frtti -fexceptions $(NNS_API_FLAGS) $(PYTORCH_FLAGS)
 LOCAL_C_INCLUDES := $(PYTORCH_INCLUDES) $(NNSTREAMER_INCLUDES) $(GST_HEADERS_COMMON)
-LOCAL_WHOLE_STATIC_LIBRARIES := pytorch-libeigen_blas pytorch-libnnpack pytorch-libpytorch_qnnpack pytorch-libXNNPACK pytorch-libtorch_cpu pytorch-libtorch pytorch-libc10 pytorch-libcpuinfo pytorch-libpthreadpool pytorch-libclog
+LOCAL_WHOLE_STATIC_LIBRARIES := pytorch-libtorch_cpu pytorch-libtorch
+LOCAL_STATIC_LIBRARIES := pytorch-libeigen_blas pytorch-libnnpack pytorch-libpytorch_qnnpack pytorch-libXNNPACK  pytorch-libc10 pytorch-libcpuinfo pytorch-libpthreadpool pytorch-libclog
 include $(BUILD_STATIC_LIBRARY)

--- a/java/android/nnstreamer/src/main/jni/Android-snpe.mk
+++ b/java/android/nnstreamer/src/main/jni/Android-snpe.mk
@@ -4,6 +4,10 @@
 # This mk file defines snpe module with prebuilt shared library.
 # (snpe-sdk, arm64-v8a only)
 # See Qualcomm Neural Processing SDK for AI (https://developer.qualcomm.com/software/qualcomm-neural-processing-sdk) for the details.
+#
+# You should check your `gradle.properties` to set the variable `SNPE_EXT_LIBRARY_PATH` properly.
+# The variable should be assigend with path for external shared libs.
+# An example: "SNPE_EXT_LIBRARY_PATH=src/main/jni/snpe/lib/ext"
 #------------------------------------------------------
 LOCAL_PATH := $(call my-dir)
 


### PR DESCRIPTION
- Add a comment for native developers.
- Exclude xnnpack and other prebuilt libs from `LOCAL_WHOLE_STATIC_LIBRARIES`
  to avoid link crash issue with tflite which also contains xnnpack and other common prebuilt libs
-  Add comments for nnfw and snpe makefiles about external libs

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>