### PR TITLE
[TDD] Implementation of DBus Model interface @open sesame 08/03 11:50

### DIFF
--- a/daemon/includes/dbus-interface.h
+++ b/daemon/includes/dbus-interface.h
@@ -22,6 +22,7 @@
 #define DBUS_ML_BUS_NAME                "org.tizen.machinelearning.service"
 #define DBUS_ML_PATH                    "/Org/Tizen/MachineLearning/Service"
 
+/* Pipeline Interface */
 #define DBUS_PIPELINE_INTERFACE          "org.tizen.machinelearning.service.pipeline"
 #define DBUS_PIPELINE_PATH               "/Org/Tizen/MachineLearning/Service/Pipeline"
 
@@ -32,5 +33,13 @@
 
 #define DBUS_PIPELINE_I_GET_STATE_HANDLER       "handle_get_state"
 #define DBUS_PIPELINE_I_GET_DESCRIPTION_HANDLER "handle_get_description"
+
+/* Model Interface */
+#define DBUS_MODEL_INTERFACE            "org.tizen.machinelearning.service.model"
+#define DBUS_MODEL_PATH                 "/Org/Tizen/MachineLearning/Service/Model"
+
+#define DBUS_MODEL_I_HANDLER_SET_PATH     "handle_set_path"
+#define DBUS_MODEL_I_HANDLER_GET_PATH     "handle_get_path"
+#define DBUS_MODEL_I_HANDLER_DELETE       "handle_delete"
 
 #endif /* __GDBUS_INTERFACE_H__ */

--- a/daemon/includes/gdbus-util.h
+++ b/daemon/includes/gdbus-util.h
@@ -24,6 +24,10 @@
 
 #include "pipeline-dbus.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /**
  * @brief DBus signal handler information to connect
  */
@@ -96,4 +100,8 @@ int gdbus_get_system_connection (gboolean is_session);
  * @brief Disconnect the DBus message bus.
  */
 void gdbus_put_system_connection (void);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 #endif /* __GDBUS_UTIL_H__ */

--- a/daemon/includes/modules.h
+++ b/daemon/includes/modules.h
@@ -18,6 +18,10 @@
 #ifndef __MODULES_H__
 #define __MODULES_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /**
  * @brief Data structure contains the name and callback functions for a specific DBus interface.
  */
@@ -65,4 +69,8 @@ void add_module (const struct module_ops *module);
  * @param[in] module DBus interface information.
  */
 void remove_module (const struct module_ops *module);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 #endif /* __MODULES_H__ */

--- a/daemon/includes/service-db.hh
+++ b/daemon/includes/service-db.hh
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file service-db.hh
+ * @date 28 Mar 2022
+ * @brief NNStreamer/Service Database Interface
+ * @see	https://github.com/nnstreamer/api
+ * @author Sangjung Woo <sangjung.woo@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#ifndef __SERVICE_DB_HH__
+#define __SERVICE_DB_HH__
+
+#include <leveldb/c.h>
+#include <iostream>
+
+/**
+ * @brief Interface for database operation of ML service
+ */
+class IMLServiceDB
+{
+public:
+  /**
+   * @brief Destroy the IMLServiceDB object
+   */
+  virtual ~IMLServiceDB ()
+  {
+  };
+  virtual void connectDB () = 0;
+  virtual void disconnectDB () = 0;
+  virtual void put (const std::string key, const std::string value) = 0;
+  virtual void get (const std::string name,
+      std::string & out_value) = 0;
+  virtual void del (const std::string name) = 0;
+};
+
+/**
+ * @brief Class for implementation of IMLServiceDB
+ */
+class MLServiceLevelDB : public IMLServiceDB
+{
+public:
+  MLServiceLevelDB (const MLServiceLevelDB &) = delete;
+  MLServiceLevelDB (MLServiceLevelDB &&) = delete;
+  MLServiceLevelDB & operator= (const MLServiceLevelDB &) = delete;
+  MLServiceLevelDB & operator= (MLServiceLevelDB &&) = delete;
+
+  virtual void connectDB () override;
+  virtual void disconnectDB () override;
+  virtual void put (const std::string name,
+      const std::string value) override;
+  virtual void get (std::string name,
+      std::string & out_value) override;
+  virtual void del (std::string name);
+
+  static IMLServiceDB & getInstance (void);
+
+private:
+  MLServiceLevelDB (std::string path);
+  virtual ~MLServiceLevelDB ();
+
+  std::string path;
+  leveldb_t *db_obj;
+  leveldb_readoptions_t *db_roptions;
+  leveldb_writeoptions_t *db_woptions;
+};
+
+#endif /* __SERVICE_DB_HH__ */

