### PR TITLE
[svace][trivial] Fix svace issues for leak and uninitialize

### DIFF
--- a/c/src/ml-api-inference-pipeline.c
+++ b/c/src/ml-api-inference-pipeline.c
@@ -2155,6 +2155,7 @@ ml_pipeline_switch_get_pad_list (ml_pipeline_switch_h h, char ***list)
       _ml_error_report
           ("Failed to allocate memory for pad list (parameter list). Out of memory?");
       ret = ML_ERROR_OUT_OF_MEMORY;
+      g_list_free_full (dllist, g_free);
       goto unlock_return;
     }
 

--- a/daemon/pipeline-module.cc
+++ b/daemon/pipeline-module.cc
@@ -375,7 +375,7 @@ static gboolean dbus_cb_core_get_state (MachinelearningServicePipeline *obj,
 {
   gint result = 0;
   GstStateChangeReturn sc_ret;
-  GstState state;
+  GstState state = GST_STATE_NULL;
   pipeline_s *p = NULL;
 
   G_LOCK (pipeline_table_lock);


### PR DESCRIPTION
- Free allocated `dllist` when allocation of other list is failed.
- Initialize an uninitialized value.