### PR TITLE
[Tizen] Generate packages for automation test tools

### DIFF
--- a/c/include/meson.build
+++ b/c/include/meson.build
@@ -1,0 +1,9 @@
+nns_capi_headers = files('nnstreamer.h', 'nnstreamer-single.h', 'ml-api-common.h')
+if get_option('enable-tizen')
+  # header for Tizen internal API
+  nns_capi_headers += files('nnstreamer-tizen-internal.h')
+else
+  subdir('platform')
+endif
+
+nns_capi_service_headers = files('ml-api-service.h')

--- a/c/include/platform/meson.build
+++ b/c/include/platform/meson.build
@@ -1,0 +1,1 @@
+nns_capi_headers += files('tizen_error.h')

--- a/c/meson.build
+++ b/c/meson.build
@@ -1,41 +1,9 @@
 # ML (Machine Learning) C-API
-
 nns_capi_include = []
 nns_capi_include += include_directories('include')
 nns_capi_include += include_directories('src')
 if not get_option('enable-tizen')
   nns_capi_include += include_directories('include/platform')
-endif
-
-nns_capi_common_srcs = []
-nns_capi_single_srcs = []
-nns_capi_pipeline_srcs = []
-
-nns_capi_common_srcs += join_paths(meson.current_source_dir(), 'src', 'ml-api-common.c')
-nns_capi_common_srcs += join_paths(meson.current_source_dir(), 'src', 'ml-api-inference-internal.c')
-nns_capi_single_srcs += join_paths(meson.current_source_dir(), 'src', 'ml-api-inference-single.c')
-nns_capi_pipeline_srcs += join_paths(meson.current_source_dir(), 'src', 'ml-api-inference-pipeline.c')
-
-if get_option('enable-tizen')
-  if get_option('enable-tizen-feature-check')
-    nns_capi_common_srcs += join_paths(meson.current_source_dir(), 'src', 'ml-api-common-tizen-feature-check.c')
-  endif
-
-  if get_option('enable-tizen-privilege-check')
-    nns_capi_common_srcs += join_paths(meson.current_source_dir(), 'src', 'ml-api-inference-tizen-privilege-check.c')
-  endif
-endif
-
-nns_capi_headers = []
-nns_capi_headers += join_paths(meson.current_source_dir(), 'include', 'nnstreamer.h')
-nns_capi_headers += join_paths(meson.current_source_dir(), 'include', 'nnstreamer-single.h')
-nns_capi_headers += join_paths(meson.current_source_dir(), 'include', 'ml-api-common.h')
-
-if get_option('enable-tizen')
-  # header for Tizen internal API
-  nns_capi_headers += join_paths(meson.current_source_dir(), 'include', 'nnstreamer-tizen-internal.h')
-else
-  nns_capi_headers += join_paths(meson.current_source_dir(), 'include', 'platform', 'tizen_error.h')
 endif
 
 
@@ -66,123 +34,8 @@ if (get_option('enable-tizen'))
   nns_capi_common_deps += [dependency('dlog')]
 endif
 