--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -4,6 +4,16 @@ if get_option('enable-machine-learning-agent')
   nns_ml_agent_gen_srcs = []
   nns_ml_agent_incs = include_directories('includes')
 
+  dlog_dep = dependency('dlog')
+  libsystemd_dep = dependency('libsystemd')
+
+  nns_ml_agent_srcs += join_paths('main.c')
+  nns_ml_agent_srcs += join_paths('modules.c')
+  nns_ml_agent_srcs += join_paths('gdbus-util.c')
+  nns_ml_agent_srcs += join_paths('service-db.cc')
+  nns_ml_agent_srcs += join_paths('pipeline-module.c')
+  nns_ml_agent_srcs += join_paths('model-dbus-impl.cc')
+
   # Generate GDbus header and code
   gdbus_prog = find_program('gdbus-codegen', required : true)
   gdbus_gen_src = custom_target('gdbus-gencode',
@@ -13,13 +23,16 @@ if get_option('enable-machine-learning-agent')
               '--generate-c-code', 'pipeline-dbus',
               '--output-directory', meson.current_build_dir(),
               '@INPUT@'])
-
   nns_ml_agent_gen_srcs += gdbus_gen_src
 
-  nns_ml_agent_srcs += join_paths('main.c')
-  nns_ml_agent_srcs += join_paths('modules.c')
-  nns_ml_agent_srcs += join_paths('gdbus-util.c')
-  nns_ml_agent_srcs += join_paths('pipeline-module.c')
+  gdbus_gen_model_src = custom_target('gdbus-model-gencode',
+    input : '../dbus/model-dbus.xml',
+    output : ['model-dbus.h', 'model-dbus.c'],
+    command : [gdbus_prog, '--interface-prefix', 'org.tizen',
+              '--generate-c-code', 'model-dbus',
+              '--output-directory', meson.current_build_dir(),
+              '@INPUT@'])
+  nns_ml_agent_gen_srcs += gdbus_gen_model_src
 
   # Enable ML Agent Test
   gdbus_gen_test_src = custom_target('gdbus-gencode-test',
@@ -32,8 +45,7 @@ if get_option('enable-machine-learning-agent')
 
   gdbus_gen_header_dep = declare_dependency(sources : nns_ml_agent_gen_srcs)
   gdbus_gen_header_test_dep = declare_dependency(sources : [nns_ml_agent_gen_srcs, gdbus_gen_test_src])
-  dlog_dep = dependency('dlog')
-  libsystemd_dep = dependency('libsystemd')
+
   ai_service_daemon_deps = [
     gdbus_gen_header_dep,
     glib_dep,
@@ -41,6 +53,7 @@ if get_option('enable-machine-learning-agent')
     gio_unix_dep,
     gst_dep,
     dlog_dep,
+    leveldb_dep,
     libsystemd_dep
   ]
 

--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -44,12 +44,15 @@ if get_option('enable-machine-learning-agent')
     libsystemd_dep
   ]
 
+  serviceDBPath = get_option('service-db-path')
   ai_service_daemon = executable('machine-learning-agent',
     nns_ml_agent_srcs,
     dependencies : [ai_service_daemon_deps],
     include_directories: nns_ml_agent_incs,
     install: true,
     install_dir: api_install_bindir,
+    cpp_args : '-DDB_PATH="' + serviceDBPath + '"'
+
   )
 
   # For unit test
