### PR TITLE
[CODEOWNERS] Fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
+# Default oweners of the repo. (integration, infra/tool files)
+* @myungjoo @jijoongmoon @again4you @jaeyun-jung
+
 # C-API
 /c/ @jaeyun-jung @again4you @myungjoo @helloahn @anyj0527 @gichan-jang
 
@@ -9,6 +12,3 @@
 
 # .NET-API
 /dotnet/ @again4you @jaeyun-jung @myungjoo @gichan-jang
-
-# Others (integration, infra/tool files)
-* @myungjoo @jijoongmoon @again4you @jaeyun-jung


### PR DESCRIPTION
The last matching pattern takes the most precedence.
Change orders.

Refer: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>