-# Build ML-API Common Lib First.
-nns_capi_common_shared_lib = shared_library ('capi-ml-common',
-  nns_capi_common_srcs,
-  dependencies: nns_capi_common_deps,
-  include_directories: nns_capi_include,
-  install: true,
-  install_dir: api_install_libdir,
-  version: api_version,
-)
-nns_capi_common_static_lib = static_library ('capi-ml-common',
-  nns_capi_common_srcs,
-  dependencies: nns_capi_common_deps,
-  include_directories: nns_capi_include,
-  install: true,
-  install_dir: api_install_libdir,
-)
-nns_capi_common_lib = nns_capi_common_shared_lib
-if get_option('default_library') == 'static'
-  nns_capi_common_lib = nns_capi_common_static_lib
-endif
-nns_capi_common_dep = declare_dependency(link_with: nns_capi_common_lib)
-nns_capi_common_deps += nns_capi_common_dep
-nns_capi_deps += nns_capi_common_dep
-nns_capi_test_deps = nns_capi_deps
-
-if (get_option('enable-tizen'))
-  nns_capi_deps += [dependency('dlog')]
-endif
-
-# Single-shot API.
-nns_capi_single_shared_lib = shared_library ('capi-ml-inference-single',
-  nns_capi_single_srcs,
-  dependencies: [nns_capi_common_deps, gobject_dep],
-  include_directories: nns_capi_include,
-  install: true,
-  install_dir: api_install_libdir,
-  version: api_version,
-)
-
-nns_capi_single_static_lib = static_library ('capi-ml-inference-single',
-  nns_capi_single_srcs,
-  dependencies: [nns_capi_common_deps, gobject_dep],
-  include_directories: nns_capi_include,
-  install: true,
-  install_dir: api_install_libdir,
-)
-
-nns_capi_single_dep = declare_dependency(link_with: nns_capi_single_shared_lib)
-if get_option('default_library') == 'static'
-  nns_capi_single_dep = declare_dependency(link_with: nns_capi_single_static_lib)
-endif
-
-
-# Pipeline API. (including single-shot API)
-nns_capi_shared_lib = shared_library ('capi-nnstreamer',
-  nns_capi_pipeline_srcs,
-  dependencies: [nns_capi_deps, nns_capi_single_dep],
-  include_directories: nns_capi_include,
-  install: true,
-  install_dir: api_install_libdir,
-  version: api_version,
-)
-
-nns_capi_static_lib = static_library ('capi-nnstreamer',
-  nns_capi_pipeline_srcs,
-  dependencies: [nns_capi_deps, nns_capi_single_dep],
-  include_directories: nns_capi_include,
-  install: true,
-  install_dir: api_install_libdir,
-)
-
-nns_capi_lib = nns_capi_shared_lib
-if get_option('default_library') == 'static'
-  nns_capi_lib = nns_capi_static_lib
-endif
-
-nns_capi_dep = declare_dependency(link_with: nns_capi_lib,
-  dependencies: [nns_capi_deps, nns_capi_single_dep],
-  include_directories: nns_capi_include,
-)
-
-# Service API
-if get_option('enable-ml-service')
-  nns_capi_service_srcs = []
-  nns_capi_service_srcs += join_paths(meson.current_source_dir(), 'src', 'ml-api-service-common.c')
-  nns_capi_service_srcs += join_paths(meson.current_source_dir(), 'src', 'ml-api-service-agent-client.c')
-  nns_capi_service_srcs += join_paths(meson.current_source_dir(), 'src', 'ml-api-service-query-client.c')
-
-  nns_capi_service_headers = []
-  nns_capi_service_headers += join_paths(meson.current_source_dir(), 'include', 'ml-api-service.h')
-
-  nns_capi_service_shared_lib = shared_library ('capi-ml-service',
-    nns_capi_service_srcs,
-    dependencies: [nns_capi_dep, ai_service_daemon_deps],
-    include_directories: nns_capi_include,
-    install: true,
-    install_dir: api_install_libdir,
-    version: api_version,
-  )
-
-  nns_capi_service_static_lib = static_library ('capi-ml-service',
-    nns_capi_service_srcs,
-    dependencies: [nns_capi_dep, ai_service_daemon_deps],
-    include_directories: nns_capi_include,
-    install: true,
-    install_dir: api_install_libdir,
-  )
-
-  nns_capi_service_dep = declare_dependency(link_with: nns_capi_service_shared_lib,
-    dependencies: [nns_capi_dep, ai_service_daemon_deps]
-  )
-  if get_option('default_library') == 'static'
-    nns_capi_service_dep = declare_dependency(link_with: nns_capi_service_static_lib,
-    dependencies: [nns_capi_dep, ai_service_daemon_deps]
-  )
-  endif
-endif
+subdir('include')
+subdir('src')
 
 ml_inf_conf = configuration_data()
 ml_inf_conf.merge_from(api_conf)

