### PR TITLE
[ml-service] Fix session type of ml-service API @open sesame 08/22 18:35

### DIFF
--- a/c/src/ml-api-service-agent-client.c
+++ b/c/src/ml-api-service-agent-client.c
@@ -145,6 +145,9 @@ ml_service_delete_pipeline (const char *name)
   return ret;
 }
 
+/**
+ * @brief Launch the pipeline of given service.
+ */
 int
 ml_service_launch_pipeline (const char *name, ml_service_h * h)
 {

--- a/c/src/ml-api-service-agent-client.c
+++ b/c/src/ml-api-service-agent-client.c
@@ -31,12 +31,24 @@ typedef struct
 static MachinelearningServicePipeline *
 _get_proxy_new_for_bus_sync (void)
 {
+  MachinelearningServicePipeline *mlsp;
+
   /** @todo deal with GError */
-  return
-      machinelearning_service_pipeline_proxy_new_for_bus_sync
+  mlsp = machinelearning_service_pipeline_proxy_new_for_bus_sync
+      (G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE,
+      "org.tizen.machinelearning.service",
+      "/Org/Tizen/MachineLearning/Service/Pipeline", NULL, NULL);
+
+  if (mlsp)
+    return mlsp;
+
+  /** Try with session type */
+  mlsp = machinelearning_service_pipeline_proxy_new_for_bus_sync
       (G_BUS_TYPE_SESSION, G_DBUS_PROXY_FLAGS_NONE,
       "org.tizen.machinelearning.service",
       "/Org/Tizen/MachineLearning/Service/Pipeline", NULL, NULL);
+
+  return mlsp;
 }
 
 /**


### PR DESCRIPTION
- Set System type for ml-service API.
- If fails to get system bus, try with session type (for unittest)

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>