### PR TITLE
C/common: override dlog infra with stderr for unit testing

### DIFF
--- a/c/meson.build
+++ b/c/meson.build
@@ -46,7 +46,6 @@ if (get_option('enable-tizen'))
 
   tizen_deps = [
     dependency('capi-system-info'),
-    dependency('dlog')
   ]
 
   if get_option('enable-tizen-privilege-check')
@@ -61,6 +60,8 @@ if (get_option('enable-tizen'))
 
   nns_capi_deps += tizen_deps
   nns_capi_common_deps += tizen_deps
+
+  nns_capi_common_deps += [dependency('dlog')]
 endif
 
 # Build ML-API Common Lib First.
@@ -84,6 +85,10 @@ if get_option('default_library') == 'static'
 endif
 nns_capi_common_dep = declare_dependency(link_with: nns_capi_common_lib)
 nns_capi_deps += nns_capi_common_dep
+nns_capi_test_deps = nns_capi_deps
+if (get_option('enable-tizen'))
+  nns_capi_deps += [dependency('dlog')]
+endif
 
 nns_capi_shared_lib = shared_library ('capi-nnstreamer',
   nns_capi_srcs,

--- a/c/src/ml-api-internal.h
+++ b/c/src/ml-api-internal.h
@@ -27,6 +27,12 @@ extern "C" {
 #define MLAPI_TAG_NAME "ml-api"
 
 #if defined(__TIZEN__)
+#ifdef FAKEDLOG
+#define _ml_loge(...) dlog_print (0, "MLAPI ERR", __VA_ARGS__)
+#define _ml_logi(...) dlog_print (0, "MLAPI_INFO", __VA_ARGS__)
+#define _ml_logw(...) dlog_print (0, "MLAPI_WARN", __VA_ARGS__)
+#define _ml_logd(...) dlog_print (0, "MLAPI_DEBUG", __VA_ARGS__)
+#else /* FAKEDLOG */
 #include <dlog.h>
 #define _ml_loge(...) \
     dlog_print (DLOG_ERROR, MLAPI_TAG_NAME, __VA_ARGS__)
@@ -36,6 +42,7 @@ extern "C" {
     dlog_print (DLOG_WARN, MLAPI_TAG_NAME, __VA_ARGS__)
 #define _ml_logd(...) \
     dlog_print (DLOG_DEBUG, MLAPI_TAG_NAME, __VA_ARGS__)
+#endif /* FAKEDLOG */
 #elif defined(__ANDROID__)
 #include <android/log.h>
 #define _ml_loge(...) \

--- a/tests/capi/meson.build
+++ b/tests/capi/meson.build
@@ -1,6 +1,19 @@
+unittest_util_static = static_library('unittest_util',
+  join_paths(meson.current_source_dir(), 'unittest_util.c'),
+  dependencies: [glib_dep],
+  install: false,
+)
+
+unittest_common_dep = declare_dependency(
+  link_with: [nns_capi_lib, unittest_util_static],
+  dependencies: [gtest_dep, nns_capi_test_deps],
+  compile_args: ['-DFAKEDLOG=1'],
+  include_directories: nns_capi_include,
+)
+
 unittest_capi_inference = executable('unittest_capi_inference',
   'unittest_capi_inference.cc',
-  dependencies: [gtest_dep, nns_capi_dep],
+  dependencies: [unittest_common_dep],
   install: get_option('install-test'),
   install_dir: unittest_install_dir
 )
@@ -8,7 +21,7 @@ test('unittest_capi_inference', unittest_capi_inference, env: testenv, timeout: 
 
 unittest_capi_inference_latency = executable('unittest_capi_inference_latency',
   'unittest_capi_inference_latency.cc',
-  dependencies: [gtest_dep, nns_capi_dep],
+  dependencies: [unittest_common_dep],
   install: get_option('install-test'),
   install_dir: unittest_install_dir
 )
@@ -16,7 +29,7 @@ test('unittest_capi_inference_latency', unittest_capi_inference_latency, env: te
 
 unittest_capi_datatype_consistency = executable('unittest_capi_datatype_consistency',
   'unittest_capi_datatype_consistency.cc',
-  dependencies: [gtest_dep, nns_capi_dep],
+  dependencies: [unittest_common_dep],
   install: get_option('install-test'),
   install_dir: unittest_install_dir
 )
@@ -25,7 +38,7 @@ test('unittest_capi_datatype_consistency', unittest_capi_datatype_consistency, e
 if nnfw_dep.found()
   unittest_capi_inference_nnfw_runtime = executable('unittest_capi_inference_nnfw_runtime',
     'unittest_capi_inference_nnfw_runtime.cc',
-    dependencies: [gtest_dep, nns_capi_dep],
+    dependencies: [unittest_common_dep],
     install: get_option('install-test'),
     install_dir: unittest_install_dir
   )

--- a/tests/capi/unittest_util.c
+++ b/tests/capi/unittest_util.c
@@ -1,0 +1,24 @@
+/**
+ * @file        unittest_util.c
+ * @date        9 Dec 2021
+ * @brief       Unittest utility functions for ML C-API
+ * @see         https://github.com/nnstreamer/api
+ * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
+ * @bug         No known bugs.
+ */
+#ifdef FAKEDLOG
+#include <glib.h>
+
+/**
+ * @brief A faked dlog_print for unittest execution.
+ */
+int dlog_print (int level, const char *tag, const char *fmt, ...)
+{
+  va_list arg_ptr;
+  va_start (arg_ptr, fmt);
+  g_logv (G_LOG_LEVEL_CRITICAL, fmt, arg_ptr);
+  va_end (arg_ptr);
+
+  return 0;
+}
+#endif


### PR DESCRIPTION
With unittesting, especially in GBS, dlog output is
not shown because dlog server is not running.

Replace it with stderr print in unittesting
for better readability in GBS.

This is similar with
https://github.com/nnstreamer/nnstreamer/pull/3571

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>