### PR TITLE
[Service/Model][Daemon] Implement APIs for the ml-service-model and daemon-side methods

### DIFF
--- a/c/src/meson.build
+++ b/c/src/meson.build
@@ -102,7 +102,7 @@ nns_capi_dep = declare_dependency(link_with: nns_capi_lib,
 if get_option('enable-ml-service')
   nns_capi_service_shared_lib = shared_library ('capi-ml-service',
     nns_capi_service_srcs,
-    dependencies: [nns_capi_dep, ai_service_daemon_deps],
+    dependencies: [nns_capi_dep, ai_service_daemon_deps, json_glib_dep],
     include_directories: nns_capi_include,
     install: true,
     install_dir: api_install_libdir,
@@ -111,7 +111,7 @@ if get_option('enable-ml-service')
 
   nns_capi_service_static_lib = static_library ('capi-ml-service',
     nns_capi_service_srcs,
-    dependencies: [nns_capi_dep, ai_service_daemon_deps],
+    dependencies: [nns_capi_dep, ai_service_daemon_deps, json_glib_dep],
     include_directories: nns_capi_include,
     install: true,
     install_dir: api_install_libdir,

--- a/c/src/ml-api-common.c
+++ b/c/src/ml-api-common.c
@@ -1325,3 +1325,41 @@ ml_option_set (ml_option_h option, const char *key, void *value,
 
   return ML_ERROR_NONE;
 }
+
+/**
+ * @brief Gets a value of key in ml_option instance.
+ */
+int
+ml_option_get (ml_option_h option, const char *key, void **value)
+{
+  ml_option_s *_option;
+  ml_option_value_s *_option_value;
+
+  check_feature_state (ML_FEATURE);
+
+  if (!option) {
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'option' is NULL. It should be a valid ml_option_h, which should be created by ml_option_create().");
+  }
+
+  if (!key) {
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'key' is NULL. It should be a valid const char*");
+  }
+
+  if (!value) {
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'value' is NULL. It should be a valid void**");
+  }
+
+  _option = (ml_option_s *) option;
+  _option_value = (ml_option_value_s *)
+      g_hash_table_lookup (_option->option_table, key);
+  if (_option_value == NULL)
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The key - %s - is not found in the option table.", key);
+
+  *value = _option_value->value;
+
+  return ML_ERROR_NONE;
+}

--- a/daemon/includes/dbus-interface.h
+++ b/daemon/includes/dbus-interface.h
@@ -40,10 +40,12 @@
 #define DBUS_MODEL_INTERFACE            "org.tizen.machinelearning.service.model"
 #define DBUS_MODEL_PATH                 "/Org/Tizen/MachineLearning/Service/Model"
 
-#define DBUS_MODEL_I_HANDLER_SET_PATH     "handle-set-path"
-#define DBUS_MODEL_I_HANDLER_GET_PATH     "handle-get-path"
-#define DBUS_MODEL_I_HANDLER_DELETE       "handle-delete"
-
-#define DBUS_MODEL_I_HANDLER_REGISTER     "handle-register"
+#define DBUS_MODEL_I_HANDLER_REGISTER           "handle-register"
+#define DBUS_MODEL_I_HANDLER_UPDATE_DESCRIPTION "handle-update-description"
+#define DBUS_MODEL_I_HANDLER_ACTIVATE           "handle-activate"
+#define DBUS_MODEL_I_HANDLER_GET                "handle-get"
+#define DBUS_MODEL_I_HANDLER_GET_ACTIVATED      "handle-get-activated"
+#define DBUS_MODEL_I_HANDLER_GET_ALL            "handle-get-all"
+#define DBUS_MODEL_I_HANDLER_DELETE             "handle-delete"
 
 #endif /* __GDBUS_INTERFACE_H__ */

--- a/daemon/includes/service-db.hh
+++ b/daemon/includes/service-db.hh
@@ -33,9 +33,11 @@ public:
   virtual void get_pipeline (const std::string name, std::string &description);
   virtual void delete_pipeline (const std::string name);
   /** @todo update methods to handle nn model */
-  virtual void set_model (const std::string name, const std::string model);
-  virtual void get_model (const std::string name, std::string &model);
-  virtual void delete_model (const std::string name);
+  virtual void set_model (const std::string name, const std::string model, const bool is_active, const std::string description, guint *version);
+  virtual void update_model_description (const std::string name, const guint version, const std::string description);
+  virtual void activate_model (const std::string name, const guint version);
+  virtual void get_model (const std::string name, std::string &model, const gint version);
+  virtual void delete_model (const std::string name, const guint version);
 
   static MLServiceDB & getInstance (void);
 

--- a/daemon/model-dbus-impl.cc
+++ b/daemon/model-dbus-impl.cc
@@ -47,23 +47,25 @@ gdbus_put_model_instance (MachinelearningServiceModel ** instance)
  * @param invoc Method invocation handle.
  * @param name The name of target model.
  * @param path The file path of target.
+ * @param is_active The active status of target model.
+ * @param description The description of target model.
  * @return @c TRUE if the request is handled. FALSE if the service is not available.
  */
 static gboolean
 gdbus_cb_model_register (MachinelearningServiceModel *obj,
     GDBusMethodInvocation *invoc,
     const gchar *name,
-    const gchar *path)
+    const gchar *path,
+    const bool is_active,
+    const gchar *description)
 {
   int ret = 0;
   guint version = 0U;
   MLServiceDB & db = MLServiceDB::getInstance ();
 
   try {
-    /**
-     * @todo register the given model to the DB, and get the version of the model.
-    */
-   version = 1U;
+    db.connectDB ();
+    db.set_model (name, path, is_active, description, &version);
   } catch (...) {
     g_critical ("DB error occurred. Failed to register the model: %s", name);
     ret = -EIO;
@@ -76,6 +78,218 @@ gdbus_cb_model_register (MachinelearningServiceModel *obj,
 }
 
 /**
+ * @brief The callback function of update description method
+ *
+ * @param obj Proxy instance.
+ * @param invoc Method invocation handle.
+ * @param name The name of target model.
+ * @param version The version of target model.
+ * @param description The description of target model.
+ * @return @c TRUE if the request is handled. FALSE if the service is not available.
+ */
+static gboolean
+gdbus_cb_model_update_description (MachinelearningServiceModel *obj,
+    GDBusMethodInvocation *invoc,
+    const gchar *name,
+    const guint version,
+    const gchar *description)
+{
+  int ret = 0;
+  MLServiceDB & db = MLServiceDB::getInstance ();
+
+  try {
+    db.connectDB ();
+    db.update_model_description (name, version, description);
+  } catch (const std::invalid_argument &e) {
+    g_critical ("There is no such model");
+    ret = -EINVAL;
+  } catch (...) {
+    g_critical ("DB error occurred. Failed to update the model description: %s", name);
+    ret = -EIO;
+  }
+
+  db.disconnectDB ();
+  machinelearning_service_model_complete_update_description (obj, invoc, ret);
+
+  return TRUE;
+}
+
+/**
+ * @brief The callback function of activate method
+ *
+ * @param obj Proxy instance.
+ * @param invoc Method invocation handle.
+ * @param name The name of target model.
+ * @param version The version of target model.
+ * @return @c TRUE if the request is handled. FALSE if the service is not available.
+ */
+static gboolean
+gdbus_cb_model_activate (MachinelearningServiceModel *obj,
+    GDBusMethodInvocation *invoc,
+    const gchar *name,
+    const guint version)
+{
+  int ret = 0;
+  MLServiceDB & db = MLServiceDB::getInstance ();
+
+  try {
+    db.connectDB ();
+    db.activate_model (name, version);
+  } catch (const std::invalid_argument &e) {
+    g_critical ("There is no such model");
+    ret = -EINVAL;
+  } catch (...) {
+    g_critical ("DB error occurred. Failed to activate the model: %s", name);
+    ret = -EIO;
+  }
+
+  db.disconnectDB ();
+  machinelearning_service_model_complete_activate (obj, invoc, ret);
+
+  return TRUE;
+}
+
+/**
+ * @brief The callback function of get method
+ *
+ * @param obj Proxy instance.
+ * @param invoc Method invocation handle.
+ * @param name The name of target model.
+ * @return @c TRUE if the request is handled. FALSE if the service is not available.
+ */
+static gboolean
+gdbus_cb_model_get (MachinelearningServiceModel *obj,
+    GDBusMethodInvocation *invoc,
+    const gchar *name,
+    const guint version)
+{
+  int ret = 0;
+  std::string model_info;
+  MLServiceDB & db = MLServiceDB::getInstance ();
+
+  try {
+    db.connectDB ();
+    db.get_model (name, model_info, version);
+  } catch (const std::invalid_argument &e) {
+    g_critical ("There is no active model");
+    ret = -EINVAL;
+  } catch (...) {
+    g_critical ("DB error occurred. Failed to get the active model: %s", name);
+    ret = -EIO;
+  }
+
+  db.disconnectDB ();
+  machinelearning_service_model_complete_get_activated (obj, invoc, model_info.c_str (), ret);
+
+  return TRUE;
+}
+
+/**
+ * @brief The callback function of get activated method
+ *
+ * @param obj Proxy instance.
+ * @param invoc Method invocation handle.
+ * @param name The name of target model.
+ * @return @c TRUE if the request is handled. FALSE if the service is not available.
+ */
+static gboolean
+gdbus_cb_model_get_activated (MachinelearningServiceModel *obj,
+    GDBusMethodInvocation *invoc,
+    const gchar *name)
+{
+  int ret = 0;
+  std::string model_info;
+  MLServiceDB & db = MLServiceDB::getInstance ();
+
+  try {
+    db.connectDB ();
+    db.get_model (name, model_info, -1);
+  } catch (const std::invalid_argument &e) {
+    g_critical ("There is no active model");
+    ret = -EINVAL;
+  } catch (...) {
+    g_critical ("DB error occurred. Failed to get the active model: %s", name);
+    ret = -EIO;
+  }
+
+  db.disconnectDB ();
+  machinelearning_service_model_complete_get_activated (obj, invoc, model_info.c_str (), ret);
+
+  return TRUE;
+}
+
+/**
+ * @brief The callback function of get all method
+ *
+ * @param obj Proxy instance.
+ * @param invoc Method invocation handle.
+ * @param name The name of target model.
+ * @return @c TRUE if the request is handled. FALSE if the service is not available.
+ */
+static gboolean
+gdbus_cb_model_get_all (MachinelearningServiceModel *obj,
+    GDBusMethodInvocation *invoc,
+    const gchar *name
+    )
+{
+  int ret = 0;
+  MLServiceDB & db = MLServiceDB::getInstance ();
+  std::string all_model_list;
+
+  try {
+    db.connectDB ();
+    db.get_model (name, all_model_list, 0);
+  } catch (const std::invalid_argument &e) {
+    g_critical ("There is no such model");
+    ret = -EINVAL;
+  } catch (...) {
+    g_critical ("DB error occurred. Failed to get all the models");
+    ret = -EIO;
+  }
+
+  db.disconnectDB ();
+
+  machinelearning_service_model_complete_get (obj, invoc, all_model_list.c_str (), ret);
+
+  return TRUE;
+}
+
+/**
+ * @brief The callback function of delete method
+ *
+ * @param obj Proxy instance.
+ * @param invoc Method invocation handle.
+ * @param name The name of target model.
+ * @param version The version of target model.
+ * @return @c TRUE if the request is handled. FALSE if the service is not available.
+ */
+static gboolean
+gdbus_cb_model_delete (MachinelearningServiceModel *obj,
+    GDBusMethodInvocation *invoc,
+    const gchar *name,
+    const guint version)
+{
+  int ret = 0;
+  MLServiceDB & db = MLServiceDB::getInstance ();
+
+  try {
+    db.connectDB ();
+    db.delete_model (name, version);
+  } catch (const std::invalid_argument &e) {
+    g_critical ("There is no such model");
+    ret = -EINVAL;
+  } catch (...) {
+    g_critical ("DB error occurred. Failed to delete the model: %s", name);
+    ret = -EIO;
+  }
+
+  db.disconnectDB ();
+  machinelearning_service_model_complete_delete (obj, invoc, ret);
+
+  return TRUE;
+}
+
+/**
  * @brief Event handler list of Model interface
  */
 static struct gdbus_signal_info handler_infos[] = {
@@ -83,8 +297,38 @@ static struct gdbus_signal_info handler_infos[] = {
     .signal_name = DBUS_MODEL_I_HANDLER_REGISTER,
     .cb = G_CALLBACK (gdbus_cb_model_register),
     .cb_data = NULL,
-    .handler_id = 0,
-  },
+    .handler_id = 1U,
+  }, {
+    .signal_name = DBUS_MODEL_I_HANDLER_UPDATE_DESCRIPTION,
+    .cb = G_CALLBACK (gdbus_cb_model_update_description),
+    .cb_data = NULL,
+    .handler_id = 2U,
+  }, {
+    .signal_name = DBUS_MODEL_I_HANDLER_ACTIVATE,
+    .cb = G_CALLBACK (gdbus_cb_model_activate),
+    .cb_data = NULL,
+    .handler_id = 3U,
+  }, {
+    .signal_name = DBUS_MODEL_I_HANDLER_GET,
+    .cb = G_CALLBACK (gdbus_cb_model_get),
+    .cb_data = NULL,
+    .handler_id = 4U,
+  }, {
+    .signal_name = DBUS_MODEL_I_HANDLER_GET_ACTIVATED,
+    .cb = G_CALLBACK (gdbus_cb_model_get_activated),
+    .cb_data = NULL,
+    .handler_id = 5U,
+  }, {
+    .signal_name = DBUS_MODEL_I_HANDLER_GET_ALL,
+    .cb = G_CALLBACK (gdbus_cb_model_get_all),
+    .cb_data = NULL,
+    .handler_id = 6U,
+  }, {
+    .signal_name = DBUS_MODEL_I_HANDLER_DELETE,
+    .cb = G_CALLBACK (gdbus_cb_model_delete),
+    .cb_data = NULL,
+    .handler_id = 7U,
+  }
 };
 
 /**

--- a/dbus/model-dbus.xml
+++ b/dbus/model-dbus.xml
@@ -5,41 +5,47 @@
     <method name="Register">
       <arg type="s" name="name" direction="in" />
       <arg type="s" name="path" direction="in" />
+      <arg type="b" name="active" direction="in" />
+      <arg type="s" name="description" direction="in" />
       <arg type="u" name="version" direction="out" />
       <arg type="i" name="result" direction="out" />
     </method>
-    <!-- Update the given model -->
-    <method name="Update">
-      <arg type="s" name="name" direction="in" />
-      <arg type="s" name="path" direction="in" />
-      <arg type="b" name="stable" direction="in" />
-      <arg type="u" name="version" direction="out" />
-      <arg type="i" name="result" direction="out" />
-    </method>
-    <!-- Rollback the given model -->
-    <method name="Rollback">
-      <arg type="s" name="name" direction="in" />
-      <arg type="u" name="version" direction="out" />
-      <arg type="i" name="result" direction="out" />
-    </method>
-    <!-- Set stable the given model -->
-    <method name="SetInference">
+    <!-- Update the model description -->
+    <method name="UpdateDescription">
       <arg type="s" name="name" direction="in" />
       <arg type="u" name="version" direction="in" />
-      <arg type="b" name="stable" direction="in" />
+      <arg type="s" name="description" direction="in" />
       <arg type="i" name="result" direction="out" />
     </method>
-    <!-- Get the latest stable model -->
-    <method name="GetLatest">
+    <!-- Activate the model -->
+    <method name="Activate">
       <arg type="s" name="name" direction="in" />
-      <arg type="s" name="path" direction="out" />
+      <arg type="u" name="version" direction="in" />
       <arg type="i" name="result" direction="out" />
     </method>
     <!-- Get the model of given version -->
     <method name="Get">
       <arg type="s" name="name" direction="in" />
       <arg type="u" name="version" direction="in" />
-      <arg type="s" name="path" direction="out" />
+      <arg type="s" name="info" direction="out" />
+      <arg type="i" name="result" direction="out" />
+    </method>
+    <!-- Get the activated model -->
+    <method name="GetActivated">
+      <arg type="s" name="name" direction="in" />
+      <arg type="s" name="info" direction="out" />
+      <arg type="i" name="result" direction="out" />
+    </method>
+    <!-- Get list of models -->
+    <method name="GetAll">
+      <arg type="s" name="name" direction="in" />
+      <arg type="s" name="info_list" direction="out" />
+      <arg type="i" name="result" direction="out" />
+    </method>
+    <!-- Delete model -->
+    <method name="Delete">
+      <arg type="s" name="name" direction="in" />
+      <arg type="u" name="version" direction="in" />
       <arg type="i" name="result" direction="out" />
     </method>
   </interface>

--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,7 @@ nnstreamer_dep = dependency('nnstreamer')
 if get_option('enable-ml-service')
   libsystemd_dep = dependency('libsystemd')
   sqlite_dep = dependency('sqlite3')
+  json_glib_dep = dependency('json-glib-1.0')
 
   if get_option('enable-tizen')
     appfw_package_manager_dep = dependency('capi-appfw-package-manager')

--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -156,6 +156,7 @@ BuildConflicts:	libarmcl-release
 %if 0%{?enable_ml_service}
 BuildRequires:  pkgconfig(libsystemd)
 BuildRequires:  pkgconfig(sqlite3)
+BuildRequires:  pkgconfig(json-glib-1.0)
 BuildRequires:  dbus
 BuildRequires:  pkgconfig(capi-appfw-package-manager)
 %endif

--- a/tests/capi/unittest_capi_service_agent_client.cc
+++ b/tests/capi/unittest_capi_service_agent_client.cc
@@ -719,12 +719,99 @@ TEST_F (MLServiceAgentTest, query_request_00_n)
 }
 
 /**
- * @brief Test the usecase of ml_servive for model. TBU.
+ * @brief Test ml_service_model_register with invalid param.
  */
-TEST_F (MLServiceAgentTest, model_00)
+TEST_F (MLServiceAgentTest, model_register_00_n)
 {
   int status;
-  const gchar *key = "mobilenet_v1";
+
+  const gchar *name = "some_model_name";
+  const gchar *path = "/valid/path/to/some/model.tflite";
+
+  const bool is_active = true;
+  const gchar *desc = "some valid description";
+  guint version;
+
+  status = ml_service_model_register (NULL, path, is_active, desc, &version);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_service_model_register (name, NULL, is_active, desc, &version);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_service_model_register (name, path, is_active, desc, NULL);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+}
+
+/**
+ * @brief Test ml_service_model_update_description with invalid param.
+ */
+TEST_F (MLServiceAgentTest, model_update_description_00_n)
+{
+  int status;
+
+  const gchar *name = "some_model_name";
+  const gchar *desc = "some valid description";
+  guint version = 12345U;
+
+  status = ml_service_model_update_description (NULL, version, desc);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_service_model_update_description (name, 0U, desc);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_service_model_update_description (name, version, NULL);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_service_model_update_description (name, version, desc);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+}
+
+/**
+ * @brief Test ml_service_model_activate with invalid param.
+ */
+TEST_F (MLServiceAgentTest, model_activate_00_n)
+{
+  int status;
+  status = ml_service_model_activate (NULL, 0U);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_service_model_activate ("some_model_name", 0U);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_service_model_activate ("some_model_name", 12345U);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+}
+
+/**
+ * @brief Test ml_service_model_get with invalid param.
+ */
+TEST_F (MLServiceAgentTest, model_get_00_n)
+{
+  int status;
+
+  const gchar *name = "some_model_name";
+  guint version = 12345U;
+  ml_option_h info_h;
+
+  status = ml_service_model_get (NULL, version, &info_h);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_service_model_get (name, version, NULL);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_service_model_get (name, version, &info_h);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+}
+
+/**
+ * @brief Test ml_service_model_get with invalid param.
+ */
+TEST_F (MLServiceAgentTest, model_get_01_n)
+{
+  int status;
+
+  const gchar *model_name = "some_invalid_model_name";
+
   const gchar *root_path = g_getenv ("MLAPI_SOURCE_ROOT_PATH");
   gchar *test_model;
   unsigned int version;
@@ -734,14 +821,317 @@ TEST_F (MLServiceAgentTest, model_00)
     return;
 
   test_model = g_build_filename (root_path, "tests", "test_models", "models",
+      "some_invalid_model_name", NULL);
+  ASSERT_FALSE (g_file_test (test_model, G_FILE_TEST_EXISTS));
+
+  status = ml_service_model_delete (model_name, 0U);
+  EXPECT_TRUE (status == ML_ERROR_NONE || status == ML_ERROR_INVALID_PARAMETER);
+
+  status = ml_service_model_register (model_name, test_model, true, NULL, &version);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  ml_option_h info_h;
+  status = ml_service_model_get (model_name, 987654321U, &info_h);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_service_model_delete (model_name, version);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  g_free (test_model);
+}
+
+/**
+ * @brief Test ml_service_model_get_activated with invalid param.
+ */
+TEST_F (MLServiceAgentTest, model_get_activated_00_n)
+{
+  int status;
+
+  const gchar *name = "some_model_name";
+  ml_option_h info_h;
+
+  status = ml_service_model_get_activated (NULL, &info_h);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_service_model_get_activated (name, NULL);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_service_model_get_activated (name, &info_h);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+}
+
+/**
+ * @brief Test ml_service_model_get_all with invalid param.
+ */
+TEST_F (MLServiceAgentTest, model_get_all_00_n)
+{
+  int status;
+
+  const gchar *name = "some_model_name";
+  ml_option_h *info_list_h;
+  guint list_size;
+
+  status = ml_service_model_get_all (NULL, &info_list_h, &list_size);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_service_model_get_all (name, NULL, &list_size);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_service_model_get_all (name, &info_list_h, NULL);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_service_model_get_all (name, &info_list_h, &list_size);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+}
+
+/**
+ * @brief Test ml_service_model_delete with invalid param.
+ */
+TEST_F (MLServiceAgentTest, model_delete_00_n)
+{
+  int status;
+
+  const gchar *name = "some_model_name";
+  guint version = 12345U;
+
+  status = ml_service_model_delete (NULL, version);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_service_model_delete (name, version);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_service_model_delete (name, 0U);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+}
+
+/**
+ * @brief Test ml_option_get with invalid param.
+ */
+TEST_F (MLServiceAgentTest, model_ml_option_get_00_n)
+{
+  int status;
+
+  const gchar *key = "some_key";
+  ml_option_h info_h;
+  gchar *value;
+
+  status = ml_option_create (&info_h);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  status = ml_option_get (NULL, key, (void **) &value);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_option_get (info_h, NULL, (void **) &value);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_option_get (info_h, key, NULL);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_option_get (info_h, key, (void **) &value);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  g_free (info_h);
+}
+
+/**
+ * @brief Test ml_option_get with invalid param.
+ */
+TEST_F (MLServiceAgentTest, model_ml_option_get_01_n)
+{
+  int status;
+
+  const gchar *model_name = "some_model_name";
+  guint version;
+  const gchar *root_path = g_getenv ("MLAPI_SOURCE_ROOT_PATH");
+
+  /* ml_service_model_register() requires absolute path to model, ignore this case. */
+  if (root_path == NULL)
+    return;
+
+  gchar *test_model = g_build_filename (root_path, "tests", "test_models", "models",
       "mobilenet_v1_1.0_224_quant.tflite", NULL);
   ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
 
-  status = ml_service_model_register (key, test_model, false, nullptr, &version);
+  const gchar *key = "some_invalid_key";
+  ml_option_h info_h = NULL;
+  gchar *value;
+
+  status = ml_service_model_delete (model_name, 0U);
+  EXPECT_TRUE (status == ML_ERROR_NONE || status == ML_ERROR_INVALID_PARAMETER);
+
+  status = ml_service_model_register (model_name, test_model, true, NULL, &version);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  status = ml_service_model_get (model_name, version, &info_h);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  gchar *path;
+  status = ml_option_get (info_h, "path", (void **) &path);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+  EXPECT_STREQ (test_model, path);
+
+  gchar *description;
+  status = ml_option_get (info_h, "description", (void **) &description);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+  EXPECT_STREQ ("", description);
+
+  status = ml_option_get (info_h, key, NULL);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_option_get (info_h, key, (void **) &value);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_option_get (NULL, key, (void **) &value);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_option_destroy (info_h);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  status = ml_service_model_delete (model_name, 0U);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  g_free (test_model);
+}
+
+/**
+ * @brief Test the usecase of ml_servive for model. TBU.
+ */
+TEST_F (MLServiceAgentTest, model_scenario)
+{
+  int status;
+  const gchar *key = "mobilenet_v1";
+  const gchar *root_path = g_getenv ("MLAPI_SOURCE_ROOT_PATH");
+  gchar *test_model1, *test_model2;
+  unsigned int version;
+
+  /* ml_service_model_register() requires absolute path to model, ignore this case. */
+  if (root_path == NULL)
+    return;
+
+  /* delete all model with the key before test */
+  status = ml_service_model_delete (key, 0U);
+  EXPECT_TRUE (status == ML_ERROR_NONE || status == ML_ERROR_INVALID_PARAMETER);
+
+  test_model1 = g_build_filename (root_path, "tests", "test_models", "models",
+      "mobilenet_v1_1.0_224_quant.tflite", NULL);
+  ASSERT_TRUE (g_file_test (test_model1, G_FILE_TEST_EXISTS));
+
+  status = ml_service_model_register (key, test_model1, true, "temp description", &version);
   EXPECT_EQ (ML_ERROR_NONE, status);
   EXPECT_EQ (1U, version);
 
-  g_free (test_model);
+  status = ml_service_model_update_description (key, version, "updated description");
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  status = ml_service_model_update_description (key, 32U, "updated description");
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  test_model2 = g_build_filename (root_path, "tests", "test_models", "models",
+      "add.tflite", NULL);
+  ASSERT_TRUE (g_file_test (test_model2, G_FILE_TEST_EXISTS));
+
+
+  status = ml_service_model_register (key, test_model2, false, "this is the temp tflite model", &version);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+  EXPECT_EQ (version, 2U);
+
+  ml_option_h activated_model_info;
+  status = ml_service_model_get_activated (key, &activated_model_info);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+  EXPECT_NE (activated_model_info, nullptr);
+
+  gchar *test_description;
+  status = ml_option_get (activated_model_info, "path", (void **) &test_description);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+  EXPECT_STREQ (test_description, test_model1);
+  status = ml_option_destroy (activated_model_info);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  ml_option_h _model_info;
+  status = ml_service_model_get (key, 2U, &_model_info);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+  EXPECT_NE (_model_info, nullptr);
+
+  status = ml_option_get (_model_info, "path", (void **) &test_description);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+  EXPECT_STREQ (test_description, test_model2);
+  status = ml_option_destroy (_model_info);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  ml_option_h *info_list;
+  guint info_num;
+
+  status = ml_service_model_get_all (key, &info_list, &info_num);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+  EXPECT_EQ (info_num, 2U);
+
+  for (guint i = 0; i < info_num; i++) {
+    gchar *version_str;
+
+    status = ml_option_get (info_list[i], "version", (void **) &version_str);
+    EXPECT_EQ (ML_ERROR_NONE, status);
+    if (g_ascii_strcasecmp (version_str, "1") == 0) {
+      gchar *is_active;
+      status = ml_option_get (info_list[i], "active", (void **) &is_active);
+      EXPECT_EQ (ML_ERROR_NONE, status);
+      EXPECT_STREQ (is_active, "T");
+
+      gchar *path;
+      status = ml_option_get (info_list[i], "path", (void **) &path);
+      EXPECT_EQ (ML_ERROR_NONE, status);
+      EXPECT_STREQ (path, test_model1);
+    } else if (g_ascii_strcasecmp (version_str, "2") == 0) {
+      gchar *is_active;
+      status = ml_option_get (info_list[i], "active", (void **) &is_active);
+      EXPECT_EQ (ML_ERROR_NONE, status);
+      EXPECT_STREQ (is_active, "F");
+
+      gchar *path;
+      status = ml_option_get (info_list[i], "path", (void **) &path);
+      EXPECT_EQ (ML_ERROR_NONE, status);
+      EXPECT_STREQ (path, test_model2);
+    } else {
+      EXPECT_TRUE (false);
+    }
+
+    status = ml_option_destroy (info_list[i]);
+    EXPECT_EQ (ML_ERROR_NONE, status);
+  }
+
+  g_free (info_list);
+
+  /* delete the active model */
+  status = ml_service_model_delete (key, 1U);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  /* no active model */
+  status = ml_service_model_get_activated (key, &activated_model_info);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_service_model_activate (key, 91243U);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = ml_service_model_activate (key, 2U);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  status = ml_service_model_get_activated (key, &activated_model_info);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  status = ml_option_get (activated_model_info, "path", (gpointer *) &test_description);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+  EXPECT_STREQ (test_description, test_model2);
+
+  status = ml_option_destroy (activated_model_info);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  status = ml_service_model_delete (key, 2U);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  status = ml_service_model_delete (key, 1U);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  g_free (test_model1);
+  g_free (test_model2);
 }
 
 /**


### PR DESCRIPTION
- Add dbus methods to handle model service APIs
- Update/Add service-db methods in sqlite3 backend
- Implement dbus method callbacks
- Implement new APIs ml_service_model_* using gdbus and json-glib

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>