### PR TITLE
[Package] Bugfix for package dependency

### DIFF
--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -63,6 +63,7 @@ Source0:	machine-learning-api-%{version}.tar
 Source1001:	capi-machine-learning-inference.manifest
 
 ## Define build requirements ##
+Requires:	capi-machine-learning-common = %{version}-%{release}
 Requires:	capi-machine-learning-inference-single = %{version}-%{release}
 Requires:	capi-machine-learning-inference-pipeline = %{version}-%{release}
 %ifarch aarch64 x86_64
@@ -146,6 +147,7 @@ You can construct a data stream pipeline with neural networks easily.
 Summary:	Tizen Native API Devel Kit for NNStreamer
 Group:		Machine Learning/ML Framework
 Requires:	capi-machine-learning-inference = %{version}-%{release}
+Requires:	capi-machine-learning-common-devel
 Requires:	capi-machine-learning-inference-single-devel
 Requires:	capi-machine-learning-inference-pipeline-devel
 %description devel


### PR DESCRIPTION
To maintain backward compatibility, capi-machine-learning-inference
package should require pipeline, single and common libraries. However,
common is omitted and it can cause break issues when making platform
image. This patch fixes this bug.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

### Self evaluation:
Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped

### Before
```bash
$ rpm -q --requires capi-machine-learning-inference-1.8.0-0.armv7l.rpm
...
capi-machine-learning-inference-pipeline = 1.8.0-0
capi-machine-learning-inference-single = 1.8.0-0
libcapi-nnstreamer.so.1
...
```

### After
```bash
$ rpm -q --requires capi-machine-learning-inference-1.8.0-0.armv7l.rpm
...
capi-machine-learning-common = 1.8.0-0
capi-machine-learning-inference-pipeline = 1.8.0-0
capi-machine-learning-inference-single = 1.8.0-0
libcapi-nnstreamer.so.1
...
```