### PR TITLE
Meson/LCOV: Fix wrong code coverage ratio for ml-agent sources

### DIFF
--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -1,11 +1,15 @@
 # Machine Learning Agent
 # This file should be included when ml-service feature is enabled.
 nns_ml_agent_incs = include_directories('includes')
-nns_ml_agent_srcs = files('main.c', 'modules.c', 'gdbus-util.c',
-  'service-db.cc', 'pipeline-dbus-impl.cc', 'model-dbus-impl.cc')
-if get_option('enable-tizen')
-  nns_ml_agent_srcs += files('pkg-mgr.c')
+nns_ml_agent_common_srcs = files('main.c', 'modules.c', 'gdbus-util.c',
+  'pipeline-dbus-impl.cc', 'model-dbus-impl.cc')
+nns_ml_agent_service_db_srcs = files('service-db.cc')
+
+if (get_option('enable-tizen'))
+  nns_ml_agent_common_srcs += files('pkg-mgr.c')
 endif
+
+nns_ml_agent_srcs = [nns_ml_agent_common_srcs, nns_ml_agent_service_db_srcs]
 
 # Generate GDbus header and code
 gdbus_prog = find_program('gdbus-codegen', required: true)
@@ -46,7 +50,7 @@ daemon_cpp_db_path_arg = '-DDB_PATH="' + serviceDBPath + '"'
 serviceDBKeyPrefix = get_option('service-db-key-prefix')
 daemon_cpp_db_key_prefix_arg = '-DMESON_KEY_PREFIX="' + serviceDBKeyPrefix + '"'
 
