### PR TITLE
[C-API] Move ml_strerror() to internal header

### DIFF
--- a/c/include/ml-api-common.h
+++ b/c/include/ml-api-common.h
@@ -381,29 +381,6 @@ int ml_tensors_data_get_tensor_data (ml_tensors_data_h data, unsigned int index,
 int ml_tensors_data_set_tensor_data (ml_tensors_data_h data, unsigned int index, const void *raw_data, const size_t data_size);
 
 /**
- * @brief Returns a human-readable string describing the last error.
- * @details This returns a human-readable, null-terminated string describing
- *         the most recent error that occured from a call to one of the
- *         funcctions in the Machine Learning API since the last call to
- *         ml_error(). The returned string should *not* be freed or
- *         overwritten by the caller.
- * @since_tizen 7.0
- * @return @c Null if no error to be reported. Otherwise the error description.
- */
-const char * ml_error (void);
-
-/**
- * @brief Returns a human-readable string describing for a error code.
- * @details This returns a human-readable, null-terminated string describing
- *         the error code of machine learning APIs.
- *         The returned string should *not* be freed or
- *         overwritten by the caller.
- * @since_tizen 7.0
- * @return @c Null for invalid error code. Otherwise the error description.
- */
-const char * ml_strerror (int errnum);
-
-/**
  * @}
  */
 #ifdef __cplusplus

--- a/c/src/ml-api-internal.h
+++ b/c/src/ml-api-internal.h
@@ -410,6 +410,30 @@ void _ml_error_report_continue_ (const char *fmt, ...);
 
 /***** End: Error reporting internal interfaces *****/
 
+/**
+ * @brief Returns a human-readable string describing the last error.
+ * @details This returns a human-readable, null-terminated string describing
+ *         the most recent error that occured from a call to one of the
+ *         funcctions in the Machine Learning API since the last call to
+ *         ml_error(). The returned string should *not* be freed or
+ *         overwritten by the caller.
+ * @since_tizen 7.0
+ * @todo Release M2
+ * @return @c Null if no error to be reported. Otherwise the error description.
+ */
+const char * ml_error (void);
+
+/**
+ * @brief Returns a human-readable string describing for a error code.
+ * @details This returns a human-readable, null-terminated string describing
+ *         the error code of machine learning APIs.
+ *         The returned string should *not* be freed or
+ *         overwritten by the caller.
+ * @since_tizen 7.0
+ * @todo Release M2
+ * @return @c Null for invalid error code. Otherwise the error description.
+ */
+const char * ml_strerror (int errnum);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
ml_strerror(), ml_error() functions are not ready to release. So they
are moved to internal header.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

### Self evaluation:
Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped