### PR TITLE
[agent][DB] Fix "delete_pipeline" to check the number of changed rows

### DIFF
--- a/daemon/service-db.cc
+++ b/daemon/service-db.cc
@@ -268,7 +268,15 @@ MLServiceDB::delete_pipeline (const std::string name)
   if (rc != SQLITE_OK) {
     g_warning ("Failed to delete pipeline description with name %s: %s (%d)", name.c_str (), errmsg, rc);
     sqlite3_clear_errmsg (errmsg);
-    throw std::invalid_argument ("Failed to delete pipeline description.");
+    throw std::runtime_error ("Failed to delete pipeline description.");
+  }
+
+  /* count the number of rows modified */
+  rc = sqlite3_changes (_db);
+  if (rc == 0) {
+    g_warning ("No pipeline description with name %s: %s (%d)", name.c_str (), errmsg, rc);
+    sqlite3_clear_errmsg (errmsg);
+    throw std::invalid_argument ("There is no pipeline description with the given name.");
   }
 }
 

--- a/tests/capi/unittest_capi_service_agent_client.cc
+++ b/tests/capi/unittest_capi_service_agent_client.cc
@@ -336,6 +336,35 @@ TEST_F (MLServiceAgentTest, delete_pipeline_00_n)
 }
 
 /**
+ * @brief Test ml_service_delete_pipeline with invalid param.
+ */
+TEST_F (MLServiceAgentTest, delete_pipeline_01_n)
+{
+  int status;
+  status = ml_service_set_pipeline ("some key", "videotestsrc ! fakesink");
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  status = ml_service_delete_pipeline ("invalid key");
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+}
+
+/**
+ * @brief Test ml_service_delete_pipeline with invalid param.
+ */
+TEST_F (MLServiceAgentTest, delete_pipeline_02_n)
+{
+  int status;
+  status = ml_service_set_pipeline ("some key", "videotestsrc ! fakesink");
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  status = ml_service_delete_pipeline ("some key");
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  status = ml_service_delete_pipeline ("some key");
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+}
+
+/**
  * @brief Test ml_service_launch_pipeline with invalid param.
  */
 TEST_F (MLServiceAgentTest, launch_pipeline_00_n)


### PR DESCRIPTION
- Check the number of changed rows after the DELETE query
- Add some negative testcases.

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>