### PR TITLE
[single] Allow tvn model when using VD_AIFW

### DIFF
--- a/c/src/ml-api-inference-single.c
+++ b/c/src/ml-api-inference-single.c
@@ -1879,6 +1879,7 @@ _ml_validate_model_file (const char *const *model,
     case ML_NNFW_TYPE_VD_AIFW:
       if (!g_str_equal (file_ext[0], ".nb") &&
           !g_str_equal (file_ext[0], ".ncp") &&
+          !g_str_equal (file_ext[0], ".tvn") &&
           !g_str_equal (file_ext[0], ".bin")) {
         status = ML_ERROR_INVALID_PARAMETER;
       }


### PR DESCRIPTION
This patch allows tvn model when using VD_AIFW framework.

Signed-off-by: yelini-jeong <yelini.jeong@samsung.com>