### PR TITLE
[build/android] Add missing arg in build.gradle

### DIFF
--- a/java/android/nnstreamer/build.gradle
+++ b/java/android/nnstreamer/build.gradle
@@ -56,6 +56,7 @@ android {
                           "GSTREAMER_ROOT_ANDROID=$gstRoot",
                           "GSTREAMER_ASSETS_DIR=src/main/assets",
                           "NNSTREAMER_ROOT=$nnsRoot",
+                          "NNSTREAMER_EDGE_ROOT=$nnsEdgeRoot",
                           "ML_API_ROOT=$mlApiRoot"
 
                 targets "nnstreamer-native"


### PR DESCRIPTION
- Add missing arg NNSTREAMER_EDGE_ROOT in build.gradle

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>