### PR TITLE
[CodeClean] Remove unnecessary code in ml-agent

### DIFF
--- a/daemon/gdbus-util.c
+++ b/daemon/gdbus-util.c
@@ -115,34 +115,6 @@ gdbus_disconnect_signal (gpointer instance, int num_signals,
 }
 
 /**
- * @brief Cleanup the instance of the DBus interface.
- */
-static void
-put_instance (gpointer * instance)
-{
-  g_object_unref (*instance);
-  *instance = NULL;
-}
-
-/**
- * @brief Get the skeleton object of the DBus interface.
- */
-MachinelearningServicePipeline *
-gdbus_get_instance_pipeline (void)
-{
-  return machinelearning_service_pipeline_skeleton_new ();
-}
-
-/**
- * @brief Put the obtained skeleton object and release the resource.
- */
-void
-gdbus_put_instance_pipeline (MachinelearningServicePipeline ** instance)
-{
-  put_instance ((gpointer *) instance);
-}
-
-/**
  * @brief Connect to the DBus message bus, which type is SYSTEM.
  */
 int

--- a/daemon/includes/gdbus-util.h
+++ b/daemon/includes/gdbus-util.h
@@ -22,8 +22,6 @@
 #include <gio/gio.h>
 #include <stdbool.h>
 
-#include "pipeline-dbus.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
@@ -41,7 +39,6 @@ struct gdbus_signal_info
 
 /**
  * @brief Export the DBus interface at the Object path on the bus connection.
- * 
  * @param instance The instance of the DBus interface to export.
  * @param obj_path The path to export the interface at.
  * @return @c 0 on success. Otherwise a negative error value.
@@ -76,22 +73,8 @@ void gdbus_disconnect_signal (gpointer instance, int num_signals,
     struct gdbus_signal_info *signal_infos);
 
 /**
- * @brief Get the skeleton object of the DBus interface.
- * @remarks If the function succeeds, @a MachinelearningServicePipeline*
- * should be released using gdbus_put_instance_pipeline().
- * @return MachinelearningServiceProcess* The skeleton object.
- */
-MachinelearningServicePipeline *gdbus_get_instance_pipeline (void);
-
-/**
- * @brief Put the obtained skeleton object and release the resource.
- * @param instance The obtained skeleton object of the DBus interface.
- */
-void gdbus_put_instance_pipeline (MachinelearningServicePipeline ** instance);
-
-/**
  * @brief Connect to the DBus message bus
- * @param is_session Ture is DBus Bus type is session.
+ * @param is_session True is DBus Bus type is session.
  * @return @c 0 on success. Otherwise a negative error value.
  */
 int gdbus_get_system_connection (gboolean is_session);