-executable('machine-learning-agent',
+nns_ml_agent_executable = executable('machine-learning-agent',
   nns_ml_agent_srcs,
   dependencies: [ai_service_daemon_deps],
   include_directories: nns_ml_agent_incs,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -21,10 +21,12 @@ if gtest_dep.found()
     gdbus_gen_header_test_dep = declare_dependency(sources: gdbus_gen_test_src,
       dependencies: gdbus_gen_header_dep)
 
+    nns_ml_agent_common_objs = nns_ml_agent_executable.extract_objects(nns_ml_agent_common_srcs)
     executable('machine-learning-agent-test',
-      [nns_ml_agent_srcs, files('daemon/test-dbus-impl.c')],
+      [nns_ml_agent_service_db_srcs, files('daemon/test-dbus-impl.c')],
       dependencies: [ai_service_daemon_deps, gdbus_gen_header_test_dep],
       include_directories: nns_ml_agent_incs,
+      objects: [nns_ml_agent_common_objs],
       cpp_args: [daemon_cpp_db_key_prefix_arg, '-DDB_PATH="."']
     )
   endif


### PR DESCRIPTION
The changes in https://github.com/nnstreamer/api/commit/2b1df86097d7f94496e7990f68f3495a2b55a4a0 make two sets of object files for the 'machine-learning-agent' and 'machine-learning-agent-test' executables, which leads to the wrong code coverage ratio for the ml-agent daemon source files. This patch fixes it.

Signed-off-by: Wook Song <wook16.song@samsung.com>

FYI, a list of ```gcno``` files are as follows:
```
./build/daemon/machine-learning-agent.p/service-db.cc.gcno
./build/daemon/machine-learning-agent.p/pipeline-dbus-impl.cc.gcno
./build/daemon/machine-learning-agent.p/meson-generated_.._model-dbus.c.gcno
./build/daemon/machine-learning-agent.p/model-dbus-impl.cc.gcno
./build/daemon/machine-learning-agent.p/gdbus-util.c.gcno
./build/daemon/machine-learning-agent.p/pkg-mgr.c.gcno
./build/daemon/machine-learning-agent.p/modules.c.gcno
./build/daemon/machine-learning-agent.p/main.c.gcno
./build/daemon/machine-learning-agent.p/meson-generated_.._pipeline-dbus.c.gcno
./build/c/src/libcapi-ml-common.so.1.8.3.p/ml-api-inference-tizen-privilege-check.c.gcno
./build/c/src/libcapi-ml-common.so.1.8.3.p/ml-api-inference-internal.c.gcno
./build/c/src/libcapi-ml-common.so.1.8.3.p/ml-api-common-tizen-feature-check.c.gcno
./build/c/src/libcapi-ml-common.so.1.8.3.p/ml-api-common.c.gcno
./build/c/src/libcapi-ml-common.a.p/ml-api-inference-tizen-privilege-check.c.gcno
./build/c/src/libcapi-ml-common.a.p/ml-api-inference-internal.c.gcno
./build/c/src/libcapi-ml-common.a.p/ml-api-common-tizen-feature-check.c.gcno
./build/c/src/libcapi-ml-common.a.p/ml-api-common.c.gcno
./build/c/src/libcapi-nnstreamer.so.1.8.3.p/ml-api-inference-pipeline.c.gcno
./build/c/src/libcapi-ml-service.so.1.8.3.p/meson-generated_.._.._.._daemon_pipeline-dbus.c.gcno
./build/c/src/libcapi-ml-service.so.1.8.3.p/ml-api-service-query-client.c.gcno
./build/c/src/libcapi-ml-service.so.1.8.3.p/ml-api-service-agent-client.c.gcno
./build/c/src/libcapi-ml-service.so.1.8.3.p/ml-api-service-common.c.gcno
./build/c/src/libcapi-ml-service.so.1.8.3.p/meson-generated_.._.._.._daemon_model-dbus.c.gcno
./build/c/src/libcapi-ml-inference-single.so.1.8.3.p/ml-api-inference-single.c.gcno
./build/c/src/libcapi-ml-inference-single.a.p/ml-api-inference-single.c.gcno
./build/c/src/libcapi-ml-service.a.p/meson-generated_.._.._.._daemon_pipeline-dbus.c.gcno
./build/c/src/libcapi-ml-service.a.p/ml-api-service-query-client.c.gcno
./build/c/src/libcapi-ml-service.a.p/ml-api-service-agent-client.c.gcno
./build/c/src/libcapi-ml-service.a.p/ml-api-service-common.c.gcno
./build/c/src/libcapi-ml-service.a.p/meson-generated_.._.._.._daemon_model-dbus.c.gcno
./build/c/src/libcapi-nnstreamer.a.p/ml-api-inference-pipeline.c.gcno
./build/tests/daemon/unittest_dbus_model.p/meson-generated_.._.._.._daemon_pipeline-dbus.c.gcno
./build/tests/daemon/unittest_dbus_model.p/unittest_dbus_model.cc.gcno
./build/tests/daemon/unittest_dbus_model.p/meson-generated_.._.._.._daemon_model-dbus.c.gcno
./build/tests/daemon/unittest_ml_agent.p/meson-generated_.._.._.._daemon_pipeline-dbus.c.gcno
./build/tests/daemon/unittest_ml_agent.p/unittest_ml_agent.cc.gcno
./build/tests/daemon/unittest_ml_agent.p/meson-generated_.._.._test-dbus.c.gcno
./build/tests/daemon/unittest_ml_agent.p/meson-generated_.._.._.._daemon_model-dbus.c.gcno
./build/tests/capi/unittest_capi_inference_nnfw_runtime.p/unittest_capi_inference_nnfw_runtime.cc.gcno
./build/tests/capi/libunittest_util.a.p/unittest_util.c.gcno
./build/tests/capi/unittest_capi_datatype_consistency.p/unittest_capi_datatype_consistency.cc.gcno
./build/tests/capi/unittest_capi_inference_latency.p/unittest_capi_inference_latency.cc.gcno
./build/tests/capi/unittest_capi_inference_single.p/unittest_capi_inference_single.cc.gcno
./build/tests/capi/unittest_capi_inference.p/unittest_capi_inference.cc.gcno
./build/tests/capi/unittest_capi_service_agent_client.p/meson-generated_.._.._.._daemon_pipeline-dbus.c.gcno
./build/tests/capi/unittest_capi_service_agent_client.p/unittest_capi_service_agent_client.cc.gcno
./build/tests/capi/unittest_capi_service_agent_client.p/meson-generated_.._.._test-dbus.c.gcno
./build/tests/capi/unittest_capi_service_agent_client.p/meson-generated_.._.._.._daemon_model-dbus.c.gcno
./build/tests/machine-learning-agent-test.p/daemon_test-dbus-impl.c.gcno
./build/tests/machine-learning-agent-test.p/meson-generated_.._.._daemon_pipeline-dbus.c.gcno
./build/tests/machine-learning-agent-test.p/meson-generated_.._.._daemon_model-dbus.c.gcno
./build/tests/machine-learning-agent-test.p/meson-generated_.._test-dbus.c.gcno
./build/tests/machine-learning-agent-test.p/.._daemon_service-db.cc.gcno
```