### PR TITLE
[C-API/Single] Add new API for "ml_option"

### DIFF
--- a/c/include/ml-api-common.h
+++ b/c/include/ml-api-common.h
@@ -143,6 +143,13 @@ typedef enum _ml_tensor_type_e
 } ml_tensor_type_e;
 
 /**
+ * @brief The function to be called when destroying the data in machine learning API.
+ * @since_tizen 7.0
+ * @param[in] user_data The user data passed from the callback registration function.
+ */
+typedef void (*ml_data_destroy_cb) (void *user_data);
+
+/**
  * @brief Callback to execute the custom-easy filter in NNStreamer pipelines.
  * @details Note that if ml_custom_easy_invoke_cb() returns negative error values, the constructed pipeline does not work properly anymore.
  *          So developers should release the pipeline handle and recreate it again.
@@ -404,6 +411,56 @@ const char * ml_error (void);
  * @return @c Null for invalid error code. Otherwise the error description.
  */
 const char * ml_strerror (int errnum);
+
+/*************
+ * ML OPTION *
+ *************/
+
+/**
+ * @brief A handle of a ml-option instance.
+ * @since_tizen 7.0
+ */
+typedef void *ml_option_h;
+
+/**
+ * @brief Creates ml-option instance.
+ * @since_tizen 7.0
+ * @remarks The @a option should be released using ml_option_destroy().
+ * @param[out] option Newly created option handle is returned.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
+ * @retval #ML_ERROR_OUT_OF_MEMORY Failed to allocate required memory.
+ */
+int ml_option_create (ml_option_h *option);
+
+/**
+ * @brief Destroys the ml-option instance.
+ * @details Note that, user should free the allocated values of ml-option in the case that destroy function is not given.
+ * @since_tizen 7.0
+ * @param[in] option The option handle to be destroyed.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
+ */
+int ml_option_destroy (ml_option_h option);
+
+/**
+ * @brief Sets a new key-value in ml-option instance.
+ * @details Note that the @a value should be valid during single task and be freed after destroying the ml-option instance unless proper @a destroy function is given. When duplicated @a key is given, the corresponding @a value is updated with the new one.
+ * @since_tizen 7.0
+ * @param[in] option The handle of ml-option.
+ * @param[in] key The key to be set.
+ * @param[in] value The value to be set.
+ * @param[in] destroy The function to destroy the value. It is called when the ml-option instance is destroyed.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
+ */
+int ml_option_set (ml_option_h option, const char* key, void *value, ml_data_destroy_cb destroy);
 
 /**
  * @}

--- a/c/include/nnstreamer-single.h
+++ b/c/include/nnstreamer-single.h
@@ -260,6 +260,23 @@ int ml_single_set_property (ml_single_h single, const char *name, const char *va
 int ml_single_get_property (ml_single_h single, const char *name, char **value);
 
 /**
+ * @brief Makes a single instance with given ml-option.
+ * @since_tizen 7.0
+ * @remarks %http://tizen.org/privilege/mediastorage is needed if @a option is relevant to media storage.
+ * @remarks %http://tizen.org/privilege/externalstorage is needed if @a option is relevant to external storage.
+ * @param[out] single This is the model handle opened. Users are required to close
+ *                   the given instance with ml_single_close().
+ * @param[in] option The handle of ml-option.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_PERMISSION_DENIED The application does not have the privilege to access to the media storage or external storage.
+ * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
+ * @retval #ML_ERROR_STREAMS_PIPE Failed to start the pipeline.
+ * @retval #ML_ERROR_OUT_OF_MEMORY Failed to allocate required memory.
+ */
+int ml_single_open_with_option (ml_single_h *single, const ml_option_h option);
+/**
  * @}
  */
 #ifdef __cplusplus

--- a/c/include/nnstreamer-tizen-internal.h
+++ b/c/include/nnstreamer-tizen-internal.h
@@ -36,6 +36,7 @@ typedef struct {
   ml_nnfw_hw_e hw;               /**< The type of hardware resource. */
   char *models;                  /**< Comma separated neural network model files. */
   char *custom_option;           /**< Custom option string for neural network framework. */
+  char *fw_name;                 /**< The explicit framework name given by user */
 } ml_single_preset;
 
 /**

--- a/c/src/ml-api-inference-single.c
+++ b/c/src/ml-api-inference-single.c
@@ -1001,7 +1001,11 @@ ml_single_open_custom (ml_single_h * single, ml_single_preset * info)
   }
 
   /* set accelerator, framework, model files and custom option */