@@ -57,7 +60,8 @@ if get_option('enable-machine-learning-agent')
   ai_service_daemon = executable('machine-learning-agent-test',
     nns_ml_agent_srcs,
     dependencies : [ai_service_daemon_deps, gdbus_gen_header_test_dep],
-    include_directories: nns_ml_agent_incs
+    include_directories: nns_ml_agent_incs,
+    cpp_args : '-DDB_PATH="."'
   )
 
   # DBus Policy configuration

--- a/daemon/model-dbus-impl.cc
+++ b/daemon/model-dbus-impl.cc
@@ -1,0 +1,254 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file model-dbus-impl.cc
+ * @date 29 Jul 2022
+ * @brief DBus implementation for Model Interface
+ * @see	https://github.com/nnstreamer/api
+ * @author Sangjung Woo <sangjung.woo@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#include <glib.h>
+#include <errno.h>
+
+#include "common.h"
+#include "modules.h"
+#include "gdbus-util.h"
+#include "dbus-interface.h"
+#include "model-dbus.h"
+#include "service-db.hh"
+
+static MachinelearningServiceModel *g_gdbus_instance = NULL;
+
+/**
+ * @brief Utility function to get the DBus proxy of Model interface.
+ */
+static MachinelearningServiceModel *
+gdbus_get_model_instance (void)
+{
+  return machinelearning_service_model_skeleton_new ();
+}
+
+/**
+ * @brief Utility function to release DBus proxy of Model interface.
+ */
+static void
+gdbus_put_model_instance (MachinelearningServiceModel ** instance)
+{
+  g_clear_object (instance);
+}
+
+/**
+ * @brief The callback function of SetPath method.
+ *
+ * @param obj Proxy instance.
+ * @param invoc Method invocation handle.
+ * @param name The name of target model.
+ * @param path the file path of target.
+ * @return @c TRUE if the request is handled. FALSE if the service is not available.
+ */
+static gboolean
+dbus_cb_model_set_path (MachinelearningServiceModel *obj,
+    GDBusMethodInvocation *invoc,
+    const gchar *name,
+    const gchar *path)
+{
+  int ret = 0;
+  IMLServiceDB &db = MLServiceLevelDB::getInstance ();
+
+  try {
+    db.connectDB();
+    db.put (name, std::string (path));
+  }
+  catch (const std::runtime_error & e)
+  {
+    ret = -EIO;
+  }
+  catch (const std::invalid_argument & e)
+  {
+    ret = -EINVAL;
+  }
+  catch (const std::exception & e)
+  {
+    ret = -EIO;
+  }
+
+  db.disconnectDB ();
+  machinelearning_service_model_complete_set_path (obj, invoc, ret);
+
+  return TRUE;
+}
+
+/**
+ * @brief The callback function of GetPath method
+ *
+ * @param obj Proxy instance.
+ * @param invoc Method invocation handle.
+ * @param name The name of target model.
+ * @return @c TRUE if the request is handled. FALSE if the service is not available.
+ */
+static gboolean
+dbus_cb_model_get_path (MachinelearningServiceModel *obj,
+    GDBusMethodInvocation *invoc,
+    const gchar *name)
+{
+  int ret = 0;
+  std::string ret_path;
+  IMLServiceDB & db = MLServiceLevelDB::getInstance ();
+
+  try {
+    db.connectDB ();
+    db.get (name, ret_path);
+  }
+  catch (const std::invalid_argument & e)
+  {
+    ret = -EINVAL;
+  }
+  catch (const std::runtime_error & e)
+  {
+    ret = -EIO;
+  }
+  catch (const std::exception & e)
+  {
+    ret = -EIO;
+  }
+
+  db.disconnectDB ();
+  machinelearning_service_model_complete_get_path (obj, invoc, ret_path.c_str(), ret);
+
+  return TRUE;
+}
+
+/**
+ * @brief The callback function of Delete method
+ *
+ * @param obj Proxy instance.
+ * @param invoc Method invocation handle.
+ * @param name The name of target model.
+ * @return @c TRUE if the request is handled. FALSE if the service is not available.
+ */
+static gboolean
+gdbus_cb_model_delete (MachinelearningServiceModel *obj,
+    GDBusMethodInvocation *invoc,
+    const gchar *name)
+{
+  int ret = 0;
+  IMLServiceDB & db = MLServiceLevelDB::getInstance ();
+
+  try {
+    db.connectDB ();
+    db.del (name);
+  }
+  catch (const std::invalid_argument & e)
+  {
+    ret = -EINVAL;
+  }
+  catch (const std::runtime_error & e)
+  {
+    ret = -EIO;
+  }
+  catch (const std::exception & e)
+  {
+    ret = -EIO;
+  }
+
+  db.disconnectDB ();
+  machinelearning_service_model_complete_delete (obj, invoc, ret);
+
+  return TRUE;
+}
+
+/**
+ * @brief Event handler list of Model interface
+ */
+static struct gdbus_signal_info handler_infos[] = {
+  {
+    .signal_name = DBUS_MODEL_I_HANDLER_SET_PATH,
+    .cb = G_CALLBACK (dbus_cb_model_set_path),
+    .cb_data = NULL,
+    .handler_id = 0,
+  }, {
+    .signal_name = DBUS_MODEL_I_HANDLER_GET_PATH,
+    .cb = G_CALLBACK (dbus_cb_model_get_path),
+    .cb_data = NULL,
+    .handler_id = 0,
+  }, {
+    .signal_name = DBUS_MODEL_I_HANDLER_DELETE,
+    .cb = G_CALLBACK (gdbus_cb_model_delete),
+    .cb_data = NULL,
+    .handler_id = 0,
+  },
+};
+
+/**
+ * @brief The callback function for probing Model Interface module.
+ */
+static int
+probe_model_module (void *data)
+{
+  int ret = 0;
+  g_debug ("probe_model_module");
+
+  g_gdbus_instance = gdbus_get_model_instance ();
+  if (NULL == g_gdbus_instance) {
+    g_critical ("cannot get a dbus instance for the %s interface\n",
+        DBUS_MODEL_INTERFACE);
+    return -ENOSYS;
+  }
+
+  ret = gdbus_connect_signal (g_gdbus_instance,
+      ARRAY_SIZE(handler_infos), handler_infos);
+  if (ret < 0) {
+    g_critical ("cannot register callbacks as the dbus method invocation "
+        "handlers\n ret: %d", ret);
+    ret = -ENOSYS;
+    goto out;
+  }
+
+  ret = gdbus_export_interface (g_gdbus_instance, DBUS_MODEL_PATH);
+  if (ret < 0) {
+    g_critical ("cannot export the dbus interface '%s' "
+        "at the object path '%s'\n", DBUS_MODEL_INTERFACE, DBUS_MODEL_PATH);
+    ret = -ENOSYS;
+    goto out_disconnect;
+  }
+
+  return 0;
+
+out_disconnect:
+  gdbus_disconnect_signal (g_gdbus_instance, 
+    ARRAY_SIZE (handler_infos), handler_infos);
+
+out:
+  gdbus_put_model_instance (&g_gdbus_instance);
+
+  return ret;
+}
+
+/**
+ * @brief The callback function for initializing Model Interface module.
+ */
+static void
+init_model_module (void *data) { }
+
+/**
+ * @brief The callback function for exiting Model Interface module.
+ */
+static void
+exit_model_module (void *data)
+{
+  gdbus_disconnect_signal (g_gdbus_instance, 
+    ARRAY_SIZE (handler_infos), handler_infos);
+  gdbus_put_model_instance (&g_gdbus_instance);
+}
+
+static const struct module_ops model_ops = {
+  .name = "model-interface",
+  .probe = probe_model_module,
+  .init = init_model_module,
+  .exit = exit_model_module,
+};
+
+MODULE_OPS_REGISTER (&model_ops)

