### PR TITLE
[CODEOWNER] Fix source code path syntex.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,14 @@
 # C-API
-/c/* @jaeyun-jung @again4you @myungjoo @helloahn @anyj0527 @gichan-jang
+/c/ @jaeyun-jung @again4you @myungjoo @helloahn @anyj0527 @gichan-jang
 
 # C++-API (SNAP & nntrainer, nnstreamer-pipeline)
-/cpp/* @nnstreamer/snap @jijoongmoon @kparichay @myungjoo @again4you
+/cpp/ @nnstreamer/snap @jijoongmoon @kparichay @myungjoo @again4you
 
 # Java-API
-/java/* @jaeyun-jung @again4you @myungjoo @helloahn @anyj0527 @gichan-jang
+/java/ @jaeyun-jung @again4you @myungjoo @helloahn @anyj0527 @gichan-jang
 
 # .NET-API
-/dotnet/* @again4you @jaeyun-jung @myungjoo @gichan-jang
+/dotnet/ @again4you @jaeyun-jung @myungjoo @gichan-jang
 
 # Others (integration, infra/tool files)
 * @myungjoo @jijoongmoon @again4you @jaeyun-jung


### PR DESCRIPTION
Currently, the source code path of the CODEOWNER is set differently than we were intended.
For example, /c/* mathces files like `c/README.md`
but not further nested files like `c/src/ml-api-common.c`
To include nested files, fix source code path syntex.

refer: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>