### PR TITLE
[test][service] Add unittests for service APIs

### DIFF
--- a/c/src/ml-api-service-agent-client.c
+++ b/c/src/ml-api-service-agent-client.c
@@ -248,6 +248,10 @@ ml_service_get_pipeline_state (ml_service_h h, ml_pipeline_state_e * state)
     _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
         "The parameter, 'h' is NULL. It should be a valid ml_service_h");
 
+  if (!state)
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'state' is NULL. It should be a valid ml_pipeline_state_e pointer");
+
   mlsp = _get_proxy_new_for_bus_sync ();
   if (!mlsp) {
     _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,

--- a/c/src/ml-api-service-common.c
+++ b/c/src/ml-api-service-common.c
@@ -71,6 +71,10 @@ ml_service_destroy (ml_service_h h)
 
     g_object_unref (mlsp);
 
+    if (ML_ERROR_INVALID_PARAMETER == ret)
+      _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+          "The data of given handle is corrupted. Please check it.");
+
     g_free (server->service_name);
     g_free (server);
   } else if (ML_SERVICE_TYPE_CLIENT_QUERY == mls->type) {


### PR DESCRIPTION
- Add code for handling invalid parameters in ml_service_destroy and ml_service_get_pipeline_state.
- Add negative TCs for launch and get_state APIs
- Add testcases with explicitly corrupted parameters.