### PR TITLE
[ML Agent] Enable PIE option for Tizen security check

### DIFF
--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -64,8 +64,8 @@ if get_option('enable-machine-learning-agent')
     include_directories: nns_ml_agent_incs,
     install: true,
     install_dir: api_install_bindir,
-    cpp_args : '-DDB_PATH="' + serviceDBPath + '"'
-
+    cpp_args : '-DDB_PATH="' + serviceDBPath + '"',
+    pie : true
   )
 
   # For unit test

--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -464,9 +464,9 @@ cp -r result %{buildroot}%{_datadir}/ml-api/unittest/
 %if 0%{?enable_machine_learning_agent}
 %files -n machine-learning-agent
 %manifest machine-learning-agent.manifest
-%{_bindir}/machine-learning-agent
-%{_unitdir}/machine-learning-agent.service
-%config %{_sysconfdir}/dbus-1/system.d/machine-learning-agent.conf
+%attr(0755,root,root) %{_bindir}/machine-learning-agent
+%attr(0644,root,root) %{_unitdir}/machine-learning-agent.service
+%attr(0644,root,root) %config %{_sysconfdir}/dbus-1/system.d/machine-learning-agent.conf
 %attr(0644,root,root) %{_datadir}/dbus-1/system-services/org.tizen.machinelearning.service.service
 %endif
 


### PR DESCRIPTION
This patch enables the PIE (Position Independent Executable) option to
comply with Tizen security. If this option is not enabled, the daemon
file will be lost its executable permission when making platform image.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

### MIC error
```bash
INFO: ###### ASLR not applied list ######
INFO: /usr/bin/winpr-hash
INFO: /usr/bin/machine-learning-agent
...
```
