### PR TITLE
[ml-agent] Add missing header

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -14,6 +14,7 @@
 #include <fcntl.h>
 #include <glib.h>
 #include <gio/gio.h>
+#include <errno.h>
 
 #include "common.h"
 #include "modules.h"


### PR DESCRIPTION
- Add missing header for errno to enable build daemon in ubuntu.

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>