### PR TITLE
C/single: elaborate invoke stream-pipe error.

### DIFF
--- a/c/src/ml-api-inference-single.c
+++ b/c/src/ml-api-inference-single.c
@@ -299,7 +299,7 @@ __invoke (ml_single * single_h, ml_tensors_data_h in, ml_tensors_data_h out)
           single_h->free_output)) {
     const char *fw_name = _ml_get_nnfw_subplugin_name (single_h->nnfw);
     _ml_error_report
-        ("Failed to invoke the tensors. The invoke callback of the tensor-filter subplugin '%s' has failed. Please contact the author of tensor-filter-%s (nnstreamer-%s) or review its source code.",
+        ("Failed to invoke the tensors. The invoke callback of the tensor-filter subplugin '%s' has failed. Please contact the author of tensor-filter-%s (nnstreamer-%s) or review its source code. Note that this usually happens when the designated framework does not support the given model (e.g., trying to run tf-lite 2.6 model with tf-lite 1.13).",
         fw_name, fw_name, fw_name);
     status = ML_ERROR_STREAMS_PIPE;
   }


### PR DESCRIPTION
When the framework version does not match the given
model's requirement, STREAM_PIPE error may happen.
Because it appears that such cases are common,
add more explanation.

Related with https://github.com/nnstreamer/nnstreamer/issues/3603

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>