### PR TITLE
[meson] change global link -> project link

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,8 +11,8 @@ project('ml-api', 'c', 'cpp',
   ]
 )
 
-add_global_link_arguments('-Wl,--no-as-needed', language: 'c')
-add_global_link_arguments('-Wl,--no-as-needed', language: 'cpp')
+add_project_link_arguments('-Wl,--no-as-needed', language: 'c')
+add_project_link_arguments('-Wl,--no-as-needed', language: 'cpp')
 
 cc = meson.get_compiler('c')
 cxx = meson.get_compiler('cpp')


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[meson] change global link -> project link</summary><br />

As recommended from a review in #137, add_global_link_argument has
changed to add_project_link_argument

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