--- a/daemon/service-db.cc
+++ b/daemon/service-db.cc
@@ -1,0 +1,190 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file service-db.cc
+ * @date 29 Jul 2022
+ * @brief Database implementation of NNStreamer/Service C-API
+ * @see https://github.com/nnstreamer/api
+ * @author Sangjung Woo <sangjung.woo@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#include <glib.h>
+
+#include "service-db.hh"
+
+#define ML_DATABASE_PATH      DB_PATH"/.ml-service-leveldb"
+
+/**
+ * @brief Get an instance of IMLServiceDB, which is created only once at runtime.
+ * @return IMLServiceDB& IMLServiceDB instance
+ */
+IMLServiceDB & MLServiceLevelDB::getInstance (void)
+{
+  static MLServiceLevelDB instance (ML_DATABASE_PATH);
+
+  return instance;
+}
+
+/**
+ * @brief Construct a new MLServiceLevelDB object
+ * @param path database path
+ */
+MLServiceLevelDB::MLServiceLevelDB (std::string path)
+:  path (path), db_obj (nullptr), db_roptions (nullptr), db_woptions (nullptr)
+{
+  db_roptions = leveldb_readoptions_create ();
+  db_woptions = leveldb_writeoptions_create ();
+  leveldb_writeoptions_set_sync (db_woptions, 1);
+}
+
+/**
+ * @brief Destroy the MLServiceLevelDB object
+ */
+MLServiceLevelDB::~MLServiceLevelDB ()
+{
+  leveldb_readoptions_destroy (db_roptions);
+  leveldb_writeoptions_destroy (db_woptions);
+}
+
+/**
+ * @brief Connect the level DB and initialize the private variables.
+ */
+void
+MLServiceLevelDB::connectDB ()
+{
+  char *err = nullptr;
+  leveldb_options_t *db_options;
+
+  if (db_obj)
+    return;
+
+  db_options = leveldb_options_create ();
+  leveldb_options_set_create_if_missing (db_options, 1);
+
+  db_obj = leveldb_open (db_options, path.c_str (), &err);
+  leveldb_options_destroy (db_options);
+  if (err != nullptr) {
+    g_warning ("Error! Failed to open database located at '%s': leveldb_open() has returned an error: %s",
+        path.c_str (), err);
+    leveldb_free (err);
+    throw std::runtime_error ("Failed to connectDB()!");
+  }
+  return;
+}
+
+/**
+ * @brief Disconnect the level DB
+ * @note LevelDB does not support multi-process and it might cause
+ * the IO exception when multiple clients write the key simultaneously.
+ */
+void
+MLServiceLevelDB::disconnectDB ()
+{
+  if (db_obj) {
+    leveldb_close (db_obj);
+    db_obj = nullptr;
+  }
+}
+
+/**
+ * @brief Set the value with the given name.
+ * @note If the name already exists, the pipeline description is overwritten.
+ * @param[in] name Unique name to retrieve the associated pipeline description.
+ * @param[in] value The pipeline description to be stored.
+ */
+void
+MLServiceLevelDB::put (const std::string name,
+    const std::string value)
+{
+  char *err = NULL;
+
+  if (name.empty() || value.empty())
+    throw std::invalid_argument ("Invalid name or value parameters!");
+
+  leveldb_put (db_obj, db_woptions, name.c_str (), name.size (),
+      value.c_str (), value.size (), &err);
+  if (err != nullptr) {
+    g_warning
+        ("Failed to call leveldb_put () for the name, '%s' of the pipeline description (size: %zu bytes / description: '%.40s')",
+        name.c_str (), value.size (),
+        value.c_str ());
+    g_warning ("leveldb_put () has returned an error: %s", err);
+    leveldb_free (err);
+    throw std::runtime_error ("Failed to put()!");
+  }
+}
+
+/**
+ * @brief Get the value with the given name.
+ * @param[in] name The unique name to retrieve.
+ * @param[out] value The pipeline corresponding with the given name.
+ */
+void
+MLServiceLevelDB::get (const std::string name,
+    std::string & out_value)
+{
+  char *err = NULL;
+  char *value = NULL;
+  gsize read_len;
+
+  if (name.empty())
+    throw std::invalid_argument ("Invalid name parameters!");
+
+  value = leveldb_get (db_obj, db_roptions, name.c_str (), name.size (),
+      &read_len, &err);
+  if (err != nullptr) {
+    g_warning
+        ("Failed to call leveldb_get() for the name %s. Error message is %s.",
+        name.c_str (), err);
+    leveldb_free (err);
+    leveldb_free (value);
+    throw std::runtime_error ("Failed to get()!");
+  }
+
+  if (!value) {
+    g_warning
+        ("Failed to find the key %s. The key should be set before reading it",
+        name.c_str ());
+    throw std::invalid_argument ("Fail to find the key");
+  }
+
+  out_value = std::string (value, read_len);
+  leveldb_free (value);
+  return;
+}
+
+/**
+ * @brief Delete the value with a given name.
+ * @param[in] name The unique name to delete
+ */
+void
+MLServiceLevelDB::del (const std::string name)
+{
+  char *err = NULL;
+  char *value = NULL;
+  gsize read_len;
+
+  if (name.empty())
+    throw std::invalid_argument ("Invalid name parameters!");
+
+  /* Check whether the key exists or not. */
+  value = leveldb_get (db_obj, db_roptions, name.c_str (), name.size (),
+      &read_len, &err);
+  if (!value) {
+    g_warning
+        ("Failed to find the key %s. The key should be set before reading it",
+        name.c_str ());
+    throw std::invalid_argument ("Fail to find the key");
+  }
+  leveldb_free (value);
+
+  leveldb_delete (db_obj, db_woptions, name.c_str (), name.size (), &err);
+  if (err != nullptr) {
+    g_warning ("Failed to delete the key %s. Error message is %s", name.c_str (),
+        err);
+    leveldb_free (err);
+    throw std::runtime_error ("Failed to del()!");
+  }
+}

