### PR TITLE
[ml-agent] Add set/get/delete pipeline method to pipeline module

### DIFF
--- a/daemon/includes/dbus-interface.h
+++ b/daemon/includes/dbus-interface.h
@@ -26,7 +26,7 @@
 #define DBUS_PIPELINE_INTERFACE          "org.tizen.machinelearning.service.pipeline"
 #define DBUS_PIPELINE_PATH               "/Org/Tizen/MachineLearning/Service/Pipeline"
 
-#define DBUS_PIPELINE_I_REGISTER_HANDLER        "handle_register_pipeline"
+#define DBUS_PIPELINE_I_LAUNCH_HANDLER          "handle_launch_pipeline"
 #define DBUS_PIPELINE_I_START_HANDLER           "handle_start_pipeline"
 #define DBUS_PIPELINE_I_STOP_HANDLER            "handle_stop_pipeline"
 #define DBUS_PIPELINE_I_DESTROY_HANDLER         "handle_destroy_pipeline"

--- a/daemon/includes/dbus-interface.h
+++ b/daemon/includes/dbus-interface.h
@@ -26,6 +26,10 @@
 #define DBUS_PIPELINE_INTERFACE          "org.tizen.machinelearning.service.pipeline"
 #define DBUS_PIPELINE_PATH               "/Org/Tizen/MachineLearning/Service/Pipeline"
 
+#define DBUS_PIPELINE_I_SET_HANDLER             "handle_set_pipeline"
+#define DBUS_PIPELINE_I_GET_HANDLER             "handle_get_pipeline"
+#define DBUS_PIPELINE_I_DELETE_HANDLER          "handle_delete_pipeline"
+
 #define DBUS_PIPELINE_I_LAUNCH_HANDLER          "handle_launch_pipeline"
 #define DBUS_PIPELINE_I_START_HANDLER           "handle_start_pipeline"
 #define DBUS_PIPELINE_I_STOP_HANDLER            "handle_stop_pipeline"

--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -11,7 +11,7 @@ if get_option('enable-machine-learning-agent')
   nns_ml_agent_srcs += join_paths('modules.c')
   nns_ml_agent_srcs += join_paths('gdbus-util.c')
   nns_ml_agent_srcs += join_paths('service-db.cc')
-  nns_ml_agent_srcs += join_paths('pipeline-module.c')
+  nns_ml_agent_srcs += join_paths('pipeline-module.cc')
   nns_ml_agent_srcs += join_paths('model-dbus-impl.cc')
 
   # Generate GDbus header and code

--- a/dbus/pipeline-dbus.xml
+++ b/dbus/pipeline-dbus.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <node name="/Org/Tizen/MachineLearning/Service">
   <interface name="org.tizen.machinelearning.service.pipeline">
-    <method name="register_pipeline">
-      <arg type="s" name="pipeline" direction="in" />
+    <method name="launch_pipeline">
+      <arg type="s" name="service_name" direction="in" />
       <arg type="i" name="result" direction="out" />
       <arg type="x" name="id" direction="out" />
     </method>

--- a/dbus/pipeline-dbus.xml
+++ b/dbus/pipeline-dbus.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <node name="/Org/Tizen/MachineLearning/Service">
   <interface name="org.tizen.machinelearning.service.pipeline">
+    <method name="set_pipeline">
+      <arg type="s" name="service_name" direction="in" />
+      <arg type="s" name="pipeline_desc" direction="in" />
+      <arg type="i" name="result" direction="out" />
+    </method>
+    <method name="get_pipeline">
+      <arg type="s" name="service_name" direction="in" />
+      <arg type="i" name="result" direction="out" />
+      <arg type="s" name="pipeline_desc" direction="out" />
+    </method>
+    <method name="delete_pipeline">
+      <arg type="s" name="service_name" direction="in" />
+      <arg type="i" name="result" direction="out" />
+    </method>
     <method name="launch_pipeline">
       <arg type="s" name="service_name" direction="in" />
       <arg type="i" name="result" direction="out" />


### PR DESCRIPTION
- Change the method name `register_pipeline` -> `launch_pipeline`.
  This method launch pipeline with given service name, if the pipeline
  description is stored in the DB beforehand.
- Change the module source file into cpp file. It's to use the db implementation.
- Add `set_pipeline`, `get_pipeline`, and `delete_pipeline` dbus call.
- These correspond with `ml_service_[set|get|delete]_pipeline` APIs.