--- a/c/src/meson.build
+++ b/c/src/meson.build
@@ -1,0 +1,126 @@
+nns_capi_common_srcs = files('ml-api-common.c', 'ml-api-inference-internal.c')
+if get_option('enable-tizen')
+  if get_option('enable-tizen-feature-check')
+    nns_capi_common_srcs += files('ml-api-common-tizen-feature-check.c')
+  endif
+
+  if get_option('enable-tizen-privilege-check')
+    nns_capi_common_srcs += files('ml-api-inference-tizen-privilege-check.c')
+  endif
+endif
+
+nns_capi_single_srcs = files('ml-api-inference-single.c')
+nns_capi_pipeline_srcs = files('ml-api-inference-pipeline.c')
+
+nns_capi_service_srcs = files('ml-api-service-common.c','ml-api-service-agent-client.c', 'ml-api-service-query-client.c')
+
+# Build ML-API Common Lib First.
+nns_capi_common_shared_lib = shared_library ('capi-ml-common',
+  nns_capi_common_srcs,
+  dependencies: nns_capi_common_deps,
+  include_directories: nns_capi_include,
+  install: true,
+  install_dir: api_install_libdir,
+  version: api_version,
+)
+nns_capi_common_static_lib = static_library ('capi-ml-common',
+  nns_capi_common_srcs,
+  dependencies: nns_capi_common_deps,
+  include_directories: nns_capi_include,
+  install: true,
+  install_dir: api_install_libdir,
+)
+nns_capi_common_lib = nns_capi_common_shared_lib
+if get_option('default_library') == 'static'
+  nns_capi_common_lib = nns_capi_common_static_lib
+endif
+nns_capi_common_dep = declare_dependency(link_with: nns_capi_common_lib)
+nns_capi_common_deps += nns_capi_common_dep
+nns_capi_deps += nns_capi_common_dep
+nns_capi_test_deps = nns_capi_deps
+
+if (get_option('enable-tizen'))
+  nns_capi_deps += [dependency('dlog')]
+endif
+
+# Single-shot API.
+nns_capi_single_shared_lib = shared_library ('capi-ml-inference-single',
+  nns_capi_single_srcs,
+  dependencies: [nns_capi_common_deps, gobject_dep],
+  include_directories: nns_capi_include,
+  install: true,
+  install_dir: api_install_libdir,
+  version: api_version,
+)
+
+nns_capi_single_static_lib = static_library ('capi-ml-inference-single',
+  nns_capi_single_srcs,
+  dependencies: [nns_capi_common_deps, gobject_dep],
+  include_directories: nns_capi_include,
+  install: true,
+  install_dir: api_install_libdir,
+)
+
+nns_capi_single_dep = declare_dependency(link_with: nns_capi_single_shared_lib)
+if get_option('default_library') == 'static'
+  nns_capi_single_dep = declare_dependency(link_with: nns_capi_single_static_lib)
+endif
+
+
+# Pipeline API. (including single-shot API)
+nns_capi_shared_lib = shared_library ('capi-nnstreamer',
+  nns_capi_pipeline_srcs,
+  dependencies: [nns_capi_deps, nns_capi_single_dep],
+  include_directories: nns_capi_include,
+  install: true,
+  install_dir: api_install_libdir,
+  version: api_version,
+)
+
+nns_capi_static_lib = static_library ('capi-nnstreamer',
+  nns_capi_pipeline_srcs,
+  dependencies: [nns_capi_deps, nns_capi_single_dep],
+  include_directories: nns_capi_include,
+  install: true,
+  install_dir: api_install_libdir,
+)
+
+nns_capi_lib = nns_capi_shared_lib
+if get_option('default_library') == 'static'
+  nns_capi_lib = nns_capi_static_lib
+endif
+
+nns_capi_dep = declare_dependency(link_with: nns_capi_lib,
+  dependencies: [nns_capi_deps, nns_capi_single_dep],
+  include_directories: nns_capi_include,
+)
+
+
+# Service API
+if get_option('enable-ml-service')
+  nns_capi_service_shared_lib = shared_library ('capi-ml-service',
+    nns_capi_service_srcs,
+    dependencies: [nns_capi_dep, ai_service_daemon_deps],
+    include_directories: nns_capi_include,
+    install: true,
+    install_dir: api_install_libdir,
+    version: api_version,
+  )
+
+  nns_capi_service_static_lib = static_library ('capi-ml-service',
+    nns_capi_service_srcs,
+    dependencies: [nns_capi_dep, ai_service_daemon_deps],
+    include_directories: nns_capi_include,
+    install: true,
+    install_dir: api_install_libdir,
+  )
+
+  nns_capi_service_dep = declare_dependency(link_with: nns_capi_service_shared_lib,
+    dependencies: [nns_capi_dep, ai_service_daemon_deps]
+  )
+  if get_option('default_library') == 'static'
+    nns_capi_service_dep = declare_dependency(link_with: nns_capi_service_static_lib,
+    dependencies: [nns_capi_dep, ai_service_daemon_deps]
+  )
+  endif
+endif

--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -1,22 +1,16 @@
 # Machine Learing Agent
 if get_option('enable-ml-service')
-  nns_ml_agent_srcs = []
   nns_ml_agent_gen_srcs = []
   nns_ml_agent_incs = include_directories('includes')
 
   libsystemd_dep = dependency('libsystemd')
 