--- a/dbus/model-dbus.xml
+++ b/dbus/model-dbus.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<node name="/Org/Tizen/MachineLearning/Service">
+  <interface name="org.tizen.machinelearning.service.model">
+    <!-- Set the file path of the designated neural network model -->
+    <method name="SetPath">
+      <arg type="s" name="name" direction="in" />
+      <arg type="s" name="path" direction="in" />
+      <arg type="i" name="result" direction="out" />
+    </method>
+    <!-- Get the file path of the designated neural network model -->
+    <method name="GetPath">
+      <arg type="s" name="name" direction="in" />
+      <arg type="s" name="path" direction="out" />
+      <arg type="i" name="result" direction="out" />
+    </method>
+    <!-- Delete the file path of the designated neural network model -->
+    <method name="Delete">
+      <arg type="s" name="name" direction="in" />
+      <arg type="i" name="result" direction="out" />
+    </method>
+  </interface>
+</node>

--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -354,6 +354,7 @@ bash %{test_script} ./tests/capi/unittest_capi_service_db_mock
 
 %if 0%{?enable_machine_learning_agent}
 bash %{test_script} ./tests/daemon/unittest_ml_agent
+bash %{test_script} ./tests/daemon/unittest_dbus_model
 %endif
 
 %if 0%{?nnfw_support}

