### PR TITLE
[Tizen] Fix gcno file path of gcov pacakge.

### DIFF
--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -422,9 +422,7 @@ popd
 builddir=$(basename $PWD)
 gcno_obj_dir=%{buildroot}%{_datadir}/gcov/obj/%{name}/"$builddir"
 mkdir -p "$gcno_obj_dir"
-pushd build
 find . -name '*.gcno' ! -path "*/tests/*" ! -name "meson-generated*" ! -name "sanitycheck*" -exec cp --parents '{}' "$gcno_obj_dir" ';'
-popd
 
 mkdir -p %{buildroot}%{_bindir}/tizen-unittests/%{name}
 install -m 0755 packaging/run-unittest.sh %{buildroot}%{_bindir}/tizen-unittests/%{name}


### PR DESCRIPTION
Fix gcno file path of gcov pacakge for compatibility with the Tizen line coverage automation tool.

 - Debug message:
  [DEBUG]:[2023-03-13,04:09:31]:[host_cmd.py:cmd:77]:geninfo: Warning: ('gcov') skipping .gcda file /home/ttf/jenkins_workspace/workspace/CEC_TIZEN_75_RPI4_GCOV_COVERAGE/CEC/res/coverage_gcov/gcov_data/capi-machine-learning-inference-1.8.3/build/c/src/libcapi-ml-service.so.1.8.3.p/ml-api-service-query-client.c.gcda because corresponding .gcno file is missing

 - Before: capi-machine-learning-inference-1.8.3\c\src\libcapi-ml-service.so.1.8.3.p

 - After: capi-machine-learning-inference-1.8.3\ **build** \c\src\libcapi-ml-service.so.1.8.3.p


Signed-off-by: gichan <gichan2.jang@samsung.com>