### PR TITLE
[TDD] Add unit tests for ML Agent and implementation

### DIFF
--- a/daemon/gdbus-util.c
+++ b/daemon/gdbus-util.c
@@ -146,13 +146,15 @@ gdbus_put_instance_pipeline (MachinelearningServicePipeline ** instance)
  * @brief Connect to the DBus message bus, which type is SYSTEM.
  */
 int
-gdbus_get_system_connection (void)
+gdbus_get_system_connection (gboolean is_session)
 {
   GError *error = NULL;
+  GBusType bus_type = is_session ? G_BUS_TYPE_SESSION : G_BUS_TYPE_SYSTEM;
 
-  g_dbus_sys_conn = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, &error);
+  g_dbus_sys_conn = g_bus_get_sync (bus_type, NULL, &error);
   if (g_dbus_sys_conn == NULL) {
     _E ("cannot connect to the system message bus: %s\n", error->message);
+    g_clear_error(&error);
     return -ENOSYS;
   }
 

--- a/daemon/includes/gdbus-util.h
+++ b/daemon/includes/gdbus-util.h
@@ -86,10 +86,11 @@ MachinelearningServicePipeline *gdbus_get_instance_pipeline (void);
 void gdbus_put_instance_pipeline (MachinelearningServicePipeline ** instance);
 
 /**
- * @brief Connect to the DBus message bus, which type is SYSTEM.
+ * @brief Connect to the DBus message bus
+ * @param is_session Ture is DBus Bus type is session.
  * @return @c 0 on success. Otherwise a negative error value.
  */
-int gdbus_get_system_connection (void);
+int gdbus_get_system_connection (gboolean is_session);
 
 /**
  * @brief Disconnect the DBus message bus.

--- a/daemon/includes/test-dbus-interface.h
+++ b/daemon/includes/test-dbus-interface.h
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * NNStreamer API / Machine Learning Agent Daemon
+ * Copyright (C) 2022 Samsung Electronics Co., Ltd. All Rights Reserved.
+ */
+
+/**
+ * @file    test-dbus-interface.h
+ * @date    16 Jul 2022
+ * @brief   Test header for the definition of DBus node and interfaces.
+ * @see     https://github.com/nnstreamer/api
+ * @author  Sangjung Woo <sangjung.woo@samsung.com>
+ * @bug     No known bugs except for NYI items
+ *
+ * @details
+ *    This defines the machine learning agent's bus, interface, and method names for Test.
+ */
+
+#ifndef __TEST_DBUS_INTERFACE_H__
+#define __TEST_DBUS_INTERFACE_H__
+
+#define DBUS_TEST_INTERFACE          "org.tizen.machinelearning.service.test"
+#define DBUS_TEST_PATH               "/Org/Tizen/MachineLearning/Service/Test"
+
+#define DBUS_TEST_I_GET_STATE_HANDLER       "handle_get_state"
+
+#endif /* __TEST_DBUS_INTERFACE_H__ */

--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -1,6 +1,7 @@
 # Machine Learing Agent
 if get_option('enable-machine-learning-agent')
   nns_ml_agent_srcs = []
+  nns_ml_agent_gen_srcs = []
   nns_ml_agent_incs = include_directories('includes')
 
   # Generate GDbus header and code
@@ -13,12 +14,23 @@ if get_option('enable-machine-learning-agent')
               '--output-directory', meson.current_build_dir(),
               '@INPUT@'])
 
-  nns_ml_agent_srcs += gdbus_gen_src[0]
+  nns_ml_agent_gen_srcs += gdbus_gen_src
+
   nns_ml_agent_srcs += join_paths('main.c')
   nns_ml_agent_srcs += join_paths('modules.c')
   nns_ml_agent_srcs += join_paths('gdbus-util.c')
 
-  gdbus_gen_header_dep = declare_dependency(sources : gdbus_gen_src)
+  # Enable ML Agent Test
+  gdbus_gen_test_src = custom_target('gdbus-gencode-test',
+    input : '../dbus/test-dbus.xml',
+    output : ['test-dbus.h', 'test-dbus.c'],
+    command : [gdbus_prog, '--interface-prefix', 'org.tizen',
+              '--generate-c-code', 'test-dbus',
+              '--output-directory', meson.current_build_dir(),
+              '@INPUT@'])
+
+  gdbus_gen_header_dep = declare_dependency(sources : nns_ml_agent_gen_srcs)
+  gdbus_gen_header_test_dep = declare_dependency(sources : [nns_ml_agent_gen_srcs, gdbus_gen_test_src])
   dlog_dep = dependency('dlog')
   libsystemd_dep = dependency('libsystemd')
   ai_service_daemon_deps = [
@@ -26,6 +38,7 @@ if get_option('enable-machine-learning-agent')
     glib_dep,
     gio_dep,
     gio_unix_dep,
+    gst_dep,
     dlog_dep,
     libsystemd_dep
   ]
