### PR TITLE
[Service/PkgMgr] Add skeleton code for the package manager

### DIFF
--- a/daemon/includes/pkg-mgr.h
+++ b/daemon/includes/pkg-mgr.h
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * NNStreamer API / Machine Learning Agent Daemon
+ * Copyright (C) 2023 Samsung Electronics Co., Ltd. All Rights Reserved.
+ */
+
+/**
+ * @file    pkg-mgr.h
+ * @date    16 Feb 2023
+ * @brief   Internal package manager utility header of Machine Learning agent daemon
+ * @see     https://github.com/nnstreamer/api
+ * @author  Sangjung Woo <sangjung.woo@samsung.com>
+ * @bug     No known bugs except for NYI items
+ *
+ * @details
+ *    This provides the Tizen package manager utility functions for the Machine Learning agent daemon.
+ */
+#ifndef __PKG_MGR_H__
+#define __PKG_MGR_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#include <glib.h>
+#include <stdio.h>
+
+#include "log.h"
+#include "package_manager.h"
+
+/**
+ * @brief Initialize the package manager handler for the resource package.
+ * @return @c 0 on success. Otherwise a negative error value.
+ */
+int pkg_mgr_init (void);
+
+/**
+ * @brief Finalize the package manager handler for the resource package.
+ * @return @c 0 on success. Otherwise a negative error value.
+ */
+int pkg_mgr_deinit (void);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* __PKG_MGR_H__ */

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -21,6 +21,7 @@
 #include "gdbus-util.h"
 #include "log.h"
 #include "dbus-interface.h"
+#include "pkg-mgr.h"
 
 static GMainLoop *g_mainloop;
 static gboolean verbose = FALSE;
@@ -108,13 +109,20 @@ main (int argc, char **argv)
 
   init_modules (NULL);
   if (postinit () < 0)
-    _E ("cannot init system\n");
+    _E ("cannot init system");
+
+  /* Register package manager callback */
+  if (pkg_mgr_init () < 0) {
+    _E ("cannot init package manager");
+  }
 
   g_main_loop_run (g_mainloop);
   exit_modules (NULL);
 
   gdbus_put_system_connection ();
   g_main_loop_unref (g_mainloop);
+
+  pkg_mgr_deinit();
 
   return 0;
 }

--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -1,7 +1,8 @@
 # Machine Learing Agent
 if get_option('enable-ml-service')
   nns_ml_agent_incs = include_directories('includes')
-  nns_ml_agent_srcs = files('main.c', 'modules.c', 'gdbus-util.c', 'service-db.cc', 'pipeline-module.cc', 'model-dbus-impl.cc')
+  nns_ml_agent_srcs = files('main.c', 'modules.c', 'gdbus-util.c', 'pkg-mgr.c',
+    'service-db.cc', 'pipeline-module.cc', 'model-dbus-impl.cc')
 
   # Generate GDbus header and code
   gdbus_prog = find_program('gdbus-codegen', required : true)
@@ -44,7 +45,8 @@ if get_option('enable-ml-service')
     gst_dep,
     leveldb_dep,
     sqlite_dep,
-    libsystemd_dep
+    libsystemd_dep,
+    appfw_package_manager_dep
   ]
 
   if (get_option('enable-tizen'))

