### PR TITLE
[C-API/common] Add fp16 type.

### DIFF
--- a/c/include/ml-api-common.h
+++ b/c/include/ml-api-common.h
@@ -140,6 +140,7 @@ typedef enum _ml_tensor_type_e
   ML_TENSOR_TYPE_FLOAT32,        /**< Float 32bit */
   ML_TENSOR_TYPE_INT64,          /**< Integer 64bit */
   ML_TENSOR_TYPE_UINT64,         /**< Unsigned integer 64bit */
+  ML_TENSOR_TYPE_FLOAT16,        /**< FP16, IEEE 754. Note that this type is supported only in aarch64/arm devices. (Since 7.0) */
   ML_TENSOR_TYPE_UNKNOWN         /**< Unknown type */
 } ml_tensor_type_e;
 
@@ -274,7 +275,7 @@ int ml_tensors_info_get_tensor_name (ml_tensors_info_h info, unsigned int index,
  * @param[in] type The tensor type to be set.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful.
- * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported. E.g., in a machine without fp16 support, trying FLOAT16 is not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_tensors_info_set_tensor_type (ml_tensors_info_h info, unsigned int index, const ml_tensor_type_e type);

--- a/c/src/ml-api-common.c
+++ b/c/src/ml-api-common.c
@@ -387,6 +387,13 @@ ml_tensors_info_set_tensor_type (ml_tensors_info_h info,
         "The parameter, type, ML_TENSOR_TYPE_UNKNOWN or out of bound. The value of type should be between 0 and ML_TENSOR_TYPE_UNKNOWN - 1. type = %d, ML_TENSOR_TYPE_UNKNOWN = %d.",
         type, ML_TENSOR_TYPE_UNKNOWN);
 
+#ifndef SUPPORT_FLOAT16
+  if (type == ML_TENSOR_TYPE_FLOAT16)
+    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
+        "Float16 (IEEE 754) is not supported by the machine (or the compiler or your build configuration). You cannot configure ml_tensors_info instance with Float16 type.");
+#endif
+ /** @todo add BFLOAT16 when nnstreamer is ready for it. */
+
   tensors_info = (ml_tensors_info_s *) info;
   G_LOCK_UNLESS_NOLOCK (*tensors_info);
 

--- a/c/src/ml-api-inference-internal.c
+++ b/c/src/ml-api-inference-internal.c
@@ -25,7 +25,7 @@
 static tensor_type
 convert_tensor_type_from (ml_tensor_type_e type)
 {
-  if (type < ML_TENSOR_TYPE_INT32 || type > ML_TENSOR_TYPE_UINT64) {
+  if (type < ML_TENSOR_TYPE_INT32 || type >= ML_TENSOR_TYPE_UNKNOWN) {
     _ml_error_report
         ("Failed to convert the type. Input ml_tensor_type_e %d is invalid.",
         type);
@@ -43,7 +43,7 @@ convert_tensor_type_from (ml_tensor_type_e type)
 static ml_tensor_type_e
 convert_ml_tensor_type_from (tensor_type type)
 {
-  if (type < _NNS_INT32 || type > _NNS_UINT64) {
+  if (type < _NNS_INT32 || type >= _NNS_END) {
     _ml_error_report
         ("Failed to convert the type. Input tensor_type %d is invalid.", type);
     return ML_TENSOR_TYPE_UNKNOWN;


### PR DESCRIPTION
Declare API formats for API change review process.

Note:
Fp16 is generally supported by arm/arm64 compilers.
However, x64/x86 compilers usually don't support it
(GCC>=12 is required along with some compiler flags).


Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>