--- a/daemon/pipeline-dbus-impl.cc
+++ b/daemon/pipeline-dbus-impl.cc
@@ -102,9 +102,6 @@ static gboolean dbus_cb_core_set_pipeline (MachinelearningServicePipeline *obj,
   } catch (const std::invalid_argument &e) {
     _E ("An exception occurred during write to the DB. Error message: %s", e.what ());
     result = -EINVAL;
-  } catch (const std::runtime_error &e) {
-    _E ("An exception occurred during write to the DB. Error message: %s", e.what ());
-    result = -EIO;
   } catch (const std::exception &e) {
     _E ("An exception occurred during write to the DB. Error message: %s", e.what ());
     result = -EIO;
@@ -139,9 +136,6 @@ static gboolean dbus_cb_core_get_pipeline (MachinelearningServicePipeline *obj,
   } catch (const std::invalid_argument &e) {
     _E ("An exception occurred during read the DB. Error message: %s", e.what ());
     result = -EINVAL;
-  } catch (const std::runtime_error &e) {
-    _E ("An exception occurred during read the DB. Error message: %s", e.what ());
-    result = -EIO;
   } catch (const std::exception &e) {
     _E ("An exception occurred during read the DB. Error message: %s", e.what ());
     result = -EIO;
@@ -175,9 +169,6 @@ static gboolean dbus_cb_core_delete_pipeline (MachinelearningServicePipeline *ob
   } catch (const std::invalid_argument &e) {
     _E ("An exception occurred during delete an item in the DB. Error message: %s", e.what ());
     result = -EINVAL;
-  } catch (const std::runtime_error &e) {
-    _E ("An exception occurred during delete an item in the DB. Error message: %s", e.what ());
-    result = -EIO;
   } catch (const std::exception &e) {
     _E ("An exception occurred during delete an item in the DB. Error message: %s", e.what ());
     result = -EIO;
@@ -218,9 +209,6 @@ static gboolean dbus_cb_core_launch_pipeline (MachinelearningServicePipeline *ob
   } catch (const std::invalid_argument &e) {
     _E ("An exception occurred during read the DB. Error message: %s", e.what ());
     result = -EINVAL;
-  } catch (const std::runtime_error &e) {
-    _E ("An exception occurred during read the DB. Error message: %s", e.what ());
-    result = -EIO;
   } catch (const std::exception &e) {
     _E ("An exception occurred during read the DB. Error message: %s", e.what ());
     result = -EIO;

--- a/daemon/pipeline-dbus-impl.cc
+++ b/daemon/pipeline-dbus-impl.cc
@@ -26,6 +26,7 @@
 #include <gdbus-util.h>
 #include <log.h>
 
+#include "pipeline-dbus.h"
 #include "service-db.hh"
 #include "dbus-interface.h"
 
@@ -66,6 +67,24 @@ static void _pipeline_free (gpointer data)
   g_mutex_clear (&p->lock);
 
   g_free (p);
+}
+
+/**
+ * @brief Get the skeleton object of the DBus interface.
+ */
+static MachinelearningServicePipeline *
+gdbus_get_pipeline_instance (void)
+{
+  return machinelearning_service_pipeline_skeleton_new ();
+}
+
+/**
+ * @brief Put the obtained skeleton object and release the resource.
+ */
+static void
+gdbus_put_pipeline_instance (MachinelearningServicePipeline ** instance)
+{
+  g_clear_object (instance);
 }
 
 /**
@@ -458,7 +477,7 @@ static int probe_pipeline_module (void *data)
 {
   int ret = 0;
 
-  g_gdbus_instance = gdbus_get_instance_pipeline ();
+  g_gdbus_instance = gdbus_get_pipeline_instance ();
   if (g_gdbus_instance == NULL) {
     _E ("cannot get a dbus instance for the %s interface\n",
         DBUS_PIPELINE_INTERFACE);
@@ -488,7 +507,7 @@ out_disconnect:
   gdbus_disconnect_signal (g_gdbus_instance,
       ARRAY_SIZE (handler_infos), handler_infos);
 out:
-  gdbus_put_instance_pipeline (&g_gdbus_instance);
+  gdbus_put_pipeline_instance (&g_gdbus_instance);
 
   return ret;
 }
@@ -528,7 +547,7 @@ static void exit_pipeline_module (void *data)
 
   gdbus_disconnect_signal (g_gdbus_instance,
       ARRAY_SIZE (handler_infos), handler_infos);
-  gdbus_put_instance_pipeline (&g_gdbus_instance);
+  gdbus_put_pipeline_instance (&g_gdbus_instance);
 }
 
 static const struct module_ops pipeline_ops = {

--- a/tests/capi/unittest_capi_service_agent_client.cc
+++ b/tests/capi/unittest_capi_service_agent_client.cc
@@ -24,7 +24,6 @@ class MLServiceAgentTest : public::testing::Test
 {
 protected:
   GTestDBus *dbus;
-  GDBusProxy *proxy;
 
 public:
   /**
@@ -42,20 +41,6 @@ public:
     g_free (services_dir);
 
     g_test_dbus_up (dbus);
-
-    GError *error = NULL;
-    proxy = g_dbus_proxy_new_for_bus_sync (
-        G_BUS_TYPE_SESSION,
-        G_DBUS_PROXY_FLAGS_NONE,
-        NULL,
-        "org.tizen.machinelearning.service",
-        "/Org/Tizen/MachineLearning/Service/Pipeline",
-        "org.tizen.machinelearning.service.pipeline",
-        NULL,
-        &error);
-
-    ASSERT_EQ (nullptr, error);
-    ASSERT_NE (nullptr, proxy);
   }
 
   /**
@@ -63,9 +48,6 @@ public:
    */
   void TearDown () override
   {
-    if (proxy)
-      g_object_unref (proxy);
-
     if (dbus) {
       g_test_dbus_down (dbus);
       g_object_unref (dbus);


### PR DESCRIPTION
- Move pipeline related code in gdbus-util to proper src.
- Let std::exception catch those runtime errors.
- Remove unnecessary code in service api test