### PR TITLE
[Single] Add input and output ranks @open sesame 4/3 15:31

### DIFF
--- a/c/src/ml-api-common.c
+++ b/c/src/ml-api-common.c
@@ -96,6 +96,25 @@ _ml_tensors_info_initialize (ml_tensors_info_s * info)
 }
 
 /**
+ * @brief Initializes the tensors information with default value.
+ */
+int
+_ml_tensors_rank_initialize (guint * rank)
+{
+  guint i;
+
+  if (!rank)
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, rank, is NULL. Provide a valid pointer.");
+
+  for (i = 0; i < ML_TENSOR_SIZE_LIMIT; i++) {
+    rank[i] = 0;
+  }
+
+  return ML_ERROR_NONE;
+}
+
+/**
  * @brief Compares the given tensor info.
  */
 static gboolean

--- a/c/src/ml-api-internal.h
+++ b/c/src/ml-api-internal.h
@@ -268,6 +268,16 @@ size_t _ml_tensor_info_get_size (const ml_tensor_info_s *info);
 int _ml_tensors_info_initialize (ml_tensors_info_s *info);
 
 /**
+ * @brief Initializes the rank information with default value.
+ * @since_tizen 7.5
+ * @param[in] info The rank array pointer to be initialized.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
+ */
+int _ml_tensors_rank_initialize (guint *rank);
+
+/**
  * @brief Frees and initialize the data in tensors info.
  * @since_tizen 5.5
  * @param[in] info The tensors info pointer to be freed.

--- a/tests/capi/unittest_capi_inference_single.cc
+++ b/tests/capi/unittest_capi_inference_single.cc
@@ -2044,6 +2044,113 @@ skip_test:
   g_free (test_model);
 }
 
+/**
+ * @brief Test for input_ranks and output_ranks property of the ml_single
+ * @details Given dimension string, check its value.
+ */
+TEST (nnstreamer_capi_singleshot, property_05_p)
+{
+  ml_single_h single;
+  char *prop_value;
+  int status;
+
+  const gchar *root_path = g_getenv ("MLAPI_SOURCE_ROOT_PATH");
+  gchar *test_model;
+
+  /* supposed to run test in build directory */
+  if (root_path == NULL)
+    root_path = "..";
+
+  /** add.tflite adds value 2 to all the values in the input */
+  test_model = g_build_filename (
+      root_path, "tests", "test_models", "models", "add.tflite", NULL);
+  ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
+
+  status = ml_single_open (&single, test_model, NULL, NULL,
+      ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_ANY);
+  if (is_enabled_tensorflow_lite) {
+    EXPECT_EQ (status, ML_ERROR_NONE);
+  } else {
+    EXPECT_NE (status, ML_ERROR_NONE);
+    goto skip_test;
+  }
+
+  status = ml_single_set_property (single, "input", "5:1:1:1");
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_single_get_property (single, "input", &prop_value);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  EXPECT_STREQ (prop_value, "5:1:1:1");
+  g_free (prop_value);
+
+  status = ml_single_set_property (single, "input", "5:1:1");
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_single_get_property (single, "input", &prop_value);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  EXPECT_STREQ (prop_value, "5:1:1");
+  g_free (prop_value);
+
+  status = ml_single_set_property (single, "input", "5:1");
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_single_get_property (single, "input", &prop_value);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  EXPECT_STREQ (prop_value, "5:1");
+  g_free (prop_value);
+
+  status = ml_single_set_property (single, "input", "5");
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_single_get_property (single, "input", &prop_value);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  EXPECT_STREQ (prop_value, "5");
+  g_free (prop_value);
+
+  status = ml_single_set_property (single, "output", "5:1:1:1");
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_single_get_property (single, "output", &prop_value);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  EXPECT_STREQ (prop_value, "5:1:1:1");
+  g_free (prop_value);
+
+  status = ml_single_set_property (single, "output", "5:1:1");
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_single_get_property (single, "output", &prop_value);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  EXPECT_STREQ (prop_value, "5:1:1");
+  g_free (prop_value);
+
+  status = ml_single_set_property (single, "output", "5:1");
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_single_get_property (single, "output", &prop_value);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  EXPECT_STREQ (prop_value, "5:1");
+  g_free (prop_value);
+
+  status = ml_single_set_property (single, "output", "5");
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_single_get_property (single, "output", &prop_value);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  EXPECT_STREQ (prop_value, "5");
+  g_free (prop_value);
+
+skip_test:
+  g_free (test_model);
+}
+
 #ifdef ENABLE_NNFW_RUNTIME
 /**
  * @brief Test NNStreamer single shot (nnfw backend)


### PR DESCRIPTION
This patch adds input and output ranks to ml_single. 
Input and output ranks are used when user explicitly sets rank property.
Related to https://github.com/nnstreamer/api/pull/241#issuecomment-1489867402