### PR TITLE
[After #196][service] Add document for newly added service APIs @open sesame 08/31 11:35

### DIFF
--- a/c/include/ml-api-service.h
+++ b/c/include/ml-api-service.h
@@ -126,7 +126,6 @@ int ml_service_start_pipeline (ml_service_h handle);
 int ml_service_stop_pipeline (ml_service_h handle);
 int ml_service_destroy_pipeline (ml_service_h handle);
 int ml_service_getstate_pipeline (ml_service_h handle, ml_pipeline_state_e *state);
-int ml_service_getdesc_pipeline (ml_service_h handle, char **desc);
 
 /**
  * @}

--- a/c/include/ml-api-service.h
+++ b/c/include/ml-api-service.h
@@ -175,7 +175,7 @@ int ml_service_stop_pipeline (ml_service_h handle);
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
  * @retval #ML_ERROR_STREAMS_PIPE Failed to access the pipeline state.
  */
-int ml_service_destroy_pipeline (ml_service_h handle);
+int ml_service_destroy (ml_service_h handle);
 
 /**
  * @brief Gets the state of given handle's pipeline.
@@ -188,7 +188,7 @@ int ml_service_destroy_pipeline (ml_service_h handle);
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
  * @retval #ML_ERROR_STREAMS_PIPE Failed to access the pipeline state.
  */
-int ml_service_getstate_pipeline (ml_service_h handle, ml_pipeline_state_e *state);
+int ml_service_get_pipeline_state (ml_service_h handle, ml_pipeline_state_e *state);
 
 /**
  * @}

--- a/c/include/ml-api-service.h
+++ b/c/include/ml-api-service.h
@@ -116,15 +116,78 @@ int ml_service_get_pipeline (const char *name, char **pipeline_desc);
 int ml_service_delete_pipeline (const char *name);
 
 /**
- * @brief handle for ml_service. To support multiple instance for a single service, user should mangage pipeline with this handle.
+ * @brief A handle for ml-service instance.
+ * @since_tizen 7.0
  */
 typedef void *ml_service_h;
 
-/** @todo Add description and decide final API name */
+/**
+ * @brief Launches the pipeline of given service and gets the service handle.
+ * @details This requests machine learning agent daemon to launch a new pipeline of given service. The pipeline of service @a name should be set.
+ * @since_tizen 7.0
+ * @remarks The @a handle should be destroyed using ml_service_destroy().
+ * @param[in] name The service name.
+ * @param[out] handle Newly created service handle is returned.
+ * @return @c 0 on Success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
+ * @retval #ML_ERROR_OUT_OF_MEMORY Failed to allocate required memory.
+ * @retval #ML_ERROR_IO_ERROR The operation of DB or filesystem has failed.
+ * @retval #ML_ERROR_STREAMS_PIPE Failed to launch the pipeline.
+ */
 int ml_service_launch_pipeline (const char *name, ml_service_h *handle);
+
+/**
+ * @brief Starts the pipeline of given service handle.
+ * @details This requests machine learning agent daemon to start the pipeline.
+ * @since_tizen 7.0
+ * @param[in] handle The service handle.
+ * @return @c 0 on Success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
+ * @retval #ML_ERROR_STREAMS_PIPE Failed to start the pipeline.
+ */
 int ml_service_start_pipeline (ml_service_h handle);
+
+/**
+ * @brief Stops the pipeline of given service handle.
+ * @details This requests machine learning agent daemon to stop the pipeline.
+ * @since_tizen 7.0
+ * @param[in] handle The service handle.
+ * @return @c 0 on Success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
+ * @retval #ML_ERROR_STREAMS_PIPE Failed to stop the pipeline.
+ */
 int ml_service_stop_pipeline (ml_service_h handle);
+
+/**
+ * @brief Destroys the given service handle.
+ * @details If given service handle is created by ml_service_launch_pipeline(), this requests machine learning agent daemon to destroy the pipeline.
+ * @since_tizen 7.0
+ * @param[in] handle The service handle.
+ * @return @c 0 on Success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
+ * @retval #ML_ERROR_STREAMS_PIPE Failed to access the pipeline state.
+ */
 int ml_service_destroy_pipeline (ml_service_h handle);
+
+/**
+ * @brief Gets the state of given handle's pipeline.
+ * @since_tizen 7.0
+ * @param[in] handle The service handle.
+ * @param[out] state The pipeline state.
+ * @return @c 0 on Success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
+ * @retval #ML_ERROR_STREAMS_PIPE Failed to access the pipeline state.
+ */
 int ml_service_getstate_pipeline (ml_service_h handle, ml_pipeline_state_e *state);
 
 /**

--- a/c/src/ml-api-service-agent-client.c
+++ b/c/src/ml-api-service-agent-client.c
@@ -260,7 +260,7 @@ ml_service_stop_pipeline (ml_service_h h)
  * @brief Destroy the pipeline of given ml_service_h
  */
 int
-ml_service_destroy_pipeline (ml_service_h h)
+ml_service_destroy (ml_service_h h)
 {
   int ret = ML_ERROR_NONE;
   ml_service_s *server = (ml_service_s *) h;
@@ -292,7 +292,7 @@ ml_service_destroy_pipeline (ml_service_h h)
  * @brief Return state of given ml_service_h
  */
 int
-ml_service_getstate_pipeline (ml_service_h h, ml_pipeline_state_e * state)
+ml_service_get_pipeline_state (ml_service_h h, ml_pipeline_state_e * state)
 {
   int ret = ML_ERROR_NONE;
   gint _state;

--- a/c/src/ml-api-service-agent-client.c
+++ b/c/src/ml-api-service-agent-client.c
@@ -58,7 +58,6 @@ int
 ml_service_set_pipeline (const char *name, const char *pipeline_desc)
 {
   int ret = ML_ERROR_NONE;
-  gint out_return_code;
   MachinelearningServicePipeline *mlsp;
 
   check_feature_state (ML_FEATURE_SERVICE);
@@ -74,10 +73,13 @@ ml_service_set_pipeline (const char *name, const char *pipeline_desc)
   }
 
   mlsp = _get_proxy_new_for_bus_sync ();
-  machinelearning_service_pipeline_call_set_pipeline_sync (mlsp, name,
-      pipeline_desc, &out_return_code, NULL, NULL);
+  if (!mlsp) {
+    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
+        "Failed to get dbus proxy.");
+  }
 
-  ret = out_return_code;
+  machinelearning_service_pipeline_call_set_pipeline_sync (mlsp, name,
+      pipeline_desc, &ret, NULL, NULL);
 
   g_object_unref (mlsp);
 
@@ -91,7 +93,6 @@ int
 ml_service_get_pipeline (const char *name, char **pipeline_desc)
 {
   int ret = ML_ERROR_NONE;
-  gint out_return_code;
   MachinelearningServicePipeline *mlsp;
 
   check_feature_state (ML_FEATURE_SERVICE);
@@ -107,10 +108,13 @@ ml_service_get_pipeline (const char *name, char **pipeline_desc)
   }
 
   mlsp = _get_proxy_new_for_bus_sync ();
-  machinelearning_service_pipeline_call_get_pipeline_sync (mlsp, name,
-      &out_return_code, pipeline_desc, NULL, NULL);
+  if (!mlsp) {
+    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
+        "Failed to get dbus proxy.");
+  }
 
-  ret = out_return_code;
+  machinelearning_service_pipeline_call_get_pipeline_sync (mlsp, name,
+      &ret, pipeline_desc, NULL, NULL);
 
   g_object_unref (mlsp);
 
@@ -124,7 +128,6 @@ int
 ml_service_delete_pipeline (const char *name)
 {
   int ret = ML_ERROR_NONE;
-  gint out_return_code;
   MachinelearningServicePipeline *mlsp;
 
   check_feature_state (ML_FEATURE_SERVICE);
@@ -135,10 +138,13 @@ ml_service_delete_pipeline (const char *name)
   }
 
   mlsp = _get_proxy_new_for_bus_sync ();
-  machinelearning_service_pipeline_call_delete_pipeline_sync (mlsp, name,
-      &out_return_code, NULL, NULL);
+  if (!mlsp) {
+    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
+        "Failed to get dbus proxy.");
+  }
 