-  fw_name = _ml_get_nnfw_subplugin_name (nnfw); /* retry for "auto" */
+  if (info->fw_name) {
+    fw_name = (const char *) info->fw_name;
+  } else {
+    fw_name = _ml_get_nnfw_subplugin_name (nnfw);       /* retry for "auto" */
+  }
   hw_name = _ml_nnfw_to_str_prop (hw);
   g_object_set (filter_obj, "framework", fw_name, "accelerator", hw_name,
       "model", info->models, NULL);
@@ -1107,6 +1111,58 @@ ml_single_open_full (ml_single_h * single, const char *model,
   info.hw = hw;
   info.models = (char *) model;
   info.custom_option = (char *) custom_option;
+
+  return ml_single_open_custom (single, &info);
+}
+
+/**
+ * @brief Open new single handle with given option.
+ */
+int
+ml_single_open_with_option (ml_single_h * single, const ml_option_h option)
+{
+  ml_option_s *_option;
+  GHashTable *table;
+  GHashTableIter iter;
+  gchar *key;
+  ml_option_value_s *_option_value;
+  ml_single_preset info = { 0, };
+
+  check_feature_state (ML_FEATURE_INFERENCE);
+
+  if (!option) {
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'option' is NULL. It should be a valid ml_option_h, which should be created by ml_option_create().");
+  }
+
+  if (!single)
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'single' (ml_single_h), is NULL. It should be a valid ml_single_h instance, usually created by ml_single_open().");
+
+  _option = (ml_option_s *) option;
+  table = _option->option_table;
+
+  g_hash_table_iter_init (&iter, table);
+  while (g_hash_table_iter_next (&iter, (gpointer *) & key,
+          (gpointer *) & _option_value)) {
+    if (g_ascii_strcasecmp (key, "input_info") == 0) {
+      info.input_info = _option_value->value;
+    } else if (g_ascii_strcasecmp (key, "output_info") == 0) {
+      info.output_info = _option_value->value;
+    } else if (g_ascii_strcasecmp (key, "nnfw") == 0) {
+      info.nnfw = *((ml_nnfw_type_e *) _option_value->value);
+    } else if (g_ascii_strcasecmp (key, "hw") == 0) {
+      info.hw = *((ml_nnfw_hw_e *) _option_value->value);
+    } else if (g_ascii_strcasecmp (key, "models") == 0) {
+      info.models = (gchar *) _option_value->value;
+    } else if (g_ascii_strcasecmp (key, "custom") == 0) {
+      info.custom_option = (gchar *) _option_value->value;
+    } else if (g_ascii_strcasecmp (key, "framework_name") == 0) {
+      info.fw_name = (gchar *) _option_value->value;
+    } else {
+      _ml_logw ("Ignore unknown key for ml_option: %s", key);
+    }
+  }
 
   return ml_single_open_custom (single, &info);
 }

--- a/c/src/ml-api-internal.h
+++ b/c/src/ml-api-internal.h
@@ -144,6 +144,25 @@ typedef struct {
 } ml_tensors_info_s;
 
 /**
+ * @brief Data structure for value of ml_option.
+ * @since_tizen 7.0
+ */
+typedef struct
+{
+  void *value; /**< The data given by user. */
+  ml_data_destroy_cb destroy; /**< The destroy func given by user. */
+} ml_option_value_s;
+
+/**
+ * @brief Data structure for ml_option.
+ * @since_tizen 7.0
+ */
+typedef struct
+{
+  GHashTable *option_table; /**< hash table used by ml_option. */
+} ml_option_s;
+
+/**
  * @brief Macro to control private lock with nolock condition (lock)
  * @param sname The name of struct (ml_tensors_info_s or ml_tensors_data_s)
  */


### PR DESCRIPTION
- Add four new APIs:
  ml_option_create
  ml_option_destroy
  ml_option_set
  ml_single_open_with_option

- It uses GHashTable {const char* key : void* value} to store various options for ml_single_open
- Add some testcases using newly added ml_option APIs

Self evaluation:
Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>