### PR TITLE
[pipeline API] Let pipeline src use current caps when it's given

### DIFF
--- a/c/src/ml-api-inference-pipeline.c
+++ b/c/src/ml-api-inference-pipeline.c
@@ -1531,7 +1531,12 @@ ml_pipeline_src_parse_tensors_info (ml_pipeline_element * elem)
     return ML_ERROR_STREAMS_PIPE;
   }
 
-  caps = gst_pad_get_allowed_caps (elem->src);
+  /* If caps is given, use it. e.g. Use cap "image/png" when the pipeline is */
+  /* given as "appsrc caps=image/png ! pngdec ! ... " */
+  caps = gst_pad_get_current_caps (elem->src);
+  if (!caps)
+    caps = gst_pad_get_allowed_caps (elem->src);
+
   if (!caps) {
     _ml_logw
         ("Cannot find caps. The pipeline is not yet negotiated for src element [%s].",

--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -102,6 +102,10 @@ BuildRequires:	lcov
 %if 0%{?unit_test}
 BuildRequires:  pkgconfig(gtest)
 BuildRequires:  pkgconfig(gmock)
+BuildRequires:	gst-plugins-good
+%if 0%{tizen_version_major} >= 5
+BuildRequires:	gst-plugins-good-extra
+%endif
 
 %if 0%{?tensorflow_support}
 BuildRequires:	tensorflow


### PR DESCRIPTION
- If current caps is given, use it rather than allowed caps.
- Use caps "image/png" when the pipeline is "appsrc caps=image/png ! pngdec ! ... "
- Add a test for decoding pngfile using appsrc (C API and android JAVA)
- It check the equality of decoded orange.png using simple pipline
  with raw file (orange.raw)

This resolves https://github.com/nnstreamer/nnstreamer/issues/3753

Self evaluation:
Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>