### PR TITLE
[Agent] Cleanup pkg-mgr code

### DIFF
--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -6,7 +6,7 @@ nns_ml_agent_common_srcs = files('main.c', 'modules.c', 'gdbus-util.c',
 nns_ml_agent_service_db_srcs = files('service-db.cc')
 
 if (get_option('enable-tizen'))
-  nns_ml_agent_common_srcs += files('pkg-mgr.c')
+  nns_ml_agent_common_srcs += files('pkg-mgr.cc')
 endif
 
 nns_ml_agent_srcs = [nns_ml_agent_common_srcs, nns_ml_agent_service_db_srcs]


### PR DESCRIPTION
* Add the service-db code for future work.
* Change a c file into a cpp file to use the service-db instance.