-  ret = out_return_code;
+  machinelearning_service_pipeline_call_delete_pipeline_sync (mlsp, name,
+      &ret, NULL, NULL);
 
   g_object_unref (mlsp);
 
@@ -151,8 +157,8 @@ ml_service_delete_pipeline (const char *name)
 int
 ml_service_launch_pipeline (const char *name, ml_service_h * h)
 {
+  int ret = ML_ERROR_NONE;
   ml_service_s *server;
-  gint out_return_code;
   gint64 out_id;
   MachinelearningServicePipeline *mlsp;
 
@@ -162,31 +168,32 @@ ml_service_launch_pipeline (const char *name, ml_service_h * h)
     _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
         "The parameter, 'h' is NULL. It should be a valid ml_service_h");
 
-  server = g_new0 (ml_service_s, 1);
+  mlsp = _get_proxy_new_for_bus_sync ();
+  if (!mlsp) {
+    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
+        "Failed to get dbus proxy.");
+  }
 
+  machinelearning_service_pipeline_call_launch_pipeline_sync (mlsp, name,
+      &ret, &out_id, NULL, NULL);
+
+  g_object_unref (mlsp);
+
+  if (0 != ret) {
+    _ml_error_report_return (ret,
+        "Failed to launch pipeline, please check its integrity.");
+  }
+
+  server = g_new0 (ml_service_s, 1);
   if (server == NULL)
     _ml_error_report_return (ML_ERROR_OUT_OF_MEMORY,
         "Failed to allocate memory for the service_server. Out of memory?");