@@ -36,6 +49,14 @@ if get_option('enable-machine-learning-agent')
     include_directories: nns_ml_agent_incs,
     install: true,
     install_dir: api_install_bindir,
+  )
+
+  # For unit test
+  nns_ml_agent_srcs += join_paths('test-dbus-impl.c')
+  ai_service_daemon = executable('machine-learning-agent-test',
+    nns_ml_agent_srcs,
+    dependencies : [ai_service_daemon_deps, gdbus_gen_header_test_dep],
+    include_directories: nns_ml_agent_incs
   )
 
   # DBus Policy configuration

--- a/daemon/test-dbus-impl.c
+++ b/daemon/test-dbus-impl.c
@@ -1,0 +1,150 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file test-dbus-impl.c
+ * @date 16 Jul 2022
+ * @brief DBus implementation for Test Interface
+ * @see	https://github.com/nnstreamer/api
+ * @author Sangjung Woo <sangjung.woo@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#include <glib.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <gst/gst.h>
+
+#include <common.h>
+#include <modules.h>
+#include <gdbus-util.h>
+#include <log.h>
+
+#include "test-dbus-interface.h"
+#include "test-dbus.h"
+
+static MachinelearningServiceTest *g_gdbus_instance = NULL;
+
+/**
+ * @brief DBus handler for 'get_state' method of Test interface.
+ */
+static gboolean
+dbus_cb_service_get_status (MachinelearningServiceTest * obj,
+    GDBusMethodInvocation * invoc)
+{
+  int ret = 0;
+  int status = 1;
+
+  machinelearning_service_test_complete_get_state (obj, invoc, status, ret);
+  return TRUE;
+}
+
+static struct gdbus_signal_info g_gdbus_signal_infos[] = {
+  {
+    .signal_name = DBUS_TEST_I_GET_STATE_HANDLER,
+    .cb = G_CALLBACK (dbus_cb_service_get_status),
+    .cb_data = NULL,
+    .handler_id = 0,
+  },
+};
+
+/**
+ * @brief Utility function to get the DBus proxy of Test interface.
+ */
+static MachinelearningServiceTest *
+gdbus_get_instance_test (void)
+{
+  return machinelearning_service_test_skeleton_new ();
+}
+
+/**
+ * @brief Utility function to release DBus proxy.
+ */
+static void
+gdbus_put_instance_test (MachinelearningServiceTest ** instance)
+{
+  g_clear_object (instance);
+}
+
+/**
+ * @brief The callback function for initializing Test module.
+ */
+static void
+init_test (void *data)
+{
+  GError *err = NULL;
+  g_debug ("init_test module");
+
+  if (!gst_init_check (NULL, NULL, &err)) {
+    if (err) {
+      g_critical ("Initializing gstreamer failed with err msg %s",
+          err->message);
+      g_clear_error (&err);
+    } else {
+      g_critical ("cannot initalize GStreamer with unknown reason.");
+    }
+  }
+}
+
+/**
+ * @brief The callback function for exiting Test modeule.
+ */
+static void
+exit_test (void *data)
+{
+  gdbus_disconnect_signal (g_gdbus_instance,
+      ARRAY_SIZE (g_gdbus_signal_infos), g_gdbus_signal_infos);
+  gdbus_put_instance_test (&g_gdbus_instance);
+}
+
+/**
+ * @brief The callback function for proving Test modeule.
+ */
+static int
+probe_test (void *data)
+{
+  int ret = 0;
+  g_debug ("probe_test");
+  g_gdbus_instance = gdbus_get_instance_test ();
+  if (g_gdbus_instance == NULL) {
+    g_critical ("cannot get a dbus instance for the %s interface\n",
+        DBUS_TEST_INTERFACE);
+    return -ENOSYS;
+  }
+
+  ret = gdbus_connect_signal (g_gdbus_instance,
+      ARRAY_SIZE (g_gdbus_signal_infos), g_gdbus_signal_infos);
+  if (ret < 0) {
+    g_critical ("cannot register callbacks as the dbus method invocation "
+        "handlers\n ret: %d", ret);
+    ret = -ENOSYS;
+    goto out;
+  }
+
+  ret = gdbus_export_interface (g_gdbus_instance, DBUS_TEST_PATH);
+  if (ret < 0) {
+    g_critical ("cannot export the dbus interface '%s' "
+        "at the object path '%s'\n", DBUS_TEST_INTERFACE, DBUS_TEST_PATH);
+    ret = -ENOSYS;
+    goto out_disconnect;
+  }
+  return 0;
+
+out_disconnect:
+  gdbus_disconnect_signal (g_gdbus_instance,
+      ARRAY_SIZE (g_gdbus_signal_infos), g_gdbus_signal_infos);
+out:
+  gdbus_put_instance_test (&g_gdbus_instance);
+
+  return ret;
+}
+
+static const struct module_ops test_ops = {
+  .name = "ml-agent-test",
+  .probe = probe_test,
+  .init = init_test,
+  .exit = exit_test,
+};
+
+MODULE_OPS_REGISTER (&test_ops)

