### PR TITLE
[service] Change error code not_support into io_error

### DIFF
--- a/c/src/ml-api-service-agent-client.c
+++ b/c/src/ml-api-service-agent-client.c
@@ -42,8 +42,7 @@ ml_service_set_pipeline (const char *name, const char *pipeline_desc)
 
   mlsp = _get_mlsp_proxy_new_for_bus_sync ();
   if (!mlsp) {
-    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
-        "Failed to get dbus proxy.");
+    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
   }
 
   result = machinelearning_service_pipeline_call_set_pipeline_sync (mlsp, name,
@@ -86,8 +85,7 @@ ml_service_get_pipeline (const char *name, char **pipeline_desc)
 
   mlsp = _get_mlsp_proxy_new_for_bus_sync ();
   if (!mlsp) {
-    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
-        "Failed to get dbus proxy.");
+    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
   }
 
   result = machinelearning_service_pipeline_call_get_pipeline_sync (mlsp, name,
@@ -125,8 +123,7 @@ ml_service_delete_pipeline (const char *name)
 
   mlsp = _get_mlsp_proxy_new_for_bus_sync ();
   if (!mlsp) {
-    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
-        "Failed to get dbus proxy.");
+    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
   }
 
   result = machinelearning_service_pipeline_call_delete_pipeline_sync (mlsp,
@@ -166,8 +163,7 @@ ml_service_launch_pipeline (const char *name, ml_service_h * h)
 
   mlsp = _get_mlsp_proxy_new_for_bus_sync ();
   if (!mlsp) {
-    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
-        "Failed to get dbus proxy.");
+    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
   }
 
   result = machinelearning_service_pipeline_call_launch_pipeline_sync (mlsp,
@@ -227,8 +223,7 @@ ml_service_start_pipeline (ml_service_h h)
 
   mlsp = _get_mlsp_proxy_new_for_bus_sync ();
   if (!mlsp) {
-    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
-        "Failed to get dbus proxy.");
+    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
   }
 
   server = (_ml_service_server_s *) mls->priv;
@@ -268,8 +263,7 @@ ml_service_stop_pipeline (ml_service_h h)
 
   mlsp = _get_mlsp_proxy_new_for_bus_sync ();
   if (!mlsp) {
-    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
-        "Failed to get dbus proxy.");
+    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
   }
 
   server = (_ml_service_server_s *) mls->priv;
@@ -314,8 +308,7 @@ ml_service_get_pipeline_state (ml_service_h h, ml_pipeline_state_e * state)
 
   mlsp = _get_mlsp_proxy_new_for_bus_sync ();
   if (!mlsp) {
-    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
-        "Failed to get dbus proxy.");
+    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
   }
 
   server = (_ml_service_server_s *) mls->priv;
@@ -381,8 +374,7 @@ ml_service_model_register (const char *name, const char *path,
 
   mlsm = _get_mlsm_proxy_new_for_bus_sync ();
   if (!mlsm) {
-    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
-        "Failed to get dbus proxy.");
+    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
   }
 
   result =