-
-
-  mlsp = _get_proxy_new_for_bus_sync ();
-  machinelearning_service_pipeline_call_launch_pipeline_sync (mlsp, name,
-      &out_return_code, &out_id, NULL, NULL);
-
-  if (out_return_code != 0) {
-    g_free (server);
-    g_object_unref (mlsp);
-    _ml_error_report_return (out_return_code,
-        "Failed to launch pipeline, please check its integrity.");
-  }
 
   server->id = out_id;
   server->service_name = g_strdup (name);
   *h = (ml_service_h *) server;
 
-  g_object_unref (mlsp);
-
-  return ML_ERROR_NONE;
+  return ret;
 }
 
 /**
@@ -195,7 +202,7 @@ ml_service_launch_pipeline (const char *name, ml_service_h * h)
 int
 ml_service_start_pipeline (ml_service_h h)
 {
-  gint out_result;
+  int ret = ML_ERROR_NONE;
   ml_service_s *server = (ml_service_s *) h;
   MachinelearningServicePipeline *mlsp;
 
@@ -206,12 +213,17 @@ ml_service_start_pipeline (ml_service_h h)
         "The parameter, 'h' is NULL. It should be a valid ml_service_h");
 
   mlsp = _get_proxy_new_for_bus_sync ();
+  if (!mlsp) {
+    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
+        "Failed to get dbus proxy.");
+  }
+
   machinelearning_service_pipeline_call_start_pipeline_sync (mlsp, server->id,
-      &out_result, NULL, NULL);
+      &ret, NULL, NULL);
 
   g_object_unref (mlsp);
 
-  return ML_ERROR_NONE;
+  return ret;
 }
 
 /**
@@ -220,7 +232,7 @@ ml_service_start_pipeline (ml_service_h h)
 int
 ml_service_stop_pipeline (ml_service_h h)
 {
-  gint out_result;
+  int ret = ML_ERROR_NONE;
   ml_service_s *server = (ml_service_s *) h;
   MachinelearningServicePipeline *mlsp;
 
@@ -231,12 +243,17 @@ ml_service_stop_pipeline (ml_service_h h)
         "The parameter, 'h' is NULL. It should be a valid ml_service_h");
 
   mlsp = _get_proxy_new_for_bus_sync ();
+  if (!mlsp) {
+    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
+        "Failed to get dbus proxy.");
+  }
+
   machinelearning_service_pipeline_call_stop_pipeline_sync (mlsp, server->id,
-      &out_result, NULL, NULL);
+      &ret, NULL, NULL);
 
   g_object_unref (mlsp);
 
-  return ML_ERROR_NONE;
+  return ret;
 }
 
 /**
@@ -245,7 +262,7 @@ ml_service_stop_pipeline (ml_service_h h)
 int
 ml_service_destroy_pipeline (ml_service_h h)
 {
-  gint out_result;
+  int ret = ML_ERROR_NONE;
   ml_service_s *server = (ml_service_s *) h;
   MachinelearningServicePipeline *mlsp;
 
@@ -256,14 +273,19 @@ ml_service_destroy_pipeline (ml_service_h h)
         "The parameter, 'h' is NULL. It should be a valid ml_service_h");
 
   mlsp = _get_proxy_new_for_bus_sync ();
+  if (!mlsp) {
+    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
+        "Failed to get dbus proxy.");
+  }
+
   machinelearning_service_pipeline_call_destroy_pipeline_sync (mlsp, server->id,
-      &out_result, NULL, NULL);
+      &ret, NULL, NULL);
 
   g_object_unref (mlsp);
 
   g_free (server->service_name);
   g_free (server);
-  return ML_ERROR_NONE;
+  return ret;
 }
 
 /**
@@ -272,7 +294,7 @@ ml_service_destroy_pipeline (ml_service_h h)
 int
 ml_service_getstate_pipeline (ml_service_h h, ml_pipeline_state_e * state)
 {
-  gint out_result;
+  int ret = ML_ERROR_NONE;
   gint _state;
   ml_service_s *server = (ml_service_s *) h;
   MachinelearningServicePipeline *mlsp;
@@ -284,12 +306,17 @@ ml_service_getstate_pipeline (ml_service_h h, ml_pipeline_state_e * state)
         "The parameter, 'h' is NULL. It should be a valid ml_service_h");
 
   mlsp = _get_proxy_new_for_bus_sync ();
+  if (!mlsp) {
+    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
+        "Failed to get dbus proxy.");
+  }
+
   machinelearning_service_pipeline_call_get_state_sync (mlsp, server->id,
-      &out_result, &_state, NULL, NULL);
+      &ret, &_state, NULL, NULL);
 
   *state = (ml_pipeline_state_e) _state;
 
   g_object_unref (mlsp);
 
-  return ML_ERROR_NONE;
+  return ret;
 }

--- a/c/src/ml-api-service-agent-client.c
+++ b/c/src/ml-api-service-agent-client.c
@@ -293,28 +293,3 @@ ml_service_getstate_pipeline (ml_service_h h, ml_pipeline_state_e * state)
 
   return ML_ERROR_NONE;
 }
-
-/**
- * @brief Return the pipeline description of given ml_service_h
- */
-int
-ml_service_getdesc_pipeline (ml_service_h h, char **desc)
-{
-  gint out_result;
-  ml_service_s *server = (ml_service_s *) h;
-  MachinelearningServicePipeline *mlsp;
-
-  check_feature_state (ML_FEATURE_SERVICE);
-
-  if (!h)
-    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
-        "The parameter, 'h' is NULL. It should be a valid ml_service_h");
-
-  mlsp = _get_proxy_new_for_bus_sync ();
-  machinelearning_service_pipeline_call_get_description_sync (mlsp, server->id,
-      &out_result, desc, NULL, NULL);
-
-  g_object_unref (mlsp);
-
-  return ML_ERROR_NONE;
-}

