### PR TITLE
[Service] validate model path

### DIFF
--- a/c/src/ml-api-service-agent-client.c
+++ b/c/src/ml-api-service-agent-client.c
@@ -10,7 +10,7 @@
  * @bug No known bugs except for NYI items
  */
 
-#include <gio/gio.h>
+#include <glib/gstdio.h>
 
 #include "ml-api-internal.h"
 #include "ml-api-service.h"
@@ -339,27 +339,43 @@ ml_service_get_pipeline_state (ml_service_h h, ml_pipeline_state_e * state)
  * @brief TBU
  */
 int
-ml_service_model_register (const char *key, const char *model_path,
+ml_service_model_register (const char *name, const char *path,
     unsigned int *version)
 {
   int ret = ML_ERROR_NONE;
   MachinelearningServiceModel *mlsm;
   GError *err = NULL;
   gboolean result;
+  gchar *dir_name;
+  GStatBuf statbuf;
 
   check_feature_state (ML_FEATURE_SERVICE);
 
-  if (!key)
+  if (!name)
     _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
-        "The parameter, 'key' is NULL. It should be a valid string");
+        "The parameter, 'name' is NULL. It should be a valid string");
 
-  if (!model_path)
+  if (!path)
     _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
-        "The parameter, 'model_path' is NULL. It should be a valid string");
+        "The parameter, 'path' is NULL. It should be a valid string");
 
   if (!version)
     _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
         "The parameter, 'version' is NULL. It should be a valid unsigned int pointer");
+
+  dir_name = g_path_get_dirname (path);
+  ret = g_stat (dir_name, &statbuf);
+  g_free (dir_name);
+
+  if (ret != 0)
+    _ml_error_report_return (ML_ERROR_PERMISSION_DENIED,
+        "Failed to get the information of the model file '%s'.", path);
+
+  if (!g_path_is_absolute (path) ||
+      !g_file_test (path, (G_FILE_TEST_EXISTS | G_FILE_TEST_IS_REGULAR)) ||
+      g_file_test (path, G_FILE_TEST_IS_SYMLINK))
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The model file '%s' is not a regular file.", path);
 
   mlsm = _get_mlsm_proxy_new_for_bus_sync ();
   if (!mlsm) {
@@ -368,7 +384,7 @@ ml_service_model_register (const char *key, const char *model_path,
   }
 
   result = machinelearning_service_model_call_register_sync (mlsm,
-      key, model_path, version, &ret, NULL, &err);
+      name, path, version, &ret, NULL, &err);
 
   g_object_unref (mlsm);
 

--- a/tests/capi/unittest_capi_service_agent_client.cc
+++ b/tests/capi/unittest_capi_service_agent_client.cc
@@ -724,14 +724,24 @@ TEST_F (MLServiceAgentTest, query_request_00_n)
 TEST_F (MLServiceAgentTest, model_00)
 {
   int status;
-
-  const gchar *key = "yolov5";
-  const gchar *model = "yolov5s-fp16.tflite";
+  const gchar *key = "mobilenet_v1";
+  const gchar *root_path = g_getenv ("MLAPI_SOURCE_ROOT_PATH");
+  gchar *test_model;
   unsigned int version;
 
-  status = ml_service_model_register (key, model, &version);
+  /* ml_service_model_register() requires absolute path to model, ignore this case. */
+  if (root_path == NULL)
+    return;
+
+  test_model = g_build_filename (root_path, "tests", "test_models", "models",
+      "mobilenet_v1_1.0_224_quant.tflite", NULL);
+  ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
+
+  status = ml_service_model_register (key, test_model, &version);
   EXPECT_EQ (ML_ERROR_NONE, status);
   EXPECT_EQ (1U, version);
+
+  g_free (test_model);
 }
 
 /**


### PR DESCRIPTION
Validate model path when registering a model to database. It should be an absolute path and not symbol link file.