### PR TITLE
[WIP][C-API/Service] bugfix for DB permission in Tizen

### DIFF
--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -320,6 +320,8 @@ bash %{test_script} ./tests/capi/unittest_capi_inference_single
 bash %{test_script} ./tests/capi/unittest_capi_inference
 bash %{test_script} ./tests/capi/unittest_datatype_consistency
 
+bash %{test_script} ./tests/capi/unittest_capi_service
+
 %if 0%{?nnfw_support}
 bash %{test_script} ./tests/capi/unittest_capi_inference_nnfw_runtime
 %endif


### PR DESCRIPTION
Because of not enough permission in the /opt/usr/dbspace in Tizen,
ML Service APIs failed when running the test cases. This patch
fixes this bug.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

### Self evaluation:
Build test: [ ]Passed [ ]Failed [X]Skipped
Run test: [ ]Passed [ ]Failed [X]Skipped