### PR TITLE
[Service/CodeClean] change class name @open sesame 2/8 10:32

### DIFF
--- a/daemon/includes/service-db.hh
+++ b/daemon/includes/service-db.hh
@@ -17,49 +17,27 @@
 #include <iostream>
 
 /**
- * @brief Interface for database operation of ML service
+ * @brief Class for ML-Service Database.
  */
-class IMLServiceDB
+class MLServiceDB
 {
 public:
-  /**
-   * @brief Destroy the IMLServiceDB object
-   */
-  virtual ~IMLServiceDB ()
-  {
-  };
-  virtual void connectDB () = 0;
-  virtual void disconnectDB () = 0;
-  virtual void put (const std::string key, const std::string value) = 0;
-  virtual void get (const std::string name,
-      std::string & out_value) = 0;
-  virtual void del (const std::string name) = 0;
-};
+  MLServiceDB (const MLServiceDB &) = delete;
+  MLServiceDB (MLServiceDB &&) = delete;
+  MLServiceDB & operator= (const MLServiceDB &) = delete;
+  MLServiceDB & operator= (MLServiceDB &&) = delete;
 
-/**
- * @brief Class for implementation of IMLServiceDB
- */
-class MLServiceLevelDB : public IMLServiceDB
-{
-public:
-  MLServiceLevelDB (const MLServiceLevelDB &) = delete;
-  MLServiceLevelDB (MLServiceLevelDB &&) = delete;
-  MLServiceLevelDB & operator= (const MLServiceLevelDB &) = delete;
-  MLServiceLevelDB & operator= (MLServiceLevelDB &&) = delete;
-
-  virtual void connectDB () override;
-  virtual void disconnectDB () override;
-  virtual void put (const std::string name,
-      const std::string value) override;
-  virtual void get (std::string name,
-      std::string & out_value) override;
+  virtual void connectDB ();
+  virtual void disconnectDB ();
+  virtual void put (const std::string name, const std::string value);
+  virtual void get (std::string name, std::string &out_value);
   virtual void del (std::string name);
 
-  static IMLServiceDB & getInstance (void);
+  static MLServiceDB & getInstance (void);
 
 private:
-  MLServiceLevelDB (std::string path);
-  virtual ~MLServiceLevelDB ();
+  MLServiceDB (std::string path);
+  virtual ~MLServiceDB ();
 
   std::string path;
   leveldb_t *db_obj;

--- a/daemon/model-dbus-impl.cc
+++ b/daemon/model-dbus-impl.cc
@@ -56,7 +56,7 @@ dbus_cb_model_set_path (MachinelearningServiceModel *obj,
     const gchar *path)
 {
   int ret = 0;
-  IMLServiceDB &db = MLServiceLevelDB::getInstance ();
+  MLServiceDB &db = MLServiceDB::getInstance ();
 
   try {
     db.connectDB();
@@ -96,7 +96,7 @@ dbus_cb_model_get_path (MachinelearningServiceModel *obj,
 {
   int ret = 0;
   std::string ret_path;
-  IMLServiceDB & db = MLServiceLevelDB::getInstance ();
+  MLServiceDB &db = MLServiceDB::getInstance ();
 
   try {
     db.connectDB ();
@@ -135,7 +135,7 @@ gdbus_cb_model_delete (MachinelearningServiceModel *obj,
     const gchar *name)
 {
   int ret = 0;
-  IMLServiceDB & db = MLServiceLevelDB::getInstance ();
+  MLServiceDB &db = MLServiceDB::getInstance ();
 
   try {
     db.connectDB ();
@@ -218,7 +218,7 @@ probe_model_module (void *data)
   return 0;
 
 out_disconnect:
-  gdbus_disconnect_signal (g_gdbus_instance, 
+  gdbus_disconnect_signal (g_gdbus_instance,
     ARRAY_SIZE (handler_infos), handler_infos);
 
 out:
@@ -239,7 +239,7 @@ init_model_module (void *data) { }
 static void
 exit_model_module (void *data)
 {
-  gdbus_disconnect_signal (g_gdbus_instance, 
+  gdbus_disconnect_signal (g_gdbus_instance,
     ARRAY_SIZE (handler_infos), handler_infos);
   gdbus_put_model_instance (&g_gdbus_instance);
 }

--- a/daemon/pipeline-module.cc
+++ b/daemon/pipeline-module.cc
@@ -75,7 +75,7 @@ static gboolean dbus_cb_core_set_pipeline (MachinelearningServicePipeline *obj,
         GDBusMethodInvocation *invoc, const gchar *service_name, const gchar *pipeline_desc, gpointer user_data)
 {
   gint result = 0;
-  IMLServiceDB &db = MLServiceLevelDB::getInstance ();
+  MLServiceDB &db = MLServiceDB::getInstance ();
 
   try {
     db.connectDB ();
@@ -112,7 +112,7 @@ static gboolean dbus_cb_core_get_pipeline (MachinelearningServicePipeline *obj,
 {
   gint result = 0;
   std::string stored_pipeline_description;
-  IMLServiceDB &db = MLServiceLevelDB::getInstance ();
+  MLServiceDB &db = MLServiceDB::getInstance ();
 
   try {
     db.connectDB ();
@@ -148,7 +148,7 @@ static gboolean dbus_cb_core_delete_pipeline (MachinelearningServicePipeline *ob
         GDBusMethodInvocation *invoc, const gchar *service_name, gpointer user_data)
 {
   gint result = 0;
-  IMLServiceDB &db = MLServiceLevelDB::getInstance ();
+  MLServiceDB &db = MLServiceDB::getInstance ();
 
   try {
     db.connectDB ();
@@ -189,7 +189,7 @@ static gboolean dbus_cb_core_launch_pipeline (MachinelearningServicePipeline *ob
   GstElement *pipeline = NULL;
   pipeline_s *p;
 
-  IMLServiceDB &db = MLServiceLevelDB::getInstance ();
+  MLServiceDB &db = MLServiceDB::getInstance ();
   std::string stored_pipeline_description;
 
   /** get pipeline description from the DB */

--- a/daemon/service-db.cc
+++ b/daemon/service-db.cc
@@ -18,22 +18,22 @@
 #define DB_KEY_PREFIX         MESON_KEY_PREFIX
 
 /**
- * @brief Get an instance of IMLServiceDB, which is created only once at runtime.
- * @return IMLServiceDB& IMLServiceDB instance
+ * @brief Get an instance of MLServiceDB, which is created only once at runtime.
+ * @return MLServiceDB& MLServiceDB instance
  */
-IMLServiceDB & MLServiceLevelDB::getInstance (void)
+MLServiceDB & MLServiceDB::getInstance (void)
 {
-  static MLServiceLevelDB instance (ML_DATABASE_PATH);
+  static MLServiceDB instance (ML_DATABASE_PATH);
 
   return instance;
 }
 
 /**
- * @brief Construct a new MLServiceLevelDB object
+ * @brief Construct a new MLServiceDB object.
  * @param path database path
  */
-MLServiceLevelDB::MLServiceLevelDB (std::string path)
-:  path (path), db_obj (nullptr), db_roptions (nullptr), db_woptions (nullptr)
+MLServiceDB::MLServiceDB (std::string path)
+: path (path), db_obj (nullptr), db_roptions (nullptr), db_woptions (nullptr)
 {
   db_roptions = leveldb_readoptions_create ();
   db_woptions = leveldb_writeoptions_create ();
@@ -41,9 +41,9 @@ MLServiceLevelDB::MLServiceLevelDB (std::string path)
 }
 
 /**
- * @brief Destroy the MLServiceLevelDB object
+ * @brief Destroy the MLServiceDB object.
  */
-MLServiceLevelDB::~MLServiceLevelDB ()
+MLServiceDB::~MLServiceDB ()
 {
   disconnectDB ();
   leveldb_readoptions_destroy (db_roptions);
@@ -51,10 +51,10 @@ MLServiceLevelDB::~MLServiceLevelDB ()
 }
 
 /**
- * @brief Connect the level DB and initialize the private variables.
+ * @brief Connect to ML Service DB and initialize the private variables.
  */
 void
-MLServiceLevelDB::connectDB ()
+MLServiceDB::connectDB ()
 {
   char *err = nullptr;
   leveldb_options_t *db_options;
@@ -77,12 +77,12 @@ MLServiceLevelDB::connectDB ()
 }
 
 /**
- * @brief Disconnect the level DB
+ * @brief Disconnect the DB.
  * @note LevelDB does not support multi-process and it might cause
  * the IO exception when multiple clients write the key simultaneously.
  */
 void
-MLServiceLevelDB::disconnectDB ()
+MLServiceDB::disconnectDB ()
 {
   if (db_obj) {
     leveldb_close (db_obj);
@@ -93,12 +93,11 @@ MLServiceLevelDB::disconnectDB ()
 /**
  * @brief Set the value with the given name.
  * @note If the name already exists, the pipeline description is overwritten.
- * @param[in] name Unique name to retrieve the associated pipeline description.
+ * @param[in] name Unique name to set the associated pipeline description.
  * @param[in] value The pipeline description to be stored.
  */
 void
-MLServiceLevelDB::put (const std::string name,
-    const std::string value)
+MLServiceDB::put (const std::string name, const std::string value)
 {
   char *err = nullptr;
 
@@ -127,8 +126,7 @@ MLServiceLevelDB::put (const std::string name,
  * @param[out] value The pipeline corresponding with the given name.
  */
 void
-MLServiceLevelDB::get (const std::string name,
-    std::string & out_value)
+MLServiceDB::get (const std::string name, std::string & out_value)
 {
   char *err = nullptr;
   char *value = nullptr;
@@ -170,7 +168,7 @@ MLServiceLevelDB::get (const std::string name,
  * @param[in] name The unique name to delete
  */
 void
-MLServiceLevelDB::del (const std::string name)
+MLServiceDB::del (const std::string name)
 {
   char *err = nullptr;
   char *value = nullptr;


### PR DESCRIPTION
Code clean, we will change the database later - level-db to sqlite. Change class name and remove interface to ML-Service DB.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>