--- a/dbus/test-dbus.xml
+++ b/dbus/test-dbus.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<node name="/Org/Tizen/MachineLearning/Service">
+  <interface name="org.tizen.machinelearning.service.test">
+    <method name="get_state">
+      <arg type="i" name="state" direction="out" />
+      <arg type="i" name="result" direction="out" />      
+    </method>
+  </interface>
+</node>

--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -351,6 +351,10 @@ bash %{test_script} ./tests/capi/unittest_datatype_consistency
 bash %{test_script} ./tests/capi/unittest_capi_service
 bash %{test_script} ./tests/capi/unittest_capi_service_db_mock
 
+%if 0%{?enable_machine_learning_agent}
+bash %{test_script} ./tests/daemon/unittest_ml_agent
+%endif
+
 %if 0%{?nnfw_support}
 bash %{test_script} ./tests/capi/unittest_capi_inference_nnfw_runtime
 %endif

--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -147,6 +147,7 @@ BuildConflicts:	libarmcl-release
 
 %if 0%{?enable_machine_learning_agent}
 BuildRequires:  pkgconfig(libsystemd)
+BuildRequires:  dbus
 %endif
 
 %description

--- a/tests/daemon/meson.build
+++ b/tests/daemon/meson.build
@@ -1,0 +1,7 @@
+unittest_ml_agent = executable('unittest_ml_agent',
+  'unittest_ml_agent.cc',
+  dependencies: [unittest_common_dep, gdbus_gen_header_test_dep],
+  install: get_option('install-test'),
+  install_dir: unittest_install_dir
+)
+test('unittest_ml_agent', unittest_ml_agent, env: testenv, timeout: 100)

--- a/tests/daemon/unittest_ml_agent.cc
+++ b/tests/daemon/unittest_ml_agent.cc
@@ -1,0 +1,129 @@
+/**
+ * @file        unittest_ml_agent.cc
+ * @date        16 Jul 2022
+ * @brief       Unit test for ML Agent itself
+ * @see         https://github.com/nnstreamer/api
+ * @author      Sangjung Woo <sangjung.woo@samsung.com>
+ * @bug         No known bugs
+ */
+
+#include <gio/gio.h>
+#include <gtest/gtest.h>
+
+#include "test-dbus.h"
+#include "../../daemon/includes/dbus-interface.h"
+#include "../../daemon/includes/test-dbus-interface.h"
+
+/**
+ * @brief Test base class for ML Agent Daemon
+ */
+class MLAgentTest : public::testing::Test
+{
+protected:
+  GTestDBus *dbus;
+  GDBusProxy *proxy;
+
+public:
+  /**
+   * @brief Setup method for each test case.
+   */
+  void SetUp() override
+  {
+    gchar *services_dir = g_build_filename (g_get_current_dir (), "tests/services", NULL);
+    dbus = g_test_dbus_new (G_TEST_DBUS_NONE);
+    g_test_dbus_add_service_dir (dbus, services_dir);
+    g_test_dbus_up (dbus);
+
+    GError *error = NULL;
+    proxy = g_dbus_proxy_new_for_bus_sync (
+      G_BUS_TYPE_SESSION,
+      G_DBUS_PROXY_FLAGS_NONE,
+      NULL,
+      DBUS_ML_BUS_NAME,
+      DBUS_TEST_PATH,
+      DBUS_TEST_INTERFACE,
+      NULL,
+      &error);
+
+    if (!proxy || error) {
+      if (error) {
+        g_critical ("Error Message : %s", error->message);
+        g_clear_error (&error);
+      }
+    }
+
+    g_free (services_dir);
+  }
+
+  /**
+   * @brief Teardown method for each test case.
+   */
+  void TearDown() override
+  {
+    if (proxy)
+      g_object_unref (proxy);
+
+    g_test_dbus_down (dbus);
+    g_object_unref (dbus);
+  }
+};
+
+/**
+ * @brief Call the 'get_state' DBus method and check the result.
+ */
+TEST_F (MLAgentTest, call_method)
+{
+  MachinelearningServiceTest *proxy = NULL;
+  GError *error = NULL;
+  int status = 0;
+  int result = 0;
+
+  /* Test : Connect to the DBus Interface */
+  proxy = machinelearning_service_test_proxy_new_for_bus_sync (
+    G_BUS_TYPE_SESSION,
+    G_DBUS_PROXY_FLAGS_NONE,
+    DBUS_ML_BUS_NAME,
+    DBUS_TEST_PATH,
+    NULL, &error);
+  if (error != NULL) {
+    g_error_free (error);
+    FAIL();
+  }
+
+  /* Test: Call the DBus method */
+  machinelearning_service_test_call_get_state_sync (proxy, &status, &result, NULL, &error);
+  if (error != NULL) {
+    g_critical ("Error : %s", error->message);
+    g_error_free (error);
+    FAIL();
+  }
+
+  /* Check the return value */
+  EXPECT_EQ (result, 0);
+  EXPECT_EQ (status, 1);
+
+  g_object_unref (proxy);
+}
+
+/**
+ * @brief Main gtest
+ */
+int
+main (int argc, char **argv)
+{
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest (&argc, argv);
+  } catch (...) {
+    g_warning ("catch 'testing::internal::<unnamed>::ClassUniqueToAlwaysTrue'");
+  }
+
+  try {
+    result = RUN_ALL_TESTS ();
+  } catch (...) {
+    g_warning ("catch `testing::internal::GoogleTestFailureException`");
+  }
+
+  return result;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -12,6 +12,7 @@ if gtest_dep.found()
   subdir('capi')
   if get_option('enable-machine-learning-agent')
     subdir('services')