--- a/daemon/includes/dbus-interface.h
+++ b/daemon/includes/dbus-interface.h
@@ -34,9 +34,7 @@
 #define DBUS_PIPELINE_I_START_HANDLER           "handle_start_pipeline"
 #define DBUS_PIPELINE_I_STOP_HANDLER            "handle_stop_pipeline"
 #define DBUS_PIPELINE_I_DESTROY_HANDLER         "handle_destroy_pipeline"
-
 #define DBUS_PIPELINE_I_GET_STATE_HANDLER       "handle_get_state"
-#define DBUS_PIPELINE_I_GET_DESCRIPTION_HANDLER "handle_get_description"
 
 /* Model Interface */
 #define DBUS_MODEL_INTERFACE            "org.tizen.machinelearning.service.model"

--- a/daemon/pipeline-module.cc
+++ b/daemon/pipeline-module.cc
@@ -406,35 +406,6 @@ static gboolean dbus_cb_core_get_state (MachinelearningServicePipeline *obj,
   return TRUE;
 }
 
-/**
- * @brief Get the description of pipeline with given id. Return the call result and its description.
- */
-static gboolean dbus_cb_core_get_description (MachinelearningServicePipeline *obj,
-        GDBusMethodInvocation *invoc, gint64 id, gpointer user_data)
-{
-  gint result = 0;
-  pipeline_s *p = NULL;
-  gchar *description = NULL;
-
-  G_LOCK (pipeline_table_lock);
-  p = (pipeline_s *) g_hash_table_lookup (pipeline_table, GINT_TO_POINTER (id));
-  G_UNLOCK (pipeline_table_lock);
-
-  if (!p) {
-    _E ("there is no pipeline with id: %" G_GINT64_FORMAT, id);
-    result = -EINVAL;
-    machinelearning_service_pipeline_complete_get_description (obj, invoc, result, NULL);
-    return FALSE;
-  }
-
-  description = g_strdup (p->description);
-
-  machinelearning_service_pipeline_complete_get_description (obj, invoc, result, description);
-
-  g_free (description);
-  return TRUE;
-}
-
 static struct gdbus_signal_info handler_infos[] = {
   {
     .signal_name = DBUS_PIPELINE_I_SET_HANDLER,
@@ -474,11 +445,6 @@ static struct gdbus_signal_info handler_infos[] = {
   }, {
     .signal_name = DBUS_PIPELINE_I_GET_STATE_HANDLER,
     .cb = G_CALLBACK (dbus_cb_core_get_state),
-    .cb_data = NULL,
-    .handler_id = 0,
-  }, {
-    .signal_name = DBUS_PIPELINE_I_GET_DESCRIPTION_HANDLER,
-    .cb = G_CALLBACK (dbus_cb_core_get_description),
     .cb_data = NULL,
     .handler_id = 0,
   },

--- a/dbus/pipeline-dbus.xml
+++ b/dbus/pipeline-dbus.xml
@@ -37,10 +37,5 @@
       <arg type="i" name="result" direction="out" />
       <arg type="i" name="state" direction="out" />
     </method>
-    <method name="get_description">
-      <arg type="x" name="id" direction="in" />
-      <arg type="i" name="result" direction="out" />
-      <arg type="s" name="description" direction="out" />
-    </method>
   </interface>
 </node>

--- a/tests/capi/unittest_capi_service_agent_client.cc
+++ b/tests/capi/unittest_capi_service_agent_client.cc
@@ -130,9 +130,6 @@ TEST_F (MLServiceAgentTest, usecase_00)
   status = ml_service_launch_pipeline (service_name, &service);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  status = ml_service_getdesc_pipeline (service, &ret_pipeline);
-  EXPECT_STREQ (pipeline_desc, ret_pipeline);
-
   status = ml_service_getstate_pipeline (service, &state);
   EXPECT_EQ (ML_ERROR_NONE, status);
   EXPECT_EQ (ML_PIPELINE_STATE_PAUSED, state);
@@ -225,9 +222,6 @@ TEST_F (MLServiceAgentTest, usecase_01)
   ml_pipeline_state_e state;
   status = ml_service_launch_pipeline (service_name, &service);
   EXPECT_EQ (ML_ERROR_NONE, status);
-
-  status = ml_service_getdesc_pipeline (service, &ret_pipeline);
-  EXPECT_STREQ (pipeline_desc, ret_pipeline);
 
   status = ml_service_getstate_pipeline (service, &state);
   EXPECT_EQ (ML_ERROR_NONE, status);

--- a/tests/capi/unittest_capi_service_agent_client.cc
+++ b/tests/capi/unittest_capi_service_agent_client.cc
@@ -130,13 +130,13 @@ TEST_F (MLServiceAgentTest, usecase_00)
   status = ml_service_launch_pipeline (service_name, &service);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  status = ml_service_getstate_pipeline (service, &state);
+  status = ml_service_get_pipeline_state (service, &state);
   EXPECT_EQ (ML_ERROR_NONE, status);
   EXPECT_EQ (ML_PIPELINE_STATE_PAUSED, state);
 
   status = ml_service_start_pipeline (service);
   EXPECT_EQ (ML_ERROR_NONE, status);
-  status = ml_service_getstate_pipeline (service, &state);
+  status = ml_service_get_pipeline_state (service, &state);
   EXPECT_EQ (ML_ERROR_NONE, status);
   EXPECT_EQ (ML_PIPELINE_STATE_PLAYING, state);
 
@@ -163,7 +163,7 @@ TEST_F (MLServiceAgentTest, usecase_00)
 
   g_usleep (1 * 1000 * 1000);
 
-  status = ml_service_destroy_pipeline (client);
+  status = ml_service_destroy (client);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
   g_usleep (1 * 1000 * 1000);
@@ -173,12 +173,12 @@ TEST_F (MLServiceAgentTest, usecase_00)
 
   g_usleep (1 * 1000 * 1000);
 
-  status = ml_service_getstate_pipeline (service, &state);
+  status = ml_service_get_pipeline_state (service, &state);
   EXPECT_EQ (ML_ERROR_NONE, status);
   EXPECT_EQ (ML_PIPELINE_STATE_PAUSED, state);
 
   /** destroy the pipeline */
-  status = ml_service_destroy_pipeline (service);
+  status = ml_service_destroy (service);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
   /** delete finished service */
@@ -223,13 +223,13 @@ TEST_F (MLServiceAgentTest, usecase_01)
   status = ml_service_launch_pipeline (service_name, &service);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  status = ml_service_getstate_pipeline (service, &state);
+  status = ml_service_get_pipeline_state (service, &state);
   EXPECT_EQ (ML_ERROR_NONE, status);
   EXPECT_EQ (ML_PIPELINE_STATE_PAUSED, state);
 
   status = ml_service_start_pipeline (service);
   EXPECT_EQ (ML_ERROR_NONE, status);
-  status = ml_service_getstate_pipeline (service, &state);
+  status = ml_service_get_pipeline_state (service, &state);
   EXPECT_EQ (ML_ERROR_NONE, status);
   EXPECT_EQ (ML_PIPELINE_STATE_PLAYING, state);
 
@@ -263,12 +263,12 @@ TEST_F (MLServiceAgentTest, usecase_01)
 
   g_usleep (1 * 1000 * 1000);
 
-  status = ml_service_getstate_pipeline (service, &state);
+  status = ml_service_get_pipeline_state (service, &state);
   EXPECT_EQ (ML_ERROR_NONE, status);
   EXPECT_EQ (ML_PIPELINE_STATE_PAUSED, state);
 
   /** destroy the pipeline */
-  status = ml_service_destroy_pipeline (service);
+  status = ml_service_destroy (service);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
   /** delete finished service */
@@ -305,12 +305,12 @@ TEST_F (MLServiceAgentTest, stop_pipeline_00_n)
 }
 
 /**
- * @brief Test ml_service_destroy_pipeline with invalid param.
+ * @brief Test ml_service_destroy with invalid param.
  */
 TEST_F (MLServiceAgentTest, close_pipeline_00_n)
 {
   int status;
-  status = ml_service_destroy_pipeline (NULL);
+  status = ml_service_destroy (NULL);
   EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
 }
 


### PR DESCRIPTION
- Add some document for newly added service APIs.
- Change API names
  `ml_service_getstate_pipeline` -> `ml_service_get_pipeline_state`
  `ml_service_destroy_pipeline` -> `ml_service_destroy`
- Fix return values and free proxy properly.


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>