### PR TITLE
[Debian] update ml-inference-api-dev package

### DIFF
--- a/c/capi-ml-inference.pc.in
+++ b/c/capi-ml-inference.pc.in
@@ -9,5 +9,5 @@ Name: tizen-api-ml-inference
 Description: ML inference API for Tizen
 Version: @VERSION@
 Requires: @ML_INFERENCE_REQUIRE@
-Libs: -L${libdir} -lcapi-nnstreamer -lcapi-nnstreamer-single -lcapi-nnstreamer-pipeline
+Libs: -L${libdir} -lcapi-nnstreamer
 Cflags: -I${includedir}/nnstreamer

--- a/c/meson.build
+++ b/c/meson.build
@@ -170,7 +170,7 @@ nns_capi_dep = declare_dependency(link_with: nns_capi_lib,
 
 ml_inf_conf = configuration_data()
 ml_inf_conf.merge_from(api_conf)
-ml_inf_conf.set('ML_INFERENCE_REQUIRE', 'capi-nnstreamer-single capi-nnstreamer-pipeline')
+ml_inf_conf.set('ML_INFERENCE_REQUIRE', 'capi-ml-inference-single capi-ml-inference-pipeline')
 configure_file(input: 'capi-ml-inference.pc.in', output: 'capi-ml-inference.pc',
   install_dir: join_paths(api_install_libdir, 'pkgconfig'),
   configuration: ml_inf_conf

--- a/debian/ml-inference-api-dev.install
+++ b/debian/ml-inference-api-dev.install
@@ -1,5 +1,7 @@
 /usr/include/nnstreamer/nnstreamer.h
 /usr/include/nnstreamer/nnstreamer-single.h
 /usr/lib/*/pkgconfig/capi-ml-inference.pc
+/usr/lib/*/pkgconfig/capi-ml-inference-single.pc
+/usr/lib/*/pkgconfig/capi-ml-inference-pipeline.pc
 /usr/lib/*/libcapi-*.a
 /usr/lib/*/libcapi-*.so


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[Debian] update ml-inference-api-dev package</summary><br />

After #131, ml-inference-api-dev is relying on capi-ml-inference-single
and capi-ml-inference-pipeline pc.

It might have been better that ml-inference-api-dev relying on
ml-inference-single/pipeline-dev. As the package is not introduced,
this patch add pc files into the ml-inference-api-dev package.

See also: https://github.com/nnstreamer/nntrainer/issues/1853#issuecomment-1064220362

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

