### PR TITLE
[service] Add ml service query client

### DIFF
--- a/c/meson.build
+++ b/c/meson.build
@@ -20,6 +20,7 @@ nns_capi_pipeline_srcs += join_paths(meson.current_source_dir(), 'src', 'ml-api-
 if get_option('enable-machine-learning-agent')
   nns_capi_service_srcs += join_paths(meson.current_source_dir(), 'src', 'ml-api-service-common.c')
   nns_capi_service_srcs += join_paths(meson.current_source_dir(), 'src', 'ml-api-service-agent-client.c')
+  nns_capi_service_srcs += join_paths(meson.current_source_dir(), 'src', 'ml-api-service-query-client.c')
 endif
 
 if get_option('enable-tizen')
@@ -161,7 +162,7 @@ nns_capi_dep = declare_dependency(link_with: nns_capi_lib,
 # Service API
 nns_capi_service_shared_lib = shared_library ('capi-ml-service',
   nns_capi_service_srcs,
-  dependencies: nns_capi_deps,
+  dependencies: nns_capi_dep,
   include_directories: nns_capi_include,
   install: true,
   install_dir: api_install_libdir,
@@ -170,7 +171,7 @@ nns_capi_service_shared_lib = shared_library ('capi-ml-service',
 
 nns_capi_service_static_lib = static_library ('capi-ml-service',
   nns_capi_service_srcs,
-  dependencies: nns_capi_deps,
+  dependencies: nns_capi_dep,
   include_directories: nns_capi_include,
   install: true,
   install_dir: api_install_libdir,

--- a/c/meson.build
+++ b/c/meson.build
@@ -18,6 +18,7 @@ nns_capi_single_srcs += join_paths(meson.current_source_dir(), 'src', 'ml-api-in
 nns_capi_pipeline_srcs += join_paths(meson.current_source_dir(), 'src', 'ml-api-inference-pipeline.c')
 
 if get_option('enable-machine-learning-agent')
+  nns_capi_service_srcs += join_paths(meson.current_source_dir(), 'src', 'ml-api-service-common.c')
   nns_capi_service_srcs += join_paths(meson.current_source_dir(), 'src', 'ml-api-service-agent-client.c')
 endif
 

--- a/c/src/ml-api-service-common.c
+++ b/c/src/ml-api-service-common.c
@@ -1,0 +1,86 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file ml-api-service-common.c
+ * @date 31 Aug 2022
+ * @brief Some implementation of NNStreamer/Service C-API
+ * @see https://github.com/nnstreamer/nnstreamer
+ * @author Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#include "ml-api-internal.h"
+#include "ml-api-service.h"
+#include "ml-api-service-private.h"
+
+/**
+ * @brief Internal function to get proxy of the pipeline d-bus interface
+ */
+MachinelearningServicePipeline *
+_get_proxy_new_for_bus_sync (void)
+{
+  MachinelearningServicePipeline *mlsp;
+
+  /** @todo deal with GError */
+  mlsp = machinelearning_service_pipeline_proxy_new_for_bus_sync
+      (G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE,
+      "org.tizen.machinelearning.service",
+      "/Org/Tizen/MachineLearning/Service/Pipeline", NULL, NULL);
+
+  if (mlsp)
+    return mlsp;
+
+  /** Try with session type */
+  mlsp = machinelearning_service_pipeline_proxy_new_for_bus_sync
+      (G_BUS_TYPE_SESSION, G_DBUS_PROXY_FLAGS_NONE,
+      "org.tizen.machinelearning.service",
+      "/Org/Tizen/MachineLearning/Service/Pipeline", NULL, NULL);
+
+  return mlsp;
+}
+
+/**
+ * @brief Destroy the pipeline of given ml_service_h
+ */
+int
+ml_service_destroy (ml_service_h h)
+{
+  int ret = ML_ERROR_NONE;
+  ml_service_s *mls = (ml_service_s *) h;
+  MachinelearningServicePipeline *mlsp;
+
+  check_feature_state (ML_FEATURE_SERVICE);
+
+  if (!h)
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'h' is NULL. It should be a valid ml_service_h.");
+
+  if (ML_SERVICE_TYPE_SERVER_PIPELINE == mls->type) {
+    _ml_service_server_s *server = (_ml_service_server_s *) mls->priv;
+
+    mlsp = _get_proxy_new_for_bus_sync ();
+    if (!mlsp) {
+      _ml_error_report ("Failed to get dbus proxy.");
+      ret = ML_ERROR_INVALID_PARAMETER;
+      goto exit;
+    }
+
+    machinelearning_service_pipeline_call_destroy_pipeline_sync (mlsp, server->id,
+        &ret, NULL, NULL);
+
+    g_object_unref (mlsp);
+
+    g_free (server->service_name);
+    g_free (server);
+  } else {
+    _ml_error_report ("Invalid type of ml_service_h.");
+    ret = ML_ERROR_INVALID_PARAMETER;
+    goto exit;
+  }
+
+exit:
+  g_free (mls);
+
+  return ret;
+}

--- a/c/src/ml-api-service-common.c
+++ b/c/src/ml-api-service-common.c
@@ -91,7 +91,6 @@ ml_service_destroy (ml_service_h h)
     }
 
     g_async_queue_unref (query->out_data_queue);
-    g_free (query->caps);
   } else {
     _ml_error_report ("Invalid type of ml_service_h.");
     ret = ML_ERROR_INVALID_PARAMETER;

--- a/c/src/ml-api-service-private.h
+++ b/c/src/ml-api-service-private.h
@@ -26,6 +26,7 @@ extern "C" {
 typedef enum {
   ML_SERVICE_TYPE = 0,
   ML_SERVICE_TYPE_SERVER_PIPELINE,
+  ML_SERVICE_TYPE_CLIENT_QUERY,
 
   ML_SERVICE_TYPE_MAX
 } ml_service_type_e;
@@ -48,6 +49,21 @@ typedef struct
   gint64 id;
   gchar *service_name;
 } _ml_service_server_s;
+
+/**
+ * @brief Structure for ml_service_query
+ */
+typedef struct
+{
+  ml_pipeline_h pipe_h;
+  ml_pipeline_src_h src_h;
+  ml_pipeline_sink_h sink_h;
+
+  gchar *caps;
+  guint timeout; /**< in ms unit */
+  GAsyncQueue *out_data_queue;
+} _ml_service_query_s;
+
 
 /**
  * @brief Internal function to get proxy of the pipeline d-bus interface

--- a/c/src/ml-api-service-private.h
+++ b/c/src/ml-api-service-private.h
@@ -15,12 +15,44 @@
 #define __ML_API_SERVICE_PRIVATE_DATA_H__
 
 #include <ml-api-service.h>
-#include <ml-api-service-internal.h>
+#include <ml-api-inference-internal.h>
+
+#include "pipeline-dbus.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
 
+typedef enum {
+  ML_SERVICE_TYPE = 0,
+  ML_SERVICE_TYPE_SERVER_PIPELINE,
+
+  ML_SERVICE_TYPE_MAX
+} ml_service_type_e;
+
+/**
+ * @brief Structure for ml_service_h
+ */
+typedef struct
+{
+  ml_service_type_e type;
+
+  void *priv;
+} ml_service_s;
+
+/**
+ * @brief Structure for ml_service_server
+ */
+typedef struct
+{
+  gint64 id;
+  gchar *service_name;
+} _ml_service_server_s;
+
+/**
+ * @brief Internal function to get proxy of the pipeline d-bus interface
+ */
+MachinelearningServicePipeline * _get_proxy_new_for_bus_sync (void);
 
 #ifdef __cplusplus
 }

--- a/c/src/ml-api-service-query-client.c
+++ b/c/src/ml-api-service-query-client.c
@@ -1,0 +1,212 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file ml-api-service-query-client.c
+ * @date 30 Aug 2022
+ * @brief Query client implementation of NNStreamer/Service C-API
+ * @see https://github.com/nnstreamer/nnstreamer
+ * @author Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#include <glib.h>
+#include <gst/gst.h>
+#include <gst/gstbuffer.h>
+#include <gst/app/app.h>
+
+#include "ml-api-internal.h"
+#include "ml-api-service.h"
+#include "ml-api-service-private.h"
+
+/**
+ * @brief Sink callback for query_client
+ */
+static void
+_sink_callback_for_query_client (const ml_tensors_data_h data,
+    const ml_tensors_info_h info, void *user_data)
+{
+  _ml_service_query_s *mls = (_ml_service_query_s *) user_data;
+  ml_tensors_data_s *data_s = (ml_tensors_data_s *) data;
+  ml_tensors_data_h copied_data = NULL;
+  ml_tensors_data_s *_copied_data_s;
+
+  guint i, count;
+
+  ml_tensors_data_create (info, &copied_data);
+  _copied_data_s = (ml_tensors_data_s *) copied_data;
+
+  ml_tensors_info_get_count (info, &count);
+  for (i = 0; i < count; ++i) {
+    memcpy (_copied_data_s->tensors[i].tensor, data_s->tensors[i].tensor,
+        data_s->tensors[i].size);
+  }
+
+  g_async_queue_push (mls->out_data_queue, copied_data);
+}
+
+/**
+ * @brief Creates query client service handle with given ml-option handle.
+ */
+int
+ml_service_query_create (ml_option_h option, ml_service_h * h)
+{
+  int status = ML_ERROR_NONE;
+
+  gchar *description = NULL;
+
+  ml_option_s *_option;
+  GHashTableIter iter;
+  gchar *key;
+  ml_option_value_s *_option_value;
+
+  GString *tensor_query_client_prop;
+  gchar *prop = NULL;
+
+  ml_service_s *mls;
+
+  _ml_service_query_s *query_s;
+  ml_pipeline_h pipe_h;
+  ml_pipeline_src_h src_h;
+  ml_pipeline_sink_h sink_h;
+  gchar *caps = NULL;
+  guint timeout = 1000U;        /* default 1s timeout */
+
+  check_feature_state (ML_FEATURE_SERVICE);
+  check_feature_state (ML_FEATURE_INFERENCE);
+
+  if (!option) {
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'option' is NULL. It should be a valid ml_option_h, which should be created by ml_option_create().");
+  }
+
+  if (!h) {
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'h' (ml_service_h), is NULL. It should be a valid ml_service_h.");
+  }
+
+  _option = (ml_option_s *) option;
+  g_hash_table_iter_init (&iter, _option->option_table);
+  tensor_query_client_prop = g_string_new (NULL);
+  while (g_hash_table_iter_next (&iter, (gpointer *) & key,
+          (gpointer *) & _option_value)) {
+    if (0 == g_ascii_strcasecmp (key, "host")) {
+      g_string_append_printf (tensor_query_client_prop, " host=%s ",
+          (gchar *) _option_value->value);
+    } else if (0 == g_ascii_strcasecmp (key, "port")) {
+      g_string_append_printf (tensor_query_client_prop, " port=%u ",
+          *((guint *) _option_value->value));
+    } else if (0 == g_ascii_strcasecmp (key, "dest-host")) {
+      g_string_append_printf (tensor_query_client_prop, " dest-host=%s ",
+          (gchar *) _option_value->value);
+    } else if (0 == g_ascii_strcasecmp (key, "dest-port")) {
+      g_string_append_printf (tensor_query_client_prop, " dest-port=%u ",
+          *((guint *) _option_value->value));
+    } else if (0 == g_ascii_strcasecmp (key, "connect-type")) {
+      g_string_append_printf (tensor_query_client_prop, " connect-type=%s ",
+          (gchar *) _option_value->value);
+    } else if (0 == g_ascii_strcasecmp (key, "topic")) {
+      g_string_append_printf (tensor_query_client_prop, " topic=%s ",
+          (gchar *) _option_value->value);
+    } else if (0 == g_ascii_strcasecmp (key, "timeout")) {
+      g_string_append_printf (tensor_query_client_prop, " timeout=%u ",
+          *((guint *) _option_value->value));
+      timeout = *((guint *) _option_value->value);
+    } else if (0 == g_ascii_strcasecmp (key, "caps")) {
+      caps = g_strdup (_option_value->value);
+    } else {
+      _ml_logw ("Ignore unknown key for ml_option: %s", key);
+    }
+  }
+
+  prop = g_string_free (tensor_query_client_prop, FALSE);
+  description =
+      g_strdup_printf
+      ("appsrc name=srcx ! %s ! tensor_query_client %s name=qcx ! tensor_sink name=sinkx async=false sync=false",
+      caps, prop);
+
+  status = ml_pipeline_construct (description, NULL, NULL, &pipe_h);
+  if (status) {
+    _ml_error_report ("failed to construct pipeline");
+    g_free (prop);
+    g_free (description);
+    return status;
+  }
+
+  g_free (prop);
+  g_free (description);
+
+  status = ml_pipeline_start (pipe_h);
+  if (status) {
+    _ml_error_report_return (status, "Failed to start pipeline");
+  }
+
+  status = ml_pipeline_src_get_handle (pipe_h, "srcx", &src_h);
+  if (status) {
+    _ml_error_report ("Failed to get src handle");
+    ml_pipeline_destroy (pipe_h);
+    return status;
+  }
+
+  query_s = g_new0 (_ml_service_query_s, 1);
+  query_s->out_data_queue = g_async_queue_new ();
+  status = ml_pipeline_sink_register (pipe_h, "sinkx",
+      _sink_callback_for_query_client, query_s, &sink_h);
+  if (status) {
+    _ml_error_report ("Failed to register sink handle");
+    ml_pipeline_destroy (pipe_h);
+    ml_pipeline_src_release_handle (src_h);
+    g_free (query_s);
+    return status;
+  }
+
+  query_s->timeout = timeout;
+  query_s->caps = caps;
+  query_s->pipe_h = pipe_h;
+  query_s->src_h = src_h;
+  query_s->sink_h = sink_h;
+  query_s->out_data_queue = g_async_queue_new ();
+
+  mls = g_new0 (ml_service_s, 1);
+  mls->type = ML_SERVICE_TYPE_CLIENT_QUERY;
+  mls->priv = query_s;
+
+  *h = mls;
+
+  return ML_ERROR_NONE;
+}
+
+/**
+ * @brief Requests query client service an output with given input data.
+ */
+int
+ml_service_query_request (ml_service_h h, const ml_tensors_data_h input,
+    ml_tensors_data_h * output)
+{
+  int status = ML_ERROR_NONE;
+  ml_service_s *mls = (ml_service_s *) h;
+  _ml_service_query_s *query;
+
+  check_feature_state (ML_FEATURE_SERVICE);
+  check_feature_state (ML_FEATURE_INFERENCE);
+
+  if (!h)
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'h' is NULL. It should be a valid ml_service_h");
+
+  query = (_ml_service_query_s *) mls->priv;
+
+  status = ml_pipeline_src_input_data (query->src_h, input,
+      ML_PIPELINE_BUF_POLICY_DO_NOT_FREE);
+  if (ML_ERROR_NONE != status) {
+    _ml_error_report_return (status, "Failed to input data");
+  }
+
+  *output = g_async_queue_timeout_pop (query->out_data_queue,
+      query->timeout * G_TIME_SPAN_MILLISECOND);
+  if (NULL == *output) {
+    _ml_error_report_return (ML_ERROR_TIMED_OUT, "timeout!");
+  }
+
+  return status;
+}

--- a/debian/control
+++ b/debian/control
@@ -41,7 +41,7 @@ Description: Development package for Machine Learning Inference API
 Package: ml-service-api
 Architecture: any
 Multi-Arch: same
-Depends: ml-inference-single-api, ${shlibs:Depends}, ${misc:Depends}
+Depends: ml-inference-api, ${shlibs:Depends}, ${misc:Depends}
 Description: Machine Learning Service API
  This package provides native API set to use Machine Learning service.
 

--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -215,7 +215,7 @@ Static library of Tizen Machine Learning Single-shot API.
 %package -n capi-machine-learning-service
 Summary:	Tizen Machine Learning Service API
 Group:		Machine Learning/ML Framework
-Requires:	capi-machine-learning-common = %{version}-%{release}
+Requires:	capi-machine-learning-inference = %{version}-%{release}
 %description -n capi-machine-learning-service
 Tizen Machine Learning Service API.
 

--- a/tests/capi/unittest_capi_service_agent_client.cc
+++ b/tests/capi/unittest_capi_service_agent_client.cc
@@ -473,6 +473,22 @@ TEST_F (MLServiceAgentTest, query_create_00_n)
 }
 
 /**
+ * @brief Test ml_service_query_create with invalid param. caps must be set.
+ */
+TEST_F (MLServiceAgentTest, query_create_01_n)
+{
+  int status;
+  ml_service_h client = NULL;
+  ml_option_h invalid_option = NULL;
+
+  status = ml_option_create (&invalid_option);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  status = ml_service_query_create (invalid_option, &client);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+}
+
+/**
  * @brief Test ml_service_query_request with invalid param.
  */
 TEST_F (MLServiceAgentTest, query_request_00_n)

--- a/tests/capi/unittest_capi_service_agent_client.cc
+++ b/tests/capi/unittest_capi_service_agent_client.cc
@@ -11,6 +11,7 @@
 #include <gtest/gtest.h>
 #include <ml-api-internal.h>
 #include <ml-api-service.h>
+#include <ml-api-inference-pipeline-internal.h>
 
 #include <netinet/tcp.h>
 #include <netinet/in.h>
@@ -315,6 +316,173 @@ TEST_F (MLServiceAgentTest, close_pipeline_00_n)
 }
 
 /**
+ * @brief use case of using service api
+ */
+TEST_F (MLServiceAgentTest, query_client)
+{
+  int status;
+
+  /** Set server pipeline and launch it */
+  const gchar *service_name = "simple_query_server_for_test";
+  int num_buffers = 5;
+  guint server_port = _get_available_port ();
+  gchar *server_pipeline_desc = g_strdup_printf ("tensor_query_serversrc port=%u num-buffers=%d ! other/tensors,num_tensors=1,dimensions=3:4:4:1,types=uint8,format=static,framerate=0/1 ! tensor_query_serversink async=false sync=false", server_port, num_buffers);
+
+  status = ml_service_set_pipeline (service_name, server_pipeline_desc);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  gchar *ret_pipeline;
+  status = ml_service_get_pipeline (service_name, &ret_pipeline);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+  EXPECT_STREQ (server_pipeline_desc, ret_pipeline);
+  g_free (server_pipeline_desc);
+  g_free (ret_pipeline);
+
+  ml_service_h service;
+  ml_pipeline_state_e state;
+  status = ml_service_launch_pipeline (service_name, &service);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  status = ml_service_get_pipeline_state (service, &state);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+  EXPECT_EQ (ML_PIPELINE_STATE_PAUSED, state);
+
+  status = ml_service_start_pipeline (service);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+  status = ml_service_get_pipeline_state (service, &state);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+  EXPECT_EQ (ML_PIPELINE_STATE_PLAYING, state);
+
+  ml_service_h client;
+  ml_option_h query_client_option = NULL;
+
+  status = ml_option_create (&query_client_option);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  gchar *host = g_strdup ("localhost");
+  status = ml_option_set (query_client_option, "host", host, g_free);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  guint client_port = _get_available_port ();
+  status = ml_option_set (query_client_option, "port", &client_port, NULL);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  gchar *dest_host = g_strdup ("localhost");
+  status = ml_option_set (query_client_option, "dest-host", dest_host, g_free);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  guint dest_port = server_port;
+  status = ml_option_set (query_client_option, "dest-port", &dest_port, NULL);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  gchar *connect_type = g_strdup ("TCP");
+  status = ml_option_set (query_client_option, "connect-type", connect_type, g_free);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  guint timeout = 10000U;
+  status = ml_option_set (query_client_option, "timeout", &timeout, NULL);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  gchar *caps_str = g_strdup ("other/tensors,num_tensors=1,format=static,types=uint8,dimensions=3:4:4:1,framerate=0/1");
+  status = ml_option_set (query_client_option, "caps", caps_str, g_free);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  /* set input tensor */
+  ml_tensors_info_h in_info;
+  ml_tensor_dimension in_dim;
+  ml_tensors_data_h input;
+
+  ml_tensors_info_create (&in_info);
+  in_dim[0] = 3;
+  in_dim[1] = 4;
+  in_dim[2] = 4;
+  in_dim[3] = 1;
+
+  ml_tensors_info_set_count (in_info, 1);
+  ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_UINT8);
+  ml_tensors_info_set_tensor_dimension (in_info, 0, in_dim);
+
+  status = ml_service_query_create (query_client_option, &client);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  status = ml_tensors_data_create (in_info, &input);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+  EXPECT_TRUE (NULL != input);
+
+  /* request output tensor with input tensor */
+  for (int i = 0; i < num_buffers; ++i) {
+    ml_tensors_data_h output;
+    uint8_t *received;
+    size_t input_data_size, output_data_size;
+    uint8_t test_data = (uint8_t) i;
+
+    ml_tensors_data_set_tensor_data (input, 0, &test_data, sizeof (uint8_t));
+
+    status = ml_service_query_request (client, input, &output);
+    EXPECT_EQ (ML_ERROR_NONE, status);
+    EXPECT_TRUE (NULL != output);
+
+    status = ml_tensors_info_get_tensor_size (in_info, 0, &input_data_size);
+    EXPECT_EQ (ML_ERROR_NONE, status);
+
+    status = ml_tensors_data_get_tensor_data (output, 0, (void **) &received, &output_data_size);
+    EXPECT_EQ (ML_ERROR_NONE, status);
+    EXPECT_EQ (input_data_size, output_data_size);
+    EXPECT_EQ (test_data, received[0]);
+
+    status = ml_tensors_data_destroy (output);
+    EXPECT_EQ (ML_ERROR_NONE, status);
+  }
+
+  /** destroy client ml_service_h */
+  status = ml_service_destroy (client);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  /** destroy server pipeline */
+  status = ml_service_stop_pipeline (service);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  status = ml_service_get_pipeline_state (service, &state);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+  EXPECT_EQ (ML_PIPELINE_STATE_PAUSED, state);
+
+  status = ml_service_destroy (service);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  /** delete finished service */
+  status = ml_service_delete_pipeline (service_name);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  /** it would fail if get the removed service */
+  status = ml_service_get_pipeline (service_name, &ret_pipeline);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  ml_option_destroy (query_client_option);
+  ml_tensors_data_destroy (input);
+  ml_tensors_info_destroy (in_info);
+}
+
+/**
+ * @brief Test ml_service_query_create with invalid param.
+ */
+TEST_F (MLServiceAgentTest, query_create_00_n)
+{
+  int status;
+  status = ml_service_query_create (NULL, NULL);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+}
+
+/**
+ * @brief Test ml_service_query_request with invalid param.
+ */
+TEST_F (MLServiceAgentTest, query_request_00_n)
+{
+  int status;
+  status = ml_service_query_request (NULL, NULL, NULL);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+}
+
+/**
  * @brief Main gtest
  */
 int
@@ -327,6 +495,8 @@ main (int argc, char **argv)
   } catch (...) {
     g_warning ("catch 'testing::internal::<unnamed>::ClassUniqueToAlwaysTrue'");
   }
+
+  _ml_initialize_gstreamer ();
 
   /* ignore tizen feature status while running the testcases */
   set_feature_state (ML_FEATURE, SUPPORTED);


### PR DESCRIPTION
- Implement two query client APIs: ml_service_query_create and ml_service_query_request
- `ml_service_query_create` creates a query client handle with given ml-option instance. The handle maintains a gstreamer pipeline with description:
"appsrc ! other/tensors,... (caps string given with ml-option) ! tensor_query_client ... (props given with ml-option) ! tensor_sink"
- `ml_service_query_request` takes an input tensor and feed it to the pipeline. An output from tensor_sink is copied to given output handle.

- Implement common feature for server and query client
- Let ml_service_destroy can destroy multiple types of service handle