+    subdir('daemon')
   endif
 else
   warning('You should install google-test on your machine.')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -10,6 +10,9 @@ testenv.set('NNSTREAMER_BUILD_ROOT_PATH', meson.build_root())
 gtest_dep = dependency('gtest', required: false)
 if gtest_dep.found()
   subdir('capi')
+  if get_option('enable-machine-learning-agent')
+    subdir('services')
+  endif
 else
   warning('You should install google-test on your machine.')
 endif

--- a/tests/services/meson.build
+++ b/tests/services/meson.build
@@ -1,0 +1,9 @@
+builddir_cdata = configuration_data()
+builddir_cdata.set('build_dir', meson.current_build_dir() / '../..')
+
+test_dbus_service_file = 'org.tizen.machinelearning.service.service'
+configure_file(
+  input: test_dbus_service_file + '.in',
+  output: test_dbus_service_file,
+  configuration: builddir_cdata
+)

--- a/tests/services/org.tizen.machinelearning.service.service.in
+++ b/tests/services/org.tizen.machinelearning.service.service.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.tizen.machinelearning.service
-Exec=@build_dir@/daemon/machine-learning-agent --session
+Exec=@build_dir@/daemon/machine-learning-agent-test --session

--- a/tests/services/org.tizen.machinelearning.service.service.in
+++ b/tests/services/org.tizen.machinelearning.service.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.tizen.machinelearning.service
+Exec=@build_dir@/daemon/machine-learning-agent --session


### PR DESCRIPTION
To test the ML Agent daemon process itself, this PR adds the unit tests and implementation for the Test DBus interface. To run unit tests in the GBS environment, the session type of the DBus bus is necessary. So It adds the command-line option to support the session bus. The default option is `SYSTEM` so it is just unit test purpose.

### Component Diagram
![component_diagram](https://user-images.githubusercontent.com/433435/180677447-8ea4adc4-6c23-4643-b163-927d28cbd5f7.JPG)


### Command-line option
```bash
$ ./machine-learning-agent --help
Usage:
  machine-learning-agent [OPTION?]

Help Options:
  -h, --help        Show help options

Application Options:
  -v, --verbose     Be verbose
  -s, --session     Bus type is session
```

### ML Agent Daemon test result in GBS envrionment
```bash
[   73s] ./tests/capi/unittest_ml_agent
[   73s] [==========] Running 1 test from 1 test suite.
[   73s] [----------] Global test environment set-up.
[   73s] [----------] 1 test from MLAgentTest
[   73s] [ RUN      ] MLAgentTest.call_method
[   73s] dbus-daemon[9196]: [session uid=1000 pid=9196] Activating service name='org.tizen.machinelearning.service' requested by ':1.0' (uid=1000 pid=9195 comm="<not-read>")
[   73s] dbus-daemon[9196]: [session uid=1000 pid=9196] Successfully activated service 'org.tizen.machinelearning.service'
[   73s] [       OK ] MLAgentTest.call_method (13 ms)
[   73s] [----------] 1 test from MLAgentTest (14 ms total)
[   73s]
[   73s] [----------] Global test environment tear-down
[   73s] [==========] 1 test from 1 test suite ran. (14 ms total)
[   73s] [  PASSED  ] 1 test.
```

### Submit History
#### V3
* Remove unnecessary newlines.
* Check the coding convention using `gst-indent` tool

#### V2
* Newly make a test binary for unit tests
* Remove unnecessary headers in code

#### V1
* First Draft
* Add command-line option for Session Bus
* Define the test DBus interface and implement its operation