### PR TITLE
[TEST] Update the test case

### DIFF
--- a/tests/capi/unittest_capi_inference.cc
+++ b/tests/capi/unittest_capi_inference.cc
@@ -1881,7 +1881,7 @@ TEST (nnstreamer_capi_util, plugin_availability_fail_invalid_02_n)
 {
   int status;
 
-  status = _ml_check_plugin_availability (NULL, "tensor_filter");
+  status = _ml_check_plugin_availability ("nnstreamer", NULL);
   EXPECT_NE (status, ML_ERROR_NONE);
 }
 


### PR DESCRIPTION
Both plugin_availability_fail_invalid_01_n and
plugin_availability_fail_invalid_02_n have the same test code. This
patch updates the parameter to test other case.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>