@@ -430,8 +422,7 @@ ml_service_model_update_description (const char *name,
 
   mlsm = _get_mlsm_proxy_new_for_bus_sync ();
   if (!mlsm) {
-    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
-        "Failed to get dbus proxy.");
+    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
   }
 
   result = machinelearning_service_model_call_update_description_sync (mlsm,
@@ -474,8 +465,7 @@ ml_service_model_activate (const char *name, const unsigned int version)
 
   mlsm = _get_mlsm_proxy_new_for_bus_sync ();
   if (!mlsm) {
-    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
-        "Failed to get dbus proxy.");
+    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
   }
 
   result = machinelearning_service_model_call_activate_sync (mlsm,
@@ -528,8 +518,7 @@ ml_service_model_get (const char *name, const unsigned int version,
 
   mlsm = _get_mlsm_proxy_new_for_bus_sync ();
   if (!mlsm) {
-    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
-        "Failed to get dbus proxy.");
+    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
   }
 
   result = machinelearning_service_model_call_get_sync (mlsm,
@@ -632,8 +621,7 @@ ml_service_model_get_activated (const char *name, ml_option_h * info)
 
   mlsm = _get_mlsm_proxy_new_for_bus_sync ();
   if (!mlsm) {
-    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
-        "Failed to get dbus proxy.");
+    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
   }
 
   result = machinelearning_service_model_call_get_activated_sync (mlsm,
@@ -740,8 +728,7 @@ ml_service_model_get_all (const char *name, ml_option_h * info_list[],
 
   mlsm = _get_mlsm_proxy_new_for_bus_sync ();
   if (!mlsm) {
-    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
-        "Failed to get dbus proxy.");
+    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
   }
 
   result = machinelearning_service_model_call_get_all_sync (mlsm,
@@ -861,8 +848,7 @@ ml_service_model_delete (const char *name, const unsigned int version)
 
   mlsm = _get_mlsm_proxy_new_for_bus_sync ();
   if (!mlsm) {
-    _ml_error_report_return (ML_ERROR_NOT_SUPPORTED,
-        "Failed to get dbus proxy.");
+    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
   }
 
   result = machinelearning_service_model_call_delete_sync (mlsm,

--- a/c/src/ml-api-service-common.c
+++ b/c/src/ml-api-service-common.c
@@ -90,7 +90,7 @@ ml_service_destroy (ml_service_h h)
     mlsp = _get_mlsp_proxy_new_for_bus_sync ();
     if (!mlsp) {
       _ml_error_report ("Failed to get dbus proxy.");
-      ret = ML_ERROR_INVALID_PARAMETER;
+      ret = ML_ERROR_IO_ERROR;
       goto exit;
     }
 

--- a/tests/capi/unittest_capi_service_agent_client.cc
+++ b/tests/capi/unittest_capi_service_agent_client.cc
@@ -451,6 +451,26 @@ TEST_F (MLServiceAgentTest, destroy_00_n)
 }
 
 /**
+ * @brief Test ml_service_destroy with explicit invalid param.
+ */
+TEST_F (MLServiceAgentTest, destroy_01_n)
+{
+  int status;
+  ml_service_h h;
+
+  ml_service_s *mls = g_new0 (ml_service_s, 1);
+  _ml_service_server_s *server = g_new0 (_ml_service_server_s, 1);
+  mls->priv = server;
+  mls->type = ML_SERVICE_TYPE_MAX;
+
+  h = (ml_service_h) mls;
+  status = ml_service_destroy (h);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  g_free (server);
+}
+
+/**
  * @brief Test ml_service APIs with invalid handle.
  */
 TEST_F (MLServiceAgentTest, explicit_invalid_handle_00_n)
@@ -1132,6 +1152,89 @@ TEST_F (MLServiceAgentTest, model_scenario)
 
   g_free (test_model1);
   g_free (test_model2);
+}
+
+/**
+ * @brief Negative test for pipeline. With DBus unconnected.
+ */
+TEST (MLServiceAgentTestDbusUnconnected, pipeline_n)
+{
+  int status;
+
+  status = ml_service_set_pipeline ("test", "test");
+  EXPECT_EQ (ML_ERROR_IO_ERROR, status);
+
+  gchar *ret_pipeline;
+  status = ml_service_get_pipeline ("test", &ret_pipeline);
+  EXPECT_EQ (ML_ERROR_IO_ERROR, status);
+
+
+  ml_service_h service;
+  status = ml_service_launch_pipeline ("test", &service);
+  EXPECT_EQ (ML_ERROR_IO_ERROR, status);
+
+  ml_service_s *mls = g_new0 (ml_service_s, 1);
+  _ml_service_server_s *server = g_new0 (_ml_service_server_s, 1);
+  mls->priv = server;
+
+  server->id = -987654321; /* explicitly set id as invalid number */
+
+  service = (ml_service_h) mls;
+  status = ml_service_start_pipeline (service);
+  EXPECT_EQ (ML_ERROR_IO_ERROR, status);
+
+  status = ml_service_stop_pipeline (service);
+  EXPECT_EQ (ML_ERROR_IO_ERROR, status);
+
+  ml_pipeline_state_e state;
+  status = ml_service_get_pipeline_state (service, &state);
+  EXPECT_EQ (ML_ERROR_IO_ERROR, status);
+
+  mls->type = ML_SERVICE_TYPE_SERVER_PIPELINE;
+  status = ml_service_destroy (service);
+  EXPECT_EQ (ML_ERROR_IO_ERROR, status);
+}
+
+/**
+ * @brief Negative test for model. With DBus unconnected.
+ */
+TEST (MLServiceAgentTestDbusUnconnected, model_n)
+{
+  int status;
+
+  const gchar *root_path = g_getenv ("MLAPI_SOURCE_ROOT_PATH");
+  unsigned int version;
+
+  /* ml_service_model_register() requires absolute path to model, ignore this case. */
+  if (root_path == NULL)
+    return;
+
+  gchar *test_model = g_build_filename (root_path, "tests", "test_models", "models",
+      "mobilenet_v1_1.0_224_quant.tflite", NULL);
+  ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
+
+  status = ml_service_model_register ("test", test_model, false, "test", &version);
+  EXPECT_EQ (ML_ERROR_IO_ERROR, status);
+
+  g_free (test_model);
+
+  status = ml_service_model_update_description ("test", 1U, "test");
+  EXPECT_EQ (ML_ERROR_IO_ERROR, status);
+
+  status = ml_service_model_activate ("test", 1U);
+  EXPECT_EQ (ML_ERROR_IO_ERROR, status);
+
+  ml_option_h model_info;
+  status = ml_service_model_get ("test", 1U, &model_info);
+  EXPECT_EQ (ML_ERROR_IO_ERROR, status);
+
+  status = ml_service_model_get_activated ("test", &model_info);
+  EXPECT_EQ (ML_ERROR_IO_ERROR, status);
+
+  ml_option_h *info_list;
+  guint info_num;
+  status = ml_service_model_get_all ("test", &info_list, &info_num);
+  EXPECT_EQ (ML_ERROR_IO_ERROR, status);
 }
 
 /**


### PR DESCRIPTION
- If failed to connect with dbus, return ML_ERROR_IO_ERROR
  rather than ML_ERROR_NOT_SUPPORTED, which should be check with tizen
  feature.
- Add negative TC with DBUS unconnected.