### PR TITLE
Fix libcapi-nnstremer is empty due to linker optimization

### DIFF
--- a/c/meson.build
+++ b/c/meson.build
@@ -112,11 +112,11 @@ nns_capi_single_static_lib = static_library ('capi-nnstreamer-single',
   install_dir: api_install_libdir,
 )
 
-nns_capi_single_lib = nns_capi_single_shared_lib
+nns_capi_single_dep = declare_dependency(link_with: nns_capi_single_shared_lib)
 if get_option('default_library') == 'static'
-  nns_capi_single_lib = nns_capi_single_static_lib
+  nns_capi_single_dep = declare_dependency(link_with: nns_capi_single_static_lib)
 endif
-nns_capi_single_dep = declare_dependency(link_with: nns_capi_single_lib)
+
 
 # Pipeline API.
 nns_capi_pipeline_shared_lib = shared_library ('capi-nnstreamer-pipeline',
@@ -136,15 +136,15 @@ nns_capi_pipeline_static_lib = static_library ('capi-nnstreamer-pipeline',
   install_dir: api_install_libdir,
 )
 
-nns_capi_pipeline_lib = nns_capi_pipeline_shared_lib
+nns_capi_pipeline_dep = declare_dependency(link_with: nns_capi_pipeline_shared_lib)
 if get_option('default_library') == 'static'
-  nns_capi_pipeline_lib = nns_capi_pipeline_static_lib
+  nns_capi_pipeline_dep = declare_dependency(link_with: nns_capi_pipeline_static_lib)
 endif
-nns_capi_pipeline_dep = declare_dependency(link_with: nns_capi_pipeline_lib)
+
 
 # Single-shot and pipeline API.
 nns_capi_shared_lib = shared_library ('capi-nnstreamer',
-  link_with: [nns_capi_single_lib, nns_capi_pipeline_lib],
+  link_with: [nns_capi_single_shared_lib, nns_capi_pipeline_shared_lib],
   include_directories: nns_capi_include,
   install: true,
   install_dir: api_install_libdir,
@@ -152,7 +152,7 @@ nns_capi_shared_lib = shared_library ('capi-nnstreamer',
 )
 
 nns_capi_static_lib = static_library ('capi-nnstreamer',
-  link_with: [nns_capi_single_lib, nns_capi_pipeline_lib],
+  link_whole: [nns_capi_single_static_lib, nns_capi_pipeline_static_lib],
   include_directories: nns_capi_include,
   install: true,
   install_dir: api_install_libdir,

--- a/meson.build
+++ b/meson.build
@@ -3,12 +3,16 @@ project('ml-api', 'c', 'cpp',
   license: ['Apache-2.0'],
   meson_version: '>=0.50.0',
   default_options: [
+    'b_asneeded=false',
     'werror=true',
     'warning_level=1',
     'c_std=gnu89',
     'cpp_std=c++14'
   ]
 )
+
+add_global_link_arguments('-Wl,--no-as-needed', language: 'c')
+add_global_link_arguments('-Wl,--no-as-needed', language: 'cpp')
 
 cc = meson.get_compiler('c')
 cxx = meson.get_compiler('cpp')


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>Fix libcapi-nnstremer is empty due to linker optimization</summary><br />

From #131, libcapi-nnstreamer.so became empty because
libcapi-nnstreamer.so does not use any symbol from
libcapi-nnstreamer-single, libcapi-nnstreamer-pipeline.so

This should be semantically resolvable by using 'link-whole' argument in
meson but it is not implemented for shared_library.

This patch address the issue by disabling `-bas-needed=false` in meson
and add -Wl,--as-needed to global linker argument.

See also: https://github.com/mesonbuild/meson/issues/3046.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

