### PR TITLE
[Doc] Change CI server domain name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # api
 
-[![Code Coverage](http://nnstreamer.mooo.com/nnstreamer-api/ci/badge/codecoverage.svg)](http://nnstreamer.mooo.com/nnstreamer-api/ci/gcov_html/index.html)
+[![Code Coverage](http://ci.nnstreamer.ai/nnstreamer-api/ci/badge/codecoverage.svg)](http://ci.nnstreamer.ai/nnstreamer-api/ci/gcov_html/index.html)
 
 Machine Learning API (Origin: C++: SNAP, C/C#: Tizen API, Java: Samsung-Research ML API)


### PR DESCRIPTION
Change CI server domain name from nnstreamer.mooo.com to ci.nnstreamer.ai

Signed-off-by: gichan <gichan2.jang@samsung.com>