### PR TITLE
[C-API/Service] Workaround for dbspace failure

### DIFF
--- a/c/src/ml-api-service-db.cc
+++ b/c/src/ml-api-service-db.cc
@@ -18,7 +18,7 @@
 #include "ml-service-db.hh"
 #include "ml-api-service.h"
 
-#define ML_DATABASE_PATH      SYS_DB_DIR"/.ml-service-leveldb"
+#define ML_DATABASE_PATH      "/tmp/.ml-service-leveldb"
 
 /**
  * @brief Class for implementation of IMLServiceDB

--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -319,6 +319,7 @@ ninja -C build %{?_smp_mflags}
 bash %{test_script} ./tests/capi/unittest_capi_inference_single
 bash %{test_script} ./tests/capi/unittest_capi_inference
 bash %{test_script} ./tests/capi/unittest_datatype_consistency
+bash %{test_script} ./tests/capi/unittest_capi_service
 
 %if 0%{?nnfw_support}
 bash %{test_script} ./tests/capi/unittest_capi_inference_nnfw_runtime


### PR DESCRIPTION
Because of SMACK control, the application process cannot access the
'/opt/usr/dbspace'. To meet the Tizen M1 release schedule, this patch
uses '/tmp' as database space. It is just a workaround and will be fixed
in the right way.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>