### PR TITLE
[C-Api] fill dim (default 1)

### DIFF
--- a/c/src/ml-api-common.c
+++ b/c/src/ml-api-common.c
@@ -551,6 +551,10 @@ ml_tensors_info_get_tensor_dimension (ml_tensors_info_h info,
     dimension[i] = tensors_info->info[index].dimension[i];
   }
 
+  /* Fill remained dim (default value 1) */
+  for (i = valid_rank; i < ML_TENSOR_RANK_LIMIT; i++)
+    dimension[i] = 1;
+
   G_UNLOCK_UNLESS_NOLOCK (*tensors_info);
   return ML_ERROR_NONE;
 }


### PR DESCRIPTION
When calling get-dimension(), fill remained dim - default dim is 1.