### PR TITLE
[android] Set tensorflow-lite v2.8.1 as default

### DIFF
--- a/java/android/nnstreamer/src/main/jni/Android-tensorflow-lite.mk
+++ b/java/android/nnstreamer/src/main/jni/Android-tensorflow-lite.mk
@@ -15,7 +15,7 @@ endif
 
 include $(NNSTREAMER_ROOT)/jni/nnstreamer.mk
 
-TFLITE_VERSION := 2.7.0
+TFLITE_VERSION := 2.8.1
 
 _TFLITE_VERSIONS = $(subst ., , $(TFLITE_VERSION))
 TFLITE_VERSION_MAJOR := $(word 1, $(_TFLITE_VERSIONS))

--- a/java/build-nnstreamer-android.sh
+++ b/java/build-nnstreamer-android.sh
@@ -58,9 +58,9 @@
 ##@@       'yes'      : build with sub-plugin for PyTorch. You can optionally specify the version of
 ##@@                    PyTorch to use by appending ':version' [1.10.1 is the default].
 ##@@       'no'       : [default] build without the sub-plugin for PyTorch
-##@@   --enable_tflite=(yes(:(1.9|1.13.1|1.15.2|2.3.0|2.7.0))?|no)
+##@@   --enable_tflite=(yes(:(1.9|1.13.1|1.15.2|2.3.0|2.7.0|2.8.1))?|no)
 ##@@       'yes'      : [default] you can optionally specify the version of tensorflow-lite to use
-##@@                    by appending ':version' [2.3.0 is the default].
+##@@                    by appending ':version' [2.8.1 is the default].
 ##@@       'no'       : build without the sub-plugin for tensorflow-lite
 ##@@   --enable_mxnet=(yes|no)
 ##@@       'yes'      : build with sub-plugin for MXNet. Currently, mxnet 1.9.1 version supported.
@@ -129,9 +129,9 @@ flatbuf_ver="1.12.0"
 enable_mqtt="no"
 paho_mqtt_c_ver="1.3.7"
 
-# Set tensorflow-lite version (available: 1.9.0 / 1.13.1 / 1.15.2 / 2.3.0 / 2.7.0)
-tf_lite_ver="2.7.0"
-tf_lite_vers_support="1.9.0 1.13.1 1.15.2 2.3.0 2.7.0"
+# Set tensorflow-lite version (available: 1.9.0 / 1.13.1 / 1.15.2 / 2.3.0 / 2.7.0 / 2.8.1)
+tf_lite_ver="2.8.1"
+tf_lite_vers_support="1.9.0 1.13.1 1.15.2 2.3.0 2.7.0 2.8.1"
 
 # Set NNFW version (https://github.com/Samsung/ONE/releases)
 nnfw_ver="1.17.0"
@@ -544,7 +544,7 @@ fi
 if [[ $enable_tflite == "yes" ]]; then
     sed -i "s|ENABLE_TF_LITE := false|ENABLE_TF_LITE := true|" nnstreamer/src/main/jni/Android-nnstreamer-prebuilt.mk
     sed -i "s|ENABLE_TF_LITE := false|ENABLE_TF_LITE := true|" nnstreamer/src/main/jni/Android.mk
-    sed -i "s|TFLITE_VERSION := 2.7.0|TFLITE_VERSION := $tf_lite_ver|" nnstreamer/src/main/jni/Android-tensorflow-lite.mk
+    sed -i "s|TFLITE_VERSION := 2.8.1|TFLITE_VERSION := $tf_lite_ver|" nnstreamer/src/main/jni/Android-tensorflow-lite.mk
     tar -xJf ./external/tensorflow-lite-$tf_lite_ver.tar.xz -C ./nnstreamer/src/main/jni
 fi
 


### PR DESCRIPTION
- Add tflite v2.8.1 support and set it as default
- This PR requires https://github.com/nnstreamer/nnstreamer-android-resource/pull/32 to be merged

Self evaluation:
Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>