--- a/daemon/pkg-mgr.c
+++ b/daemon/pkg-mgr.c
@@ -1,0 +1,129 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file    pkg-mgr.c
+ * @date    16 Feb 2023
+ * @brief   NNStreamer/Utilities C-API Wrapper.
+ * @see	    https://github.com/nnstreamer/api
+ * @author  Sangjung Woo <sangjung.woo@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#include "pkg-mgr.h"
+
+static package_manager_h pkg_mgr = NULL;
+
+/**
+ * @brief Callback function to be invoked for resource package.
+ * @param type the package type such as rpk, tpk, wgt, etc.
+ * @param package the name of the package
+ * @param event_type the type of the request such as install, uninstall, update
+ * @param event_state the current state of the requests such as completed, failed
+ * @param progress the progress for the request
+ * @param error the error code when the package manager is failed
+ * @param user_data user data to be passed
+ */
+static void _pkg_mgr_event_cb (const char *type, const char *package,
+  package_manager_event_type_e event_type, package_manager_event_state_e event_state,
+  int progress, package_manager_error_e error, void *user_data)
+{
+  GDir *dir;
+  gchar *pkg_path = NULL;
+  _I ("type: %s, package: %s, event_type: %d, event_state: %d", type, package, event_type, event_state);
+  
+  if (g_strcmp0 (type, "rpk") != 0)
+    return;
+
+  /* TODO Define the path of the model & xml files */
+  pkg_path = g_strdup_printf ("/opt/usr/globalapps/%s/shared/res", package);
+
+  if (event_type == PACKAGE_MANAGER_EVENT_TYPE_INSTALL && event_state == PACKAGE_MANAGER_EVENT_STATE_COMPLETED) {
+    /* TODO Need to register the model into database */
+    if (g_file_test (pkg_path, G_FILE_TEST_IS_DIR)) {
+      _I ("package path: %s", pkg_path);
+      dir = g_dir_open (pkg_path, 0, NULL);
+      if (dir) {
+        const gchar *file_name;
+        while ((file_name = g_dir_read_name (dir))) {
+          _I ("- file: %s", file_name);
+        }
+        g_dir_close (dir);
+      }
+    }
+  } else if (event_type == PACKAGE_MANAGER_EVENT_TYPE_UNINSTALL && event_state == PACKAGE_MANAGER_EVENT_STATE_STARTED) {
+    /* TODO Need to invalid model */
+    if (g_file_test (pkg_path, G_FILE_TEST_IS_DIR)) {
+      _I ("package path: %s", pkg_path);
+      dir = g_dir_open (pkg_path, 0, NULL);
+      if (dir) {
+        const gchar *file_name;
+        while ((file_name = g_dir_read_name (dir))) {
+          _I ("- file: %s", file_name);
+        }
+        g_dir_close (dir);
+      }
+    }
+  } else if (event_type == PACKAGE_MANAGER_EVENT_TYPE_UPDATE && event_state == PACKAGE_MANAGER_EVENT_STATE_COMPLETED) {
+    /* TODO Need to update database */
+    if (g_file_test (pkg_path, G_FILE_TEST_IS_DIR)) {
+      _I ("package path: %s", pkg_path);
+      dir = g_dir_open (pkg_path, 0, NULL);
+      if (dir) {
+        const gchar *file_name;
+        while ((file_name = g_dir_read_name (dir))) {
+          _I ("- file: %s", file_name);
+        }
+        g_dir_close (dir);
+      }
+    }
+  } else {
+    /* Do not consider other events: do nothing */
+  }
+
+  g_free (pkg_path);
+  pkg_path = NULL;
+}
+
+/**
+ * @brief Initialize the package manager handler for the resource package.
+ */
+int pkg_mgr_init(void)
+{
+  int ret = 0;
+
+  ret = package_manager_create (&pkg_mgr);
+  if (ret != PACKAGE_MANAGER_ERROR_NONE) {
+      _E ("package_manager_create() failed: %d", ret);
+      return -1;
+  }
+
+  /* Monitoring install, uninstall and upgrade events of the resource package. */
+  ret = package_manager_set_event_status (pkg_mgr,
+    PACKAGE_MANAGER_STATUS_TYPE_INSTALL|PACKAGE_MANAGER_STATUS_TYPE_UNINSTALL|PACKAGE_MANAGER_STATUS_TYPE_UPGRADE);
+  if (ret != PACKAGE_MANAGER_ERROR_NONE) {
+    _E ("package_manager_set_event_status() failed: %d", ret);
+    return -1;
+  }
+
+  ret = package_manager_set_event_cb (pkg_mgr, _pkg_mgr_event_cb, NULL);
+  if (ret != PACKAGE_MANAGER_ERROR_NONE) {
+    _E ("package_manager_set_event_cb() failed: %d", ret);
+    return -1;
+  }
+  return 0;
+}
+
+/**
+ * @brief Finalize the package manager handler for the resource package.
+ */
+int pkg_mgr_deinit(void)
+{
+  int ret = 0;
+  ret = package_manager_destroy (pkg_mgr);
+  if (ret != PACKAGE_MANAGER_ERROR_NONE) {
+    _E ("package_manager_destroy() failed: %d", ret);
+    return -1;
+  }
+  return 0;
+}

--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,7 @@ nnstreamer_dep = dependency('nnstreamer')
 if get_option('enable-ml-service')
   libsystemd_dep = dependency('libsystemd')
   sqlite_dep = dependency('sqlite3')
+  appfw_package_manager_dep = dependency('capi-appfw-package-manager')
 
   leveldb_dep = dependency('leveldb', required: false)
   if (not leveldb_dep.found())

--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -159,6 +159,7 @@ BuildRequires:  pkgconfig(libsystemd)
 BuildRequires:  pkgconfig(leveldb)
 BuildRequires:  pkgconfig(sqlite3)
 BuildRequires:  dbus
+BuildRequires:  pkgconfig(capi-appfw-package-manager)
 %endif
 
 %description


### PR DESCRIPTION
To get the event from the package manager, the callback function should be registered in ML Agent. This patch adds the skeleton code to get the install, uninstall, and upgrade event of the resource package from the package manager. Related work such as update the database of ML Agent should be needed.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

### Basic Operation
```bash
root:~> /usr/bin/machine-learning-agent 
init gstreamer

# Package Uninstall: event_type: 1 / event_state: 0 (STARTED) -> 2 (COMPLETED)
type: rpk, package: org.tizen.mlmodel, event_type: 1, event_state: 0
package path: /opt/usr/globalapps/org.tizen.mlmodel/shared/res
- file: mobilenet_v2_1.0_224.tflite
- file: model_description.xml
type: rpk, package: org.tizen.mlmodel, event_type: 1, event_state: 2

# Package Install: event_type: 0
type: rpk, package: org.tizen.mlmodel, event_type: 0, event_state: 0
type: rpk, package: org.tizen.mlmodel, event_type: 0, event_state: 2
package path: /opt/usr/globalapps/org.tizen.mlmodel/shared/res
- file: mobilenet_v2_1.0_224.tflite
- file: model_description.xml

# Package Update: event_type: 2
type: rpk, package: org.tizen.mlmodel, event_type: 2, event_state: 0
type: rpk, package: org.tizen.mlmodel, event_type: 2, event_state: 2
package path: /opt/usr/globalapps/org.tizen.mlmodel/shared/res
- file: mobilenet_v2_1.0_224.tflite
- file: model_description.xml

```