### PR TITLE
[Service] do not free handle in error case

### DIFF
--- a/c/src/ml-api-service-common.c
+++ b/c/src/ml-api-service-common.c
@@ -89,9 +89,7 @@ ml_service_destroy (ml_service_h h)
 
     mlsp = _get_mlsp_proxy_new_for_bus_sync ();
     if (!mlsp) {
-      _ml_error_report ("Failed to get dbus proxy.");
-      ret = ML_ERROR_IO_ERROR;
-      goto exit;
+      _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
     }
 
     result = machinelearning_service_pipeline_call_destroy_pipeline_sync (mlsp,
@@ -106,8 +104,8 @@ ml_service_destroy (ml_service_h h)
     }
     g_clear_error (&err);
 
-    if (ML_ERROR_INVALID_PARAMETER == ret)
-      _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+    if (ML_ERROR_NONE != ret)
+      _ml_error_report_return (ret,
           "The data of given handle is corrupted. Please check it.");
 
     g_free (server->service_name);
@@ -132,13 +130,10 @@ ml_service_destroy (ml_service_h h)
     g_async_queue_unref (query->out_data_queue);
     g_free (query);
   } else {
-    _ml_error_report ("Invalid type of ml_service_h.");
-    ret = ML_ERROR_INVALID_PARAMETER;
-    goto exit;
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "Invalid type of ml_service_h.");
   }
 
-exit:
   g_free (mls);
-
-  return ret;
+  return ML_ERROR_NONE;
 }

--- a/c/src/ml-api-service-private.h
+++ b/c/src/ml-api-service-private.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 typedef enum {
-  ML_SERVICE_TYPE = 0,
+  ML_SERVICE_TYPE_UNKNOWN = 0,
   ML_SERVICE_TYPE_SERVER_PIPELINE,
   ML_SERVICE_TYPE_CLIENT_QUERY,
 

--- a/tests/capi/unittest_capi_service_agent_client.cc
+++ b/tests/capi/unittest_capi_service_agent_client.cc
@@ -468,6 +468,7 @@ TEST_F (MLServiceAgentTest, destroy_01_n)
   EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
 
   g_free (server);
+  g_free (mls);
 }
 
 /**
@@ -1194,6 +1195,9 @@ TEST (MLServiceAgentTestDbusUnconnected, pipeline_n)
   mls->type = ML_SERVICE_TYPE_SERVER_PIPELINE;
   status = ml_service_destroy (service);
   EXPECT_EQ (ML_ERROR_IO_ERROR, status);
+
+  g_free (server);
+  g_free (mls);
 }
 
 /**


### PR DESCRIPTION
If called service-destroy function, do not free allocated handle if an error from dbus or database is raised.