-  nns_ml_agent_srcs += join_paths('main.c')
-  nns_ml_agent_srcs += join_paths('modules.c')
-  nns_ml_agent_srcs += join_paths('gdbus-util.c')
-  nns_ml_agent_srcs += join_paths('service-db.cc')
-  nns_ml_agent_srcs += join_paths('pipeline-module.cc')
-  nns_ml_agent_srcs += join_paths('model-dbus-impl.cc')
+  nns_ml_agent_srcs = files('main.c', 'modules.c', 'gdbus-util.c', 'service-db.cc', 'pipeline-module.cc', 'model-dbus-impl.cc')
 
   # Generate GDbus header and code
   gdbus_prog = find_program('gdbus-codegen', required : true)
   gdbus_gen_src = custom_target('gdbus-gencode',
-    input : '../dbus/pipeline-dbus.xml',
+    input : pipeline_dbus_input,
     output : ['pipeline-dbus.h', 'pipeline-dbus.c'],
     command : [gdbus_prog, '--interface-prefix', 'org.tizen',
               '--generate-c-code', 'pipeline-dbus',
@@ -25,7 +19,7 @@ if get_option('enable-ml-service')
   nns_ml_agent_gen_srcs += gdbus_gen_src
 
   gdbus_gen_model_src = custom_target('gdbus-model-gencode',
-    input : '../dbus/model-dbus.xml',
+    input : model_dbus_input,
     output : ['model-dbus.h', 'model-dbus.c'],
     command : [gdbus_prog, '--interface-prefix', 'org.tizen',
               '--generate-c-code', 'model-dbus',
@@ -35,7 +29,7 @@ if get_option('enable-ml-service')
 
   # Enable ML Agent Test
   gdbus_gen_test_src = custom_target('gdbus-gencode-test',
-    input : '../dbus/test-dbus.xml',
+    input : test_dbus_input,
     output : ['test-dbus.h', 'test-dbus.c'],
     command : [gdbus_prog, '--interface-prefix', 'org.tizen',
               '--generate-c-code', 'test-dbus',
@@ -77,7 +71,7 @@ if get_option('enable-ml-service')
   )
 
   # For unit test
-  nns_ml_agent_srcs += join_paths('test-dbus-impl.c')
+  nns_ml_agent_srcs += files('test-dbus-impl.c')
   ai_service_daemon = executable('machine-learning-agent-test',
     nns_ml_agent_srcs,
     dependencies : [ai_service_daemon_deps, gdbus_gen_header_test_dep],

--- a/dbus/meson.build
+++ b/dbus/meson.build
@@ -1,0 +1,3 @@
+pipeline_dbus_input = files('pipeline-dbus.xml')
+model_dbus_input = files('model-dbus.xml')
+test_dbus_input = files('test-dbus.xml')

--- a/meson.build
+++ b/meson.build
@@ -156,6 +156,7 @@ api_conf.set('LIB_INSTALL_DIR', api_install_libdir)
 api_conf.set('INCLUDE_INSTALL_DIR', api_install_includedir)
 
 if get_option('enable-ml-service')
+  subdir('dbus')
   subdir('daemon')
 endif
 

--- a/packaging/run-unittest.sh
+++ b/packaging/run-unittest.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+##
+## @file run-unittest.sh
+## @author Gichan Jang <gichan2.jang@samsung.com>
+## @date 08 Dec 2022
+## @brief Run unit test on automation tool.
+##
+setup() {
+    echo "setup start"
+}
+
+test_main() {
+    echo "test_main start"
+	testlist=$(find /usr/bin/unittest-ml -type f -executable -name "unittest_*")
+    for test in ${testlist}; do
+	  ${test}
+    done
+}
+
+teardown() {
+    echo "teardown start"
+}
+
+main() {
+    setup
+    test_main
+    teardown
+}
+
+main "\$*"

--- a/tests/capi/meson.build
+++ b/tests/capi/meson.build
@@ -1,5 +1,5 @@
 unittest_util_static = static_library('unittest_util',
-  join_paths(meson.current_source_dir(), 'unittest_util.c'),
+  files('unittest_util.c'),
   dependencies: [glib_dep],
   install: false,
 )


### PR DESCRIPTION
 - Generate gcov and unittest package with "gcov 1" option for tizen test
automation tools.
- Costruct paths automatically using `files` not manually. This patch fixes wrong object file names.
Foe example, 
before: _home_abuild_rpmbuild_BUILD_capi-machine-learning-inference-1.8.3_c_src_ml-api-inference-internal.c.o
after: ml-api-inference-internal.c.o

Signed-off-by: gichan <gichan2.jang@samsung.com>