### PR TITLE
[Tizen/PPM] deprecated API from 7.5

### DIFF
--- a/c/meson.build
+++ b/c/meson.build
@@ -21,7 +21,9 @@ if (get_option('enable-tizen'))
 
   if get_option('enable-tizen-privilege-check')
     tizen_deps += dependency('dpm')
-    tizen_deps += dependency('capi-privacy-privilege-manager')
+    if ((tizenVmajor < 7) or (tizenVmajor == 7 and tizenVminor < 5))
+      tizen_deps += dependency('capi-privacy-privilege-manager')
+    endif
     tizen_deps += dependency('mm-camcorder')
 
     if (tizenVmajor >= 5)

--- a/c/src/ml-api-inference-tizen-privilege-check.c
+++ b/c/src/ml-api-inference-tizen-privilege-check.c
@@ -15,14 +15,16 @@
 #endif
 
 #include <glib.h>
-
-#include <system_info.h>
-#include <restriction.h>        /* device policy manager */
-#include <privacy_privilege_manager.h>
 #include <nnstreamer.h>
 #include "ml-api-internal.h"
 #include "ml-api-inference-internal.h"
 #include "ml-api-inference-pipeline-internal.h"
+
+#include <system_info.h>
+#include <restriction.h>        /* device policy manager */
+#if TIZENPPM
+#include <privacy_privilege_manager.h>
+#endif
 #if TIZEN5PLUS
 #include <mm_resource_manager.h>
 #endif
@@ -135,6 +137,7 @@ typedef struct
 
 /** The following functions are either not used or supported in Tizen 4 */
 #if TIZEN5PLUS
+#if TIZENPPM
 /**
  * @brief Function to check tizen privilege.
  */
@@ -157,6 +160,9 @@ ml_tizen_check_privilege (const gchar * privilege)
 
   return status;
 }
+#else
+#define ml_tizen_check_privilege(...) (ML_ERROR_NONE)
+#endif /* TIZENPPM */
 
 /**
  * @brief Function to check device policy.
@@ -852,7 +858,7 @@ ml_tizen_mm_convert_element (ml_pipeline_h pipe, gchar ** result,
 {
   return ML_ERROR_NOT_SUPPORTED;
 }
-#endif
+#endif /* TIZEN5PLUS */
 
 /**
  * @brief Releases the resource handle of Tizen.

--- a/c/src/ml-api-internal.h
+++ b/c/src/ml-api-internal.h
@@ -106,6 +106,9 @@ typedef enum {
 #define TIZENMMCONF 1
 #endif
 #endif
+#if ((TIZENVERSION < 7) || (TIZENVERSION == 7 && TIZENVERSIONMINOR < 5))
+#define TIZENPPM 1
+#endif
 
 #else /* __TIZEN__ */
 #define check_feature_state(...)
@@ -118,6 +121,9 @@ typedef enum {
 #ifndef TIZENMMCONF
 #define TIZENMMCONF 0
 #endif /* TIZENMMCONF */
+#ifndef TIZENPPM
+#define TIZENPPM 0
+#endif /* TIZENPPM */
 
 #define EOS_MESSAGE_TIME_LIMIT 100
 #define WAIT_PAUSED_TIME_LIMIT 100

--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -83,12 +83,14 @@ BuildRequires:	meson >= 0.50.0
 %if %{with tizen}
 %if 0%{?enable_tizen_privilege}
 BuildRequires:	pkgconfig(dpm)
+%if (0%{tizen_version_major} < 7) || (0%{?tizen_version_major} == 7 && 0%{?tizen_version_minor} < 5)
 BuildRequires:	pkgconfig(capi-privacy-privilege-manager)
+%endif
 BuildRequires:	pkgconfig(mm-camcorder)
 %if 0%{tizen_version_major} >= 5
 BuildRequires:	pkgconfig(mm-resource-manager)
 %endif
-%endif
+%endif # enable_tizen_privilege
 BuildRequires:	pkgconfig(capi-system-info)
 BuildRequires:	pkgconfig(capi-base-common)
 BuildRequires:	pkgconfig(dlog)

--- a/tests/capi/unittest_capi_inference.cc
+++ b/tests/capi/unittest_capi_inference.cc
@@ -68,6 +68,7 @@ typedef struct {
   } while (0)
 
 #if defined (__TIZEN__)
+#if TIZENPPM
 /**
  * @brief Test NNStreamer pipeline construct with Tizen cam
  * @details Failure case to check permission (camera privilege)
@@ -105,6 +106,7 @@ TEST (nnstreamer_capi_construct_destruct, tizen_cam_fail_02_n)
 
   g_free (pipeline);
 }
+#endif /* TIZENPPM */
 
 /**
  * @brief Test NNStreamer pipeline construct with Tizen internal API.


### PR DESCRIPTION
From Tizen 7.5, privacy-privilege-mgr API will be deprecated.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>