--- a/tests/daemon/meson.build
+++ b/tests/daemon/meson.build
@@ -5,3 +5,11 @@ unittest_ml_agent = executable('unittest_ml_agent',
   install_dir: unittest_install_dir
 )
 test('unittest_ml_agent', unittest_ml_agent, env: testenv, timeout: 100)
+
+unittest_dbus_model = executable('unittest_dbus_model',
+  'unittest_dbus_model.cc',
+  dependencies: [unittest_common_dep, gdbus_gen_header_dep],
+  install: get_option('install-test'),
+  install_dir: unittest_install_dir
+)
+test('unittest_dbus_model', unittest_dbus_model, env: testenv, timeout: 100)

--- a/tests/daemon/unittest_dbus_model.cc
+++ b/tests/daemon/unittest_dbus_model.cc
@@ -1,0 +1,225 @@
+/**
+ * @file        unittest_dbus_model.cc
+ * @date        29 Jul 2022
+ * @brief       Unit test for DBus Model interface
+ * @see         https://github.com/nnstreamer/api
+ * @author      Sangjung Woo <sangjung.woo@samsung.com>
+ * @bug         No known bugs
+ */
+
+#include <gio/gio.h>
+#include <gtest/gtest.h>
+#include <errno.h>
+
+#include "model-dbus.h"
+#include "../../daemon/includes/dbus-interface.h"
+
+/**
+ * @brief Test base class of DBus Model interface
+ */
+class DbusModelTest : public::testing::Test
+{
+protected:
+  GTestDBus *dbus;
+  GDBusProxy *server_proxy;
+  MachinelearningServiceModel *client_proxy;
+
+public:
+  /**
+   * @brief Construct a new DbusModelTest object
+   */
+  DbusModelTest()
+    : dbus(nullptr), server_proxy(nullptr), client_proxy(nullptr) { }
+
+  /**
+   * @brief Setup method for each test case.
+   */
+  void SetUp() override
+  {
+    g_autofree gchar *services_dir = g_build_filename (g_get_current_dir (), "tests/services", NULL);
+    dbus = g_test_dbus_new (G_TEST_DBUS_NONE);
+    g_test_dbus_add_service_dir (dbus, services_dir);
+    g_test_dbus_up (dbus);
+
+    GError *error = NULL;
+    server_proxy = g_dbus_proxy_new_for_bus_sync (
+      G_BUS_TYPE_SESSION,
+      G_DBUS_PROXY_FLAGS_NONE,
+      NULL,
+      DBUS_ML_BUS_NAME,
+      DBUS_MODEL_PATH,
+      DBUS_MODEL_INTERFACE,
+      NULL,
+      &error);
+
+    if (!server_proxy || error) {
+      if (error) {
+        g_critical ("Error Message : %s", error->message);
+        g_clear_error (&error);
+      }
+    }
+
+    client_proxy = machinelearning_service_model_proxy_new_for_bus_sync (
+      G_BUS_TYPE_SESSION,
+      G_DBUS_PROXY_FLAGS_NONE,
+      DBUS_ML_BUS_NAME,
+      DBUS_MODEL_PATH,
+      NULL, &error);
+    if (!client_proxy || error) {
+      if (error) {
+        g_critical ("Error Message : %s", error->message);
+        g_clear_error (&error);
+      }
+    }
+  }
+
+  /**
+   * @brief Teardown method for each test case.
+   */
+  void TearDown() override
+  {
+    if (server_proxy)
+      g_object_unref (server_proxy);
+
+    if (client_proxy)
+      g_object_unref (client_proxy);
+
+    g_test_dbus_down (dbus);
+    g_object_unref (dbus);
+  }
+};
+
+/**
+ * @brief Call the 'set_path' DBus method to store the model name and its file path.
+ */
+TEST_F (DbusModelTest, set_path_00_p)
+{
+  int ret;
+  const gchar *name = "mobilenetv3";
+  const gchar *path = "/opt/usr/shared/mobilenet_v3.pb";
+  GError *error = nullptr;
+
+  /* Test: Store the model name and its file path */
+  machinelearning_service_model_call_set_path_sync (
+    client_proxy, name, path, &ret, nullptr, &error);
+  EXPECT_EQ (ret, 0);
+}
+
+/**
+ * @brief Call the 'SetPath' DBus method with invalid parameters.
+ */
+TEST_F (DbusModelTest, set_path_invalid_param_01_n)
+{
+  int ret;
+  const gchar *name = "mobilenetv3";
+  const gchar *path = "/opt/usr/shared/mobilenet_v3.pb";
+  GError *error = nullptr;
+
+  /* Test: Call with empty name and file path */
+  machinelearning_service_model_call_set_path_sync (
+    client_proxy, "", path, &ret, nullptr, &error);
+  EXPECT_EQ (ret, -EINVAL);
+
+  machinelearning_service_model_call_set_path_sync (
+    client_proxy, name, "", &ret, nullptr, &error);
+  EXPECT_EQ (ret, -EINVAL);
+}
+
+/**
+ * @brief Call the 'GetPath' DBus method and check its result
+ */
+TEST_F (DbusModelTest, get_path_02_p)
+{
+  int ret;
+  const gchar *name = "mobilenetv3";
+  const gchar *path = "/opt/usr/shared/mobilenet_v3.pb";
+  g_autofree gchar *out_path = nullptr;
+  GError *error = nullptr;
+
+  machinelearning_service_model_call_set_path_sync (
+    client_proxy, name, path, &ret, nullptr, &error);
+  EXPECT_EQ (ret, 0);
+
+  /* Test */
+  machinelearning_service_model_call_get_path_sync (
+    client_proxy, name, &out_path, &ret, nullptr, &error);
+  EXPECT_EQ (ret, 0);
+  ASSERT_STREQ (out_path, path);
+}
+
+/**
+ * @brief Call the 'GetPath' DBus method with invalid parameter
+ */
+TEST_F (DbusModelTest, get_path_invalid_param_03_n)
+{
+  int ret;
+  g_autofree gchar *out_path = nullptr;
+  GError *error = nullptr;
+
+  /* Test: Call with empty name */
+  machinelearning_service_model_call_get_path_sync (
+    client_proxy, "", &out_path, &ret, nullptr, &error);
+  EXPECT_EQ (ret, -EINVAL);
+}
+
+/**
+ * @brief Call the 'Delete' DBus method and check its result
+ */
+TEST_F (DbusModelTest, delete_04_p)
+{
+  int ret;
+  const gchar *name = "mobilenetv3";
+  const gchar *path = "/opt/usr/shared/mobilenet_v3.pb";
+  g_autofree gchar *out_path = nullptr;
+  GError *error = nullptr;
+
+  machinelearning_service_model_call_set_path_sync (
+    client_proxy, name, path, &ret, nullptr, &error);
+  EXPECT_EQ (ret, 0);
+
+  /* Test */
+  machinelearning_service_model_call_delete_sync (
+    client_proxy, name, &ret, nullptr, &error);
+  EXPECT_EQ (ret, 0);
+
+  machinelearning_service_model_call_get_path_sync (
+    client_proxy, name, &out_path, &ret, nullptr, &error);
+  EXPECT_EQ (ret, -EINVAL);
+}
+
+/**
+ * @brief Call the 'Delete' DBus method with invalid parameter
+ */
+TEST_F (DbusModelTest, delete_invalid_param_05_n)
+{
+  int ret;
+  GError *error = nullptr;
+
+  /* Test: Call with empty name */
+  machinelearning_service_model_call_delete_sync (
+    client_proxy, "", &ret, nullptr, &error);
+  EXPECT_EQ (ret, -EINVAL);
+}
+
+/**
+ * @brief Main gtest
+ */
+int
+main (int argc, char **argv)
+{
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest (&argc, argv);
+  } catch (...) {
+    g_warning ("catch 'testing::internal::<unnamed>::ClassUniqueToAlwaysTrue'");
+  }
+
+  try {
+    result = RUN_ALL_TESTS ();
+  } catch (...) {
+    g_warning ("catch `testing::internal::GoogleTestFailureException`");
+  }
+
+  return result;
+}


### PR DESCRIPTION
This patch newly adds the unit test case of the DBus Model interface and its implementation code. DBus Model interface handles the neural network model files by storing the name of a model file and its file path in the internal key-value database. To improve the maintainability, this PR defines the `IMLServiceDB` interface so the backend database could be changed easily.

### Overall Architecture
![0003](https://user-images.githubusercontent.com/433435/181686938-f74f9359-1400-415e-8b15-00676a5a54a3.JPG)

### IMLServceDB Class diagram
![0002](https://user-images.githubusercontent.com/433435/181686961-2721a29a-111b-4149-92fa-6ce52c822f32.jpg)

### Submit History
#### V3
* Use `#define` header-guard instead of `#pragma once` since it is not standard in C++

#### V2
* Move the `client proxy` to SetUp() method.
* Remove unused headers
* Fix the boilerplate code

#### V1
* First draft
* Implementation of DBus Model interface and its test cases