### PR TITLE
MLAgent: Introduce libml-agentd

### DIFF
--- a/c/src/meson.build
+++ b/c/src/meson.build
@@ -102,18 +102,20 @@ nns_capi_dep = declare_dependency(link_with: nns_capi_lib,
 if get_option('enable-ml-service')
   nns_capi_service_shared_lib = shared_library ('capi-ml-service',
     nns_capi_service_srcs,
-    dependencies: [nns_capi_dep, ai_service_daemon_deps],
-    include_directories: nns_capi_include,
+    dependencies: [nns_capi_dep, ml_agentd_deps],
+    include_directories: [nns_capi_include, ml_agentd_incs],
     install: true,
     install_dir: api_install_libdir,
+    link_with: ml_agentd_lib,
     version: api_version,
   )
 
   nns_capi_service_static_lib = static_library ('capi-ml-service',
     nns_capi_service_srcs,
-    dependencies: [nns_capi_dep, ai_service_daemon_deps],
-    include_directories: nns_capi_include,
+    dependencies: [nns_capi_dep, ml_agentd_deps],
+    include_directories: [nns_capi_include, ml_agentd_incs],
     install: true,
+    link_with: ml_agentd_lib,
     install_dir: api_install_libdir,
   )
 
@@ -123,7 +125,7 @@ if get_option('enable-ml-service')
   endif
 
   nns_capi_service_dep = declare_dependency(link_with: nns_capi_service_lib,
-    dependencies: [nns_capi_dep, ai_service_daemon_deps],
+    dependencies: [nns_capi_dep, ml_agentd_deps],
     include_directories: nns_capi_include
   )
 endif

--- a/c/src/ml-api-service-agent-client.c
+++ b/c/src/ml-api-service-agent-client.c
@@ -13,9 +13,10 @@
 #include <glib/gstdio.h>
 #include <json-glib/json-glib.h>
 
+#include "ml-agent-dbus-interface.h"
 #include "ml-api-internal.h"
-#include "ml-api-service.h"
 #include "ml-api-service-private.h"
+#include "ml-api-service.h"
 
 #if defined(__TIZEN__)
 #include <app_common.h>
@@ -100,9 +101,7 @@ int
 ml_service_set_pipeline (const char *name, const char *pipeline_desc)
 {
   int ret = ML_ERROR_NONE;
-  MachinelearningServicePipeline *mlsp;
   GError *err = NULL;
-  gboolean result;
 
   check_feature_state (ML_FEATURE_SERVICE);
 
@@ -116,20 +115,12 @@ ml_service_set_pipeline (const char *name, const char *pipeline_desc)
         "The parameter, 'pipeline_desc' is NULL. It should be a valid string.");
   }
 
-  mlsp = _get_mlsp_proxy_new_for_bus_sync ();
-  if (!mlsp) {
-    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
-  }
-
-  result = machinelearning_service_pipeline_call_set_pipeline_sync (mlsp, name,
-      pipeline_desc, &ret, NULL, &err);
-
-  g_object_unref (mlsp);
-
-  if (!result) {
+  ret =
+      ml_agent_dbus_interface_pipeline_set_description (name, pipeline_desc,
+      &err);
+  if (ret < 0) {
     _ml_error_report ("Failed to invoke the method set_pipeline (%s).",
         err ? err->message : "Unknown error");
-    ret = ML_ERROR_IO_ERROR;
   }
   g_clear_error (&err);
 
@@ -143,9 +134,7 @@ int
 ml_service_get_pipeline (const char *name, char **pipeline_desc)
 {
   int ret = ML_ERROR_NONE;
-  MachinelearningServicePipeline *mlsp;
   GError *err = NULL;
-  gboolean result;
 
   check_feature_state (ML_FEATURE_SERVICE);
 
@@ -159,20 +148,12 @@ ml_service_get_pipeline (const char *name, char **pipeline_desc)
         "The parameter 'pipeline_desc'. It should be a valid char**");
   }
 
-  mlsp = _get_mlsp_proxy_new_for_bus_sync ();
-  if (!mlsp) {
-    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
-  }
-
-  result = machinelearning_service_pipeline_call_get_pipeline_sync (mlsp, name,
-      &ret, pipeline_desc, NULL, &err);
-
-  g_object_unref (mlsp);
-
-  if (!result) {
+  ret =
+      ml_agent_dbus_interface_pipeline_get_description (name, pipeline_desc,
+      &err);
+  if (ret < 0) {
     _ml_error_report ("Failed to invoke the method get_pipeline (%s).",
         err ? err->message : "Unknown error");
-    ret = ML_ERROR_IO_ERROR;
   }
   g_clear_error (&err);
 
@@ -186,9 +167,7 @@ int
 ml_service_delete_pipeline (const char *name)
 {
   int ret = ML_ERROR_NONE;
-  MachinelearningServicePipeline *mlsp;
   GError *err = NULL;
-  gboolean result;
 
   check_feature_state (ML_FEATURE_SERVICE);
 
@@ -197,20 +176,10 @@ ml_service_delete_pipeline (const char *name)
         "The parameter, 'name' is NULL, It should be a valid string");
   }
 
-  mlsp = _get_mlsp_proxy_new_for_bus_sync ();
-  if (!mlsp) {
-    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
-  }
-
-  result = machinelearning_service_pipeline_call_delete_pipeline_sync (mlsp,
-      name, &ret, NULL, &err);
-
-  g_object_unref (mlsp);
-
-  if (!result) {
+  ret = ml_agent_dbus_interface_pipeline_delete (name, &err);
+  if (ret < 0) {
     _ml_error_report ("Failed to invoke the method delete_pipeline (%s).",
         err ? err->message : "Unknown error");
-    ret = ML_ERROR_IO_ERROR;
   }
   g_clear_error (&err);
 
@@ -224,12 +193,10 @@ int
 ml_service_launch_pipeline (const char *name, ml_service_h * h)
 {
   int ret = ML_ERROR_NONE;
+  GError *err = NULL;
   ml_service_s *mls;
   _ml_service_server_s *server;
   gint64 out_id;
-  MachinelearningServicePipeline *mlsp;
-  GError *err = NULL;
-  gboolean result;
 
   check_feature_state (ML_FEATURE_SERVICE);
 
@@ -237,26 +204,12 @@ ml_service_launch_pipeline (const char *name, ml_service_h * h)
     _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
         "The parameter, 'h' is NULL. It should be a valid ml_service_h");
 
-  mlsp = _get_mlsp_proxy_new_for_bus_sync ();
-  if (!mlsp) {
-    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
-  }
-
-  result = machinelearning_service_pipeline_call_launch_pipeline_sync (mlsp,
-      name, &ret, &out_id, NULL, &err);
-
-  g_object_unref (mlsp);
-
-  if (!result) {
+  ret = ml_agent_dbus_interface_pipeline_launch (name, &out_id, &err);
+  if (ret < 0) {
     _ml_error_report ("Failed to invoke the method launch_pipeline (%s).",
-        err ? err->message : "Unknown error");
-    ret = ML_ERROR_IO_ERROR;
-  }
-  g_clear_error (&err);
-
-  if (ML_ERROR_NONE != ret) {
-    _ml_error_report_return (ret,
-        "Failed to launch pipeline, please check its integrity.");
+        (err ? err->message : "Unknown error"));
+    g_clear_error (&err);
+    return ret;
   }
 
   mls = g_new0 (ml_service_s, 1);
@@ -287,9 +240,7 @@ ml_service_start_pipeline (ml_service_h h)
   int ret = ML_ERROR_NONE;
   ml_service_s *mls = (ml_service_s *) h;
   _ml_service_server_s *server;
-  MachinelearningServicePipeline *mlsp;
   GError *err = NULL;
-  gboolean result;
 
   check_feature_state (ML_FEATURE_SERVICE);
 
@@ -297,21 +248,11 @@ ml_service_start_pipeline (ml_service_h h)
     _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
         "The parameter, 'h' is NULL. It should be a valid ml_service_h");
 
-  mlsp = _get_mlsp_proxy_new_for_bus_sync ();
-  if (!mlsp) {
-    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
-  }
-
   server = (_ml_service_server_s *) mls->priv;
-  result = machinelearning_service_pipeline_call_start_pipeline_sync (mlsp,
-      server->id, &ret, NULL, &err);
-
-  g_object_unref (mlsp);
-
-  if (!result) {
+  ret = ml_agent_dbus_interface_pipeline_start (server->id, &err);
+  if (ret < 0) {
     _ml_error_report ("Failed to invoke the method start_pipeline (%s).",
         err ? err->message : "Unknown error");
-    ret = ML_ERROR_IO_ERROR;
   }
   g_clear_error (&err);
 
@@ -327,9 +268,7 @@ ml_service_stop_pipeline (ml_service_h h)
   int ret = ML_ERROR_NONE;
   ml_service_s *mls = (ml_service_s *) h;
   _ml_service_server_s *server;
-  MachinelearningServicePipeline *mlsp;
   GError *err = NULL;
-  gboolean result;
 
   check_feature_state (ML_FEATURE_SERVICE);
 
@@ -337,21 +276,11 @@ ml_service_stop_pipeline (ml_service_h h)
     _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
         "The parameter, 'h' is NULL. It should be a valid ml_service_h");
 
-  mlsp = _get_mlsp_proxy_new_for_bus_sync ();
-  if (!mlsp) {
-    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
-  }
-
   server = (_ml_service_server_s *) mls->priv;
-  result = machinelearning_service_pipeline_call_stop_pipeline_sync (mlsp,
-      server->id, &ret, NULL, &err);
-
-  g_object_unref (mlsp);
-
-  if (!result) {
+  ret = ml_agent_dbus_interface_pipeline_stop (server->id, &err);
+  if (ret < 0) {
     _ml_error_report ("Failed to invoke the method stop_pipeline (%s).",
         err ? err->message : "Unknown error");
-    ret = ML_ERROR_IO_ERROR;
   }
   g_clear_error (&err);
 
@@ -368,9 +297,7 @@ ml_service_get_pipeline_state (ml_service_h h, ml_pipeline_state_e * state)
   gint _state = ML_PIPELINE_STATE_UNKNOWN;
   ml_service_s *mls = (ml_service_s *) h;
   _ml_service_server_s *server;
-  MachinelearningServicePipeline *mlsp;
   GError *err = NULL;
-  gboolean result;
 
   check_feature_state (ML_FEATURE_SERVICE);
 
@@ -382,26 +309,15 @@ ml_service_get_pipeline_state (ml_service_h h, ml_pipeline_state_e * state)
     _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
         "The parameter, 'state' is NULL. It should be a valid ml_pipeline_state_e pointer");
 
-  mlsp = _get_mlsp_proxy_new_for_bus_sync ();
-  if (!mlsp) {
-    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
-  }
-
   server = (_ml_service_server_s *) mls->priv;
-  result = machinelearning_service_pipeline_call_get_state_sync (mlsp,
-      server->id, &ret, &_state, NULL, &err);
-
-  *state = (ml_pipeline_state_e) _state;
-
-  g_object_unref (mlsp);
-
-  if (!result) {
+  ret = ml_agent_dbus_interface_pipeline_get_state (server->id, &_state, &err);
+  if (ret < 0) {
     _ml_error_report ("Failed to invoke the method get_state (%s).",
         err ? err->message : "Unknown error");
-    ret = ML_ERROR_IO_ERROR;
   }
   g_clear_error (&err);
 
+  *state = (ml_pipeline_state_e) _state;
   return ret;
 }
 
@@ -414,10 +330,8 @@ ml_service_model_register (const char *name, const char *path,
 {
   int ret = ML_ERROR_NONE;
 
-  MachinelearningServiceModel *mlsm;
+  g_autofree gchar *dir_name = NULL;
   GError *err = NULL;
-  gboolean result;
-  gchar *dir_name;
   GStatBuf statbuf;
 
   g_autofree gchar *app_info = NULL;
@@ -442,15 +356,14 @@ ml_service_model_register (const char *name, const char *path,
 
   dir_name = g_path_get_dirname (path);
   ret = g_stat (dir_name, &statbuf);
-  g_free (dir_name);
-
-  if (ret != 0)
+  if (ret != 0) {
     _ml_error_report_return (ML_ERROR_PERMISSION_DENIED,
         "Failed to get the information of the model file '%s'.", path);
+  }
 
-  if (!g_path_is_absolute (path) ||
-      !g_file_test (path, (G_FILE_TEST_EXISTS | G_FILE_TEST_IS_REGULAR)) ||
-      g_file_test (path, G_FILE_TEST_IS_SYMLINK))
+  if (!g_path_is_absolute (path)
+      || !g_file_test (path, (G_FILE_TEST_EXISTS | G_FILE_TEST_IS_REGULAR))
+      || g_file_test (path, G_FILE_TEST_IS_SYMLINK))
     _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
         "The model file '%s' is not a regular file.", path);
 
@@ -480,7 +393,7 @@ ml_service_model_register (const char *name, const char *path,
    *   _ml_error_report_return (ML_ERROR_PERMISSION_DENIED,
    *      "The model file '%s' is not in the app's resource directory.", path);
    * }
-  */
+   */
 
   builder = json_builder_new ();
   json_builder_begin_object (builder);
@@ -500,23 +413,11 @@ ml_service_model_register (const char *name, const char *path,
   app_info = json_generator_to_data (gen, NULL);
 app_info_exit:
 #endif
-
-  mlsm = _get_mlsm_proxy_new_for_bus_sync ();
-  if (!mlsm) {
-    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
-  }
-
-  result =
-      machinelearning_service_model_call_register_sync (mlsm, name, path,
-      activate, description ? description : "", app_info ? app_info : "",
-      version, &ret, NULL, &err);
-
-  g_object_unref (mlsm);
-
-  if (!result) {
+  ret = ml_agent_dbus_interface_model_register (name, path, activate,
+      description ? description : "", app_info ? app_info : "", version, &err);
+  if (ret < 0) {
     _ml_error_report ("Failed to invoke the method register (%s).",
         err ? err->message : "Unknown error");
-    ret = ML_ERROR_IO_ERROR;
   }
   g_clear_error (&err);
 
@@ -532,9 +433,7 @@ ml_service_model_update_description (const char *name,
 {
   int ret = ML_ERROR_NONE;
 
-  MachinelearningServiceModel *mlsm;
   GError *err = NULL;
-  gboolean result;
 
   check_feature_state (ML_FEATURE_SERVICE);
 
@@ -550,22 +449,14 @@ ml_service_model_update_description (const char *name,
     _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
         "The parameter, 'description' is NULL. It should be a valid string");
 
-  mlsm = _get_mlsm_proxy_new_for_bus_sync ();
-  if (!mlsm) {
-    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
-  }
+  ret =
+      ml_agent_dbus_interface_model_update_description (name, version,
+      description, &err);
 
-  result = machinelearning_service_model_call_update_description_sync (mlsm,
-      name, version, description, &ret, NULL, &err);
-
-  g_object_unref (mlsm);
-
-  if (!result) {
+  if (ret < 0) {
     _ml_error_report ("Failed to invoke the method update_description (%s).",
         err ? err->message : "Unknown error");
-    ret = ML_ERROR_IO_ERROR;
   }
-
   g_clear_error (&err);
 
   return ret;
@@ -579,9 +470,7 @@ ml_service_model_activate (const char *name, const unsigned int version)
 {
   int ret = ML_ERROR_NONE;
 
-  MachinelearningServiceModel *mlsm;
   GError *err = NULL;
-  gboolean result;
 
   check_feature_state (ML_FEATURE_SERVICE);
 
@@ -593,22 +482,11 @@ ml_service_model_activate (const char *name, const unsigned int version)
     _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
         "The parameter, 'version' is 0. It should be a valid unsigned int");
 
-  mlsm = _get_mlsm_proxy_new_for_bus_sync ();
-  if (!mlsm) {
-    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
-  }
-
-  result = machinelearning_service_model_call_activate_sync (mlsm,
-      name, version, &ret, NULL, &err);
-
-  g_object_unref (mlsm);
-
-  if (!result) {
+  ret = ml_agent_dbus_interface_model_activate (name, version, &err);
+  if (ret < 0) {
     _ml_error_report ("Failed to invoke the method activate (%s).",
         err ? err->message : "Unknown error");
-    ret = ML_ERROR_IO_ERROR;
   }
-
   g_clear_error (&err);
 
   return ret;
@@ -624,9 +502,7 @@ ml_service_model_get (const char *name, const unsigned int version,
   int ret = ML_ERROR_NONE;
 
   ml_option_h _info = NULL;
-  MachinelearningServiceModel *mlsm;
   GError *err = NULL;
-  gboolean result;
   gchar *description = NULL;
 
   JsonParser *parser = NULL;
@@ -646,21 +522,11 @@ ml_service_model_get (const char *name, const unsigned int version,
     _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
         "The parameter, 'info' is NULL. It should be a valid pointer to ml_info_h");
 
-  mlsm = _get_mlsm_proxy_new_for_bus_sync ();
-  if (!mlsm) {
-    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
-  }
-
-  result = machinelearning_service_model_call_get_sync (mlsm,
-      name, version, &description, &ret, NULL, &err);
-
-  g_object_unref (mlsm);
-
-  if (!result) {
+  ret = ml_agent_dbus_interface_model_get (name, version, &description, &err);
+  if (ret < 0) {
     _ml_error_report ("Failed to invoke the method get_activated (%s).",
         err ? err->message : "Unknown error");
     g_clear_error (&err);
-    ret = ML_ERROR_IO_ERROR;
     goto error;
   }
 
@@ -733,11 +599,8 @@ ml_service_model_get_activated (const char *name, ml_option_h * info)
   int ret = ML_ERROR_NONE;
 
   ml_option_h _info = NULL;
-  MachinelearningServiceModel *mlsm;
   GError *err = NULL;
-  gboolean result;
   g_autofree gchar *description = NULL;
-
   g_autoptr (JsonParser) parser = NULL;
   JsonObjectIter iter;
   JsonNode *root_node;
@@ -755,21 +618,11 @@ ml_service_model_get_activated (const char *name, ml_option_h * info)
     _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
         "The parameter, 'info' is NULL. It should be a valid pointer to ml_info_h");
 
-  mlsm = _get_mlsm_proxy_new_for_bus_sync ();
-  if (!mlsm) {
-    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
-  }
-
-  result = machinelearning_service_model_call_get_activated_sync (mlsm,
-      name, &description, &ret, NULL, &err);
-
-  g_object_unref (mlsm);
-
-  if (!result) {
+  ret = ml_agent_dbus_interface_model_get_activated (name, &description, &err);
+  if (ret < 0) {
     _ml_error_report ("Failed to invoke the method get_activated (%s).",
         err ? err->message : "Unknown error");
     g_clear_error (&err);
-    ret = ML_ERROR_IO_ERROR;
     goto error;
   }
 
@@ -839,9 +692,7 @@ ml_service_model_get_all (const char *name, ml_option_h * info_list[],
   int ret = ML_ERROR_NONE;
 
   ml_option_h *_info_list = NULL;
-  MachinelearningServiceModel *mlsm;
   GError *err = NULL;
-  gboolean result;
   gchar *description = NULL;
   guint i, n;
 
@@ -864,21 +715,11 @@ ml_service_model_get_all (const char *name, ml_option_h * info_list[],
 
   *num = 0;
 
-  mlsm = _get_mlsm_proxy_new_for_bus_sync ();
-  if (!mlsm) {
-    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
-  }
-
-  result = machinelearning_service_model_call_get_all_sync (mlsm,
-      name, &description, &ret, NULL, &err);
-
-  g_object_unref (mlsm);
-
-  if (!result) {
+  ret = ml_agent_dbus_interface_model_get_all (name, &description, &err);
+  if (ret < 0) {
     _ml_error_report ("Failed to invoke the method get_activated (%s).",
         err ? err->message : "Unknown error");
     g_clear_error (&err);
-    ret = ML_ERROR_IO_ERROR;
     goto error;
   }
 
@@ -980,9 +821,7 @@ int
 ml_service_model_delete (const char *name, const unsigned int version)
 {
   int ret = ML_ERROR_NONE;
-  MachinelearningServiceModel *mlsm;
   GError *err = NULL;
-  gboolean result;
 
   check_feature_state (ML_FEATURE_SERVICE);
 
@@ -990,22 +829,11 @@ ml_service_model_delete (const char *name, const unsigned int version)
     _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
         "The parameter, 'name' is NULL. It should be a valid string");
 
-  mlsm = _get_mlsm_proxy_new_for_bus_sync ();
-  if (!mlsm) {
-    _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
-  }
-
-  result = machinelearning_service_model_call_delete_sync (mlsm,
-      name, version, &ret, NULL, &err);
-
-  g_object_unref (mlsm);
-
-  if (!result) {
+  ret = ml_agent_dbus_interface_model_delete (name, version, &err);
+  if (ret < 0) {
     _ml_error_report ("Failed to invoke the method delete (%s).",
         err ? err->message : "Unknown error");
-    ret = ML_ERROR_IO_ERROR;
   }
-
   g_clear_error (&err);
 
   return ret;

--- a/c/src/ml-api-service-common.c
+++ b/c/src/ml-api-service-common.c
@@ -13,58 +13,7 @@
 #include "ml-api-internal.h"
 #include "ml-api-service.h"
 #include "ml-api-service-private.h"
-
-/**
- * @brief Internal function to get proxy of the pipeline d-bus interface
- */
-MachinelearningServicePipeline *
-_get_mlsp_proxy_new_for_bus_sync (void)
-{
-  MachinelearningServicePipeline *mlsp;
-
-  /** @todo deal with GError */
-  mlsp = machinelearning_service_pipeline_proxy_new_for_bus_sync
-      (G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE,
-      "org.tizen.machinelearning.service",
-      "/Org/Tizen/MachineLearning/Service/Pipeline", NULL, NULL);
-
-  if (mlsp)
-    return mlsp;
-
-  /** Try with session type */
-  mlsp = machinelearning_service_pipeline_proxy_new_for_bus_sync
-      (G_BUS_TYPE_SESSION, G_DBUS_PROXY_FLAGS_NONE,
-      "org.tizen.machinelearning.service",
-      "/Org/Tizen/MachineLearning/Service/Pipeline", NULL, NULL);
-
-  return mlsp;
-}
-
-/**
- * @brief Internal function to get proxy of the model d-bus interface
- */
-MachinelearningServiceModel *
-_get_mlsm_proxy_new_for_bus_sync (void)
-{
-  MachinelearningServiceModel *mlsm;
-
-  /** @todo deal with GError */
-  mlsm = machinelearning_service_model_proxy_new_for_bus_sync
-      (G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE,
-      "org.tizen.machinelearning.service",
-      "/Org/Tizen/MachineLearning/Service/Model", NULL, NULL);
-
-  if (mlsm)
-    return mlsm;
-
-  /** Try with session type */
-  mlsm = machinelearning_service_model_proxy_new_for_bus_sync
-      (G_BUS_TYPE_SESSION, G_DBUS_PROXY_FLAGS_NONE,
-      "org.tizen.machinelearning.service",
-      "/Org/Tizen/MachineLearning/Service/Model", NULL, NULL);
-
-  return mlsm;
-}
+#include "../../daemon/includes/ml-agent-dbus-interface.h"
 
 /**
  * @brief Destroy the pipeline of given ml_service_h
@@ -82,25 +31,13 @@ ml_service_destroy (ml_service_h h)
         "The parameter, 'h' is NULL. It should be a valid ml_service_h.");
 
   if (ML_SERVICE_TYPE_SERVER_PIPELINE == mls->type) {
-    MachinelearningServicePipeline *mlsp;
     _ml_service_server_s *server = (_ml_service_server_s *) mls->priv;
     GError *err = NULL;
-    gboolean result;
 
-    mlsp = _get_mlsp_proxy_new_for_bus_sync ();
-    if (!mlsp) {
-      _ml_error_report_return (ML_ERROR_IO_ERROR, "Failed to get dbus proxy.");
-    }
-
-    result = machinelearning_service_pipeline_call_destroy_pipeline_sync (mlsp,
-        server->id, &ret, NULL, &err);
-
-    g_object_unref (mlsp);
-
-    if (!result) {
+    ret = ml_agent_dbus_interface_pipeline_destroy (server->id, &err);
+    if (ret < 0) {
       _ml_error_report ("Failed to invoke the method destroy_pipeline (%s).",
           err ? err->message : "Unknown error");
-      ret = ML_ERROR_IO_ERROR;
     }
     g_clear_error (&err);
 

--- a/daemon/includes/meson.build
+++ b/daemon/includes/meson.build
@@ -1,0 +1,1 @@
+ml_agentd_headers = files('ml-agent-dbus-interface.h')

--- a/daemon/includes/ml-agent-dbus-interface.h
+++ b/daemon/includes/ml-agent-dbus-interface.h
@@ -1,0 +1,159 @@
+/**
+ * @file    ml-agent-dbus-interface.h
+ * @date    5 April 2023
+ * @brief   A set of exported DBus interfaces for managing pipelines and models
+ * @see     https://github.com/nnstreamer/api
+ * @author  Wook Song <wook16.song@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#ifndef __ML_AGENT_DBUS_INTERFACE_H__
+#define __ML_AGENT_DBUS_INTERFACE_H__
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#include <glib.h>
+
+/**
+ * @brief A dbus interface exported for setting the description of a pipeline
+ * @param[in] name A name indicating the pipeline whose description would be set
+ * @param[in] pipeline_desc A stringified description of the pipeline
+ * @param[out] err Return location for error of NULL
+ * @return 0 on success, a negative error value if @err is set
+ */
+gint ml_agent_dbus_interface_pipeline_set_description (const gchar *name, const gchar *pipeline_desc, GError **err);
+
+/**
+ * @brief A dbus interface exported for getting the pipeline's description corresponding to the given @name
+ * @param[in] name A given name of the pipeline to get the description
+ * @param[out] pipeline_desc A stringified description of the pipeline
+ * @param[out] err Return location for error of NULL
+ * @return 0 on success, a negative error value if @err is set
+ */
+gint ml_agent_dbus_interface_pipeline_get_description (const gchar *name, gchar **pipeline_desc, GError **err);
+
+/**
+ * @brief A dbus interface exported for deletion of the pipeline's description corresponding to the given @name
+ * @param[in] name A given name of the pipeline to remove the description
+ * @param[out] err Return location for error of NULL
+ * @return 0 on success, a negative error value if @err is set
+ */
+gint ml_agent_dbus_interface_pipeline_delete (const gchar * name, GError ** err);
+
+/**
+ * @brief A dbus interface exported for launching the pipeline's description corresponding to the given @name
+ * @param[in] name A given name of the pipeline to launch
+ * @param[out] id Return an integer identifier for the launched pipeline
+ * @param[out] err Return location for error of NULL
+ * @return 0 on success, a negative error value if @err is set
+ */
+gint ml_agent_dbus_interface_pipeline_launch (const gchar *name, gint64 *id, GError ** err);
+
+/**
+ * @brief A dbus interface exported for changing the pipeline's state of the given @id to start
+ * @param[in] id An identifier of the launched pipeline whose state would be changed to start
+ * @param[out] err Return location for error of NULL
+ * @return 0 on success, a negative error value if @err is set
+ */
+gint ml_agent_dbus_interface_pipeline_start (gint64 id, GError ** err);
+
+/**
+ * @brief A dbus interface exported for changing the pipeline's state of the given @id to stop
+ * @param[in] id An identifier of the launched pipeline whose state would be changed to stop
+ * @param[out] err Return location for error of NULL
+ * @return 0 on success, a negative error value if @err is set
+ */
+gint ml_agent_dbus_interface_pipeline_stop (gint64 id, GError ** err);
+
+/**
+ * @brief A dbus interface exported for destroying a launched pipeline corresponding to the given @id
+ * @param[in] id An identifier of the launched pipeline that would be destroyed
+ * @param[out] err Return location for error of NULL
+ * @return 0 on success, a negative error value if @err is set
+ */
+gint ml_agent_dbus_interface_pipeline_destroy (gint64 id, GError ** err);
+
+/**
+ * @brief A dbus interface exported for getting the pipeline's state of the given @id
+ * @param[in] id An identifier of the launched pipeline that would be destroyed
+ * @param[out] state Return location for the pieline's state
+ * @param[out] err Return location for error of NULL
+ * @return 0 on success, a negative error value if @err is set
+ */
+gint ml_agent_dbus_interface_pipeline_get_state (gint64 id, gint * state, GError ** err);
+
+/**
+ * @brief A dbus interface exported for registering a model
+ * @param[in] name A name indicating the model that would be registered
+ * @param[in] path A path that specifies the location of the model file
+ * @param[in] activate An initial activation state
+ * @param[in] description A stringified description of the given model
+ * @param[in] app_info Application-specific information from Tizen's RPK
+ * @param[out] version Return location for the version of the given model registered
+ * @param[out] err Return location for error of NULL
+ * @return 0 on success, a negative error value if @err is set
+ */
+gint ml_agent_dbus_interface_model_register(const gchar *name, const gchar *path, const gboolean activate, const gchar *description, const gchar *app_info, guint *version, GError ** err);
+
+/**
+ * @brief A dbus interface exported for updating the description of the given model, @name
+ * @param[in] name A name indicating the model whose description would be updated
+ * @param[in] version A version for identifying the model whose description would be updated
+ * @param[in] description A new description to update the existing one
+ * @param[out] err Return location for error of NULL
+ * @return 0 on success, a negative error value if @err is set
+ */
+gint ml_agent_dbus_interface_model_update_description (const gchar *name, const guint version, const gchar *description, GError ** err);
+
+/**
+ * @brief A dbus interface exported for activating the model of @name and @version
+ * @param[in] name A name indicating a registered model
+ * @param[in] version A version of the given model, @name
+ * @param[out] err Return location for error of NULL
+ * @return 0 on success, a negative error value if @err is set
+ */
+gint ml_agent_dbus_interface_model_activate(const gchar *name, const guint version, GError ** err);
+
+/**
+ * @brief A dbus interface exported for getting the description of the given model of @name and @version
+ * @param[in] name A name indicating the model whose description would be get
+ * @param[in] version A version of the given model, @name
+ * @param[out] description Return location for the description of the given model of @name and @version
+ * @param[out] err Return location for error of NULL
+ * @return 0 on success, a negative error value if @err is set
+ */
+gint ml_agent_dbus_interface_model_get(const gchar *name, const guint version, gchar ** description, GError ** err);
+
+/**
+ * @brief A dbus interface exported for getting the description of the activated model of the given @name
+ * @param[in] name A name indicating the model whose description would be get
+ * @param[out] description Return location for the description of an activated model of the given @name
+ * @param[out] err Return location for error of NULL
+ * @return 0 on success, a negative error value if @err is set
+ */
+gint ml_agent_dbus_interface_model_get_activated(const gchar *name, gchar ** description, GError ** err);
+
+/**
+ * @brief A dbus interface exported for getting the description of all the models corresponding to the given @name
+ * @param[in] name A name indicating the models whose description would be get
+ * @param[out] description Return location for the description of all the models corresponding to the given @name
+ * @param[out] err Return location for error of NULL
+ * @return 0 on success, a negative error value if @err is set
+ */
+gint ml_agent_dbus_interface_model_get_all(const gchar *name, gchar ** description, GError ** err);
+
+/**
+ * @brief A dbus interface exported for removing the model of @name and @version
+ * @param[in] name A name indicating the model that would be removed
+ * @param[in] version A version for identifying a specific model whose name is @name
+ * @param[in] description A new description to update the existing one
+ * @param[out] err Return location for error of NULL
+ * @return 0 on success, a negative error value if @err is set
+ */
+gint ml_agent_dbus_interface_model_delete(const gchar *name, const guint version, GError ** err);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* __ML_AGENT_DBUS_INTERFACE_H__ */

--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -1,15 +1,13 @@
 # Machine Learning Agent
 # This file should be included when ml-service feature is enabled.
-nns_ml_agent_incs = include_directories('includes')
-nns_ml_agent_common_srcs = files('main.c', 'modules.c', 'gdbus-util.c',
+ml_agentd_incs = include_directories('includes')
+ml_agentd_lib_common_srcs = files('modules.c', 'gdbus-util.c', 'ml-agent-dbus-interface.c',
   'pipeline-dbus-impl.cc', 'model-dbus-impl.cc')
-nns_ml_agent_service_db_srcs = files('service-db.cc')
+ml_agentd_lib_service_db_srcs = files('service-db.cc')
 
 if (get_option('enable-tizen'))
-  nns_ml_agent_common_srcs += files('pkg-mgr.cc')
+  ml_agentd_lib_common_srcs += files('pkg-mgr.cc')
 endif
-
-nns_ml_agent_srcs = [nns_ml_agent_common_srcs, nns_ml_agent_service_db_srcs]
 
 # Generate GDbus header and code
 gdbus_prog = find_program('gdbus-codegen', required: true)
@@ -31,7 +29,7 @@ gdbus_gen_model_src = custom_target('gdbus-model-gencode',
 
 gdbus_gen_header_dep = declare_dependency(sources: [gdbus_gen_pipeline_src, gdbus_gen_model_src])
 
-ai_service_daemon_deps = [
+ml_agentd_deps = [
   gdbus_gen_header_dep,
   glib_dep,
   gio_dep,
@@ -42,7 +40,7 @@ ai_service_daemon_deps = [
 ]
 
 if (get_option('enable-tizen'))
-  ai_service_daemon_deps += [
+  ml_agentd_deps += [
     dependency('capi-appfw-app-common'),
     dependency('capi-appfw-package-manager'),
     dependency('dlog')
@@ -55,13 +53,44 @@ daemon_cpp_db_path_arg = '-DDB_PATH="' + serviceDBPath + '"'
 serviceDBKeyPrefix = get_option('service-db-key-prefix')
 daemon_cpp_db_key_prefix_arg = '-DMESON_KEY_PREFIX="' + serviceDBKeyPrefix + '"'
 
-nns_ml_agent_executable = executable('machine-learning-agent',
-  nns_ml_agent_srcs,
-  dependencies: [ai_service_daemon_deps],
-  include_directories: nns_ml_agent_incs,
+ml_agentd_lib_srcs = [ml_agentd_lib_common_srcs, ml_agentd_lib_service_db_srcs]
+ml_agentd_shared_lib = shared_library ('ml-agentd',
+  ml_agentd_lib_srcs,
+  dependencies: ml_agentd_deps,
+  include_directories: ml_agentd_incs,
+  install: true,
+  install_dir: api_install_libdir,
+  cpp_args: [daemon_cpp_db_path_arg, daemon_cpp_db_key_prefix_arg],
+  version: api_version,
+)
+ml_agentd_static_lib = static_library('ml-agentd',
+  ml_agentd_lib_srcs,
+  dependencies: ml_agentd_deps,
+  include_directories: ml_agentd_incs,
+  install: true,
+  install_dir: api_install_libdir,
+  cpp_args: [daemon_cpp_db_path_arg, daemon_cpp_db_key_prefix_arg],
+  pic: true,
+)
+
+ml_agentd_lib = ml_agentd_shared_lib
+if get_option('default_library') == 'static'
+    ml_agentd_lib = ml_agentd_static_lib
+endif
+
+subdir('includes')
+install_headers(ml_agentd_headers,
+  subdir: 'ml-agentd'
+)
+
+ml_agentd_main_file = files('main.c')
+ml_agent_executable = executable('machine-learning-agent',
+  ml_agentd_main_file,
+  link_with: ml_agentd_lib,
+  dependencies: ml_agentd_deps,
+  include_directories: ml_agentd_incs,
   install: true,
   install_dir: api_install_bindir,
-  cpp_args: [daemon_cpp_db_path_arg, daemon_cpp_db_key_prefix_arg],
   pie: true
 )
 

--- a/daemon/ml-agent-dbus-interface.c
+++ b/daemon/ml-agent-dbus-interface.c
@@ -1,0 +1,494 @@
+/**
+ * @file    ml-agent-dbus-interface.c
+ * @date    5 April 2023
+ * @brief   A set of exported DBus interfaces for managing pipelines and models
+ * @see     https://github.com/nnstreamer/api
+ * @author  Wook Song <wook16.song@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#include "includes/ml-agent-dbus-interface.h"
+#include "includes/dbus-interface.h"
+#include "model-dbus.h"
+#include "pipeline-dbus.h"
+
+#include <glib.h>
+
+typedef enum
+{
+  ML_AGENT_DBUS_SERVICE_PIPELINE = 0,
+  ML_AGENT_DBUS_SERVICE_MODEL,
+  ML_AGENT_DBUS_SERVICE_END,
+} ml_agent_dbus_service_type_e;
+
+typedef gpointer ml_agent_dbus_proxy_h;
+
+/**
+ * @brief An internal helper to get the dbus proxy
+ */
+static ml_agent_dbus_proxy_h
+_get_proxy_new_for_bus_sync (ml_agent_dbus_service_type_e type, GError ** err)
+{
+  static const GBusType bus_types[] = { G_BUS_TYPE_SYSTEM, G_BUS_TYPE_SESSION };
+  static const size_t num_bus_types =
+      sizeof (bus_types) / sizeof (bus_types[0]);
+  ml_agent_dbus_proxy_h *proxy = NULL;
+  GError *_err = NULL;
+  size_t i;
+
+  switch (type) {
+    case ML_AGENT_DBUS_SERVICE_PIPELINE:
+    {
+      MachinelearningServicePipeline *mlsp;
+
+      for (i = 0; i < num_bus_types; ++i) {
+        g_clear_error (&_err);
+        mlsp =
+            machinelearning_service_pipeline_proxy_new_for_bus_sync (bus_types
+            [i], G_DBUS_PROXY_FLAGS_NONE, DBUS_ML_BUS_NAME, DBUS_PIPELINE_PATH,
+            NULL, &_err);
+        if (mlsp) {
+          break;
+        }
+      }
+      proxy = (ml_agent_dbus_proxy_h *) mlsp;
+      break;
+    }
+    case ML_AGENT_DBUS_SERVICE_MODEL:
+    {
+      MachinelearningServiceModel *mlsm;
+
+      for (i = 0; i < num_bus_types; ++i) {
+        g_clear_error (&_err);
+
+        mlsm =
+            machinelearning_service_model_proxy_new_for_bus_sync (bus_types[i],
+            G_DBUS_PROXY_FLAGS_NONE, DBUS_ML_BUS_NAME, DBUS_MODEL_PATH, NULL,
+            &_err);
+        if (mlsm)
+          break;
+      }
+      proxy = (ml_agent_dbus_proxy_h *) mlsm;
+      break;
+    }
+    default:
+      break;
+  }
+
+  if (_err) {
+    *err = g_error_copy (_err);
+    g_clear_error (&_err);
+  }
+
+  return proxy;
+}
+
+/**
+ * @brief A dbus interface exported for setting the description of a pipeline
+ */
+gint
+ml_agent_dbus_interface_pipeline_set_description (const gchar * name,
+    const gchar * pipeline_desc, GError ** err)
+{
+  MachinelearningServicePipeline *mlsp;
+  gboolean result;
+
+  if (!name || !pipeline_desc) {
+    g_return_val_if_reached (-EINVAL);
+  }
+
+  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_DBUS_SERVICE_PIPELINE, err);
+  if (!mlsp) {
+    g_return_val_if_reached (-EIO);
+  }
+
+  result =
+      machinelearning_service_pipeline_call_set_pipeline_sync
+      (MACHINELEARNING_SERVICE_PIPELINE (mlsp), name, pipeline_desc, NULL, NULL,
+      err);
+  g_object_unref (mlsp);
+  g_return_val_if_fail (result, -EIO);
+
+  return 0;
+}
+
+/**
+ * @brief A dbus interface exported for getting the pipeline's description corresponding to the given @name
+ */
+gint
+ml_agent_dbus_interface_pipeline_get_description (const gchar * name,
+    gchar ** pipeline_desc, GError ** err)
+{
+  MachinelearningServicePipeline *mlsp;
+  gboolean result;
+  gint ret;
+
+  if (!name || !pipeline_desc) {
+    g_return_val_if_reached (-EINVAL);
+  }
+
+  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_DBUS_SERVICE_PIPELINE, err);
+  if (!mlsp) {
+    g_return_val_if_reached (-EIO);
+  }
+
+  result =
+      machinelearning_service_pipeline_call_get_pipeline_sync
+      (MACHINELEARNING_SERVICE_PIPELINE (mlsp), name, &ret, pipeline_desc, NULL,
+      err);
+  g_object_unref (mlsp);
+
+  g_return_val_if_fail (ret == 0 && result, ret);
+
+  return 0;
+}
+
+/**
+ * @brief A dbus interface exported for deletion of the pipeline's description corresponding to the given @name
+ */
+gint
+ml_agent_dbus_interface_pipeline_delete (const gchar * name, GError ** err)
+{
+  MachinelearningServicePipeline *mlsp;
+  gboolean result;
+  gint ret;
+
+  if (!name) {
+    g_return_val_if_reached (-EINVAL);
+  }
+
+  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_DBUS_SERVICE_PIPELINE, err);
+  if (!mlsp) {
+    g_return_val_if_reached (-EIO);
+  }
+
+  result =
+      machinelearning_service_pipeline_call_delete_pipeline_sync
+      (MACHINELEARNING_SERVICE_PIPELINE (mlsp), name, &ret, NULL, err);
+  g_object_unref (mlsp);
+
+  g_return_val_if_fail (ret == 0 && result, ret);
+
+  return 0;
+}
+
+/**
+ * @brief A dbus interface exported for launching the pipeline's description corresponding to the given @name
+ */
+gint
+ml_agent_dbus_interface_pipeline_launch (const gchar * name, gint64 * id,
+    GError ** err)
+{
+  MachinelearningServicePipeline *mlsp;
+  gboolean result;
+  gint ret;
+
+  if (!name) {
+    g_return_val_if_reached (-EINVAL);
+  }
+
+  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_DBUS_SERVICE_PIPELINE, err);
+  if (!mlsp) {
+    g_return_val_if_reached (-EIO);
+  }
+
+  result =
+      machinelearning_service_pipeline_call_launch_pipeline_sync (mlsp, name,
+      &ret, id, NULL, err);
+  g_object_unref (mlsp);
+
+  g_return_val_if_fail (ret == 0 && result, ret);
+
+  return 0;
+}
+
+/**
+ * @brief A dbus interface exported for changing the pipeline's state of the given @id to start
+ */
+gint
+ml_agent_dbus_interface_pipeline_start (gint64 id, GError ** err)
+{
+  MachinelearningServicePipeline *mlsp;
+  gboolean result;
+  gint ret;
+
+  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_DBUS_SERVICE_PIPELINE, err);
+  if (!mlsp) {
+    g_return_val_if_reached (-EIO);
+  }
+
+  result =
+      machinelearning_service_pipeline_call_start_pipeline_sync (mlsp, id, &ret,
+      NULL, err);
+  g_object_unref (mlsp);
+
+  g_return_val_if_fail (ret == 0 && result, ret);
+
+  return 0;
+}
+
+/**
+ * @brief A dbus interface exported for changing the pipeline's state of the given @id to stop
+ */
+gint
+ml_agent_dbus_interface_pipeline_stop (gint64 id, GError ** err)
+{
+  MachinelearningServicePipeline *mlsp;
+  gboolean result;
+  gint ret;
+
+  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_DBUS_SERVICE_PIPELINE, err);
+  if (!mlsp) {
+    g_return_val_if_reached (-EIO);
+  }
+
+  result =
+      machinelearning_service_pipeline_call_stop_pipeline_sync (mlsp, id, &ret,
+      NULL, err);
+  g_object_unref (mlsp);
+
+  g_return_val_if_fail (ret == 0 && result, ret);
+
+  return 0;
+}
+
+/**
+ * @brief A dbus interface exported for destroying a launched pipeline corresponding to the given @id
+ */
+gint
+ml_agent_dbus_interface_pipeline_destroy (gint64 id, GError ** err)
+{
+  MachinelearningServicePipeline *mlsp;
+
+  gboolean result;
+  gint ret;
+
+  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_DBUS_SERVICE_PIPELINE, err);
+  if (!mlsp) {
+    g_return_val_if_reached (-EIO);
+  }
+
+  result =
+      machinelearning_service_pipeline_call_destroy_pipeline_sync (mlsp, id,
+      &ret, NULL, err);
+  g_object_unref (mlsp);
+
+  g_return_val_if_fail (ret == 0 && result, ret);
+
+  return 0;
+}
+
+/**
+ * @brief A dbus interface exported for getting the pipeline's state of the given @id
+ */
+gint
+ml_agent_dbus_interface_pipeline_get_state (gint64 id, gint * state,
+    GError ** err)
+{
+  MachinelearningServicePipeline *mlsp;
+
+  gboolean result;
+  gint ret;
+
+  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_DBUS_SERVICE_PIPELINE, err);
+  if (!mlsp) {
+    g_return_val_if_reached (-EIO);
+  }
+
+  result =
+      machinelearning_service_pipeline_call_get_state_sync (mlsp, id, &ret,
+      state, NULL, err);
+  g_object_unref (mlsp);
+
+  g_return_val_if_fail (ret == 0 && result, ret);
+
+  return 0;
+}
+
+
+/**
+ * @brief A dbus interface exported for registering a model
+ */
+gint
+ml_agent_dbus_interface_model_register (const gchar * name, const gchar * path,
+    const gboolean activate, const gchar * description, const gchar *app_info,
+    guint * version, GError ** err)
+{
+  MachinelearningServiceModel *mlsm;
+
+  gboolean result;
+  gint ret;
+
+  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_DBUS_SERVICE_MODEL, err);
+  if (!mlsm) {
+    g_return_val_if_reached (-EIO);
+  }
+
+  result = machinelearning_service_model_call_register_sync (mlsm, name, path,
+      activate, description ? description : "", app_info ? app_info : "",
+      version, &ret, NULL, err);
+  g_object_unref (mlsm);
+
+  g_return_val_if_fail (ret == 0 && result, ret);
+
+  return 0;
+}
+
+/**
+ * @brief A dbus interface exported for updating the description of the given model, @name
+ */
+gint
+ml_agent_dbus_interface_model_update_description (const gchar * name,
+    const guint version, const gchar * description, GError ** err)
+{
+  MachinelearningServiceModel *mlsm;
+
+  gboolean result;
+  gint ret;
+
+  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_DBUS_SERVICE_MODEL, err);
+  if (!mlsm) {
+    g_return_val_if_reached (-EIO);
+  }
+
+  result =
+      machinelearning_service_model_call_update_description_sync (mlsm, name,
+      version, description, &ret, NULL, err);
+  g_object_unref (mlsm);
+
+  g_return_val_if_fail (ret == 0 && result, ret);
+
+  return 0;
+}
+
+/**
+ * @brief A dbus interface exported for activating the model of @name and @version
+ */
+gint
+ml_agent_dbus_interface_model_activate (const gchar * name, const guint version,
+    GError ** err)
+{
+  MachinelearningServiceModel *mlsm;
+
+  gboolean result;
+  gint ret;
+
+  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_DBUS_SERVICE_MODEL, err);
+  if (!mlsm) {
+    g_return_val_if_reached (-EIO);
+  }
+
+  result =
+      machinelearning_service_model_call_activate_sync (mlsm, name, version,
+      &ret, NULL, err);
+  g_object_unref (mlsm);
+
+  g_return_val_if_fail (ret == 0 && result, ret);
+
+  return 0;
+}
+
+/**
+ * @brief A dbus interface exported for getting the description of the given model of @name and @version
+ */
+gint
+ml_agent_dbus_interface_model_get (const gchar * name, const guint version,
+    gchar ** description, GError ** err)
+{
+  MachinelearningServiceModel *mlsm;
+
+  gboolean result;
+  gint ret;
+
+  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_DBUS_SERVICE_MODEL, err);
+  if (!mlsm) {
+    g_return_val_if_reached (-EIO);
+  }
+
+  result =
+      machinelearning_service_model_call_get_sync (mlsm, name, version,
+      description, &ret, NULL, err);
+  g_object_unref (mlsm);
+
+  g_return_val_if_fail (ret == 0 && result, ret);
+
+  return 0;
+}
+
+/**
+ * @brief A dbus interface exported for getting the description of the activated model of the given @name
+ */
+gint
+ml_agent_dbus_interface_model_get_activated (const gchar * name,
+    gchar ** description, GError ** err)
+{
+  MachinelearningServiceModel *mlsm;
+  gboolean result;
+  gint ret;
+
+  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_DBUS_SERVICE_MODEL, err);
+  if (!mlsm) {
+    g_return_val_if_reached (-EIO);
+  }
+
+  result =
+      machinelearning_service_model_call_get_activated_sync (mlsm, name,
+      description, &ret, NULL, err);
+  g_object_unref (mlsm);
+
+  g_return_val_if_fail (ret == 0 && result, ret);
+
+  return 0;
+}
+
+/**
+ * @brief  A dbus interface exported for getting the description of all the models corresponding to the given @name
+ */
+gint
+ml_agent_dbus_interface_model_get_all (const gchar * name, gchar ** description,
+    GError ** err)
+{
+  MachinelearningServiceModel *mlsm;
+  gboolean result;
+  gint ret;
+
+  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_DBUS_SERVICE_MODEL, err);
+  if (!mlsm) {
+    g_return_val_if_reached (-EIO);
+  }
+
+  result =
+      machinelearning_service_model_call_get_all_sync (mlsm, name, description,
+      &ret, NULL, err);
+  g_object_unref (mlsm);
+
+  g_return_val_if_fail (ret == 0 && result, ret);
+
+  return 0;
+}
+
+/**
+ * @brief A dbus interface exported for removing the model of @name and @version
+ */
+gint
+ml_agent_dbus_interface_model_delete (const gchar * name, const guint version,
+    GError ** err)
+{
+  MachinelearningServiceModel *mlsm;
+  gboolean result;
+  gint ret;
+
+  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_DBUS_SERVICE_MODEL, err);
+  if (!mlsm) {
+    g_return_val_if_reached (-EIO);
+  }
+
+  result =
+      machinelearning_service_model_call_delete_sync (mlsm, name, version, &ret,
+      NULL, err);
+  g_object_unref (mlsm);
+
+  g_return_val_if_fail (ret == 0 && result, ret);
+
+  return 0;
+}

--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -233,10 +233,23 @@ Requires:	capi-machine-learning-inference-devel = %{version}-%{release}
 Tizen internal headers for Tizen Machine Learning API.
 
 %if 0%{?enable_ml_service}
+%package -n libmachine-learning-agent
+Summary:	Library that exports interfaces provided by Machine Learning Agent Service
+Group:		Machine Learning/ML Framework = %{version}-%{release}
+%description -n libmachine-learning-agent
+Shared library to export interfaces provided by the Machine Learning Agent Service.
+
+%package -n libmachine-learning-agent-devel
+Summary:	Development headers and static library for interfaces provided by Machine Learning Agent Service
+Group:		Machine Learning/ML Framework
+Requires:	libmachine-learning-agent  = %{version}-%{release}
+%description -n libmachine-learning-agent-devel
+Development headers and static library for interfaces provided by Machine Learning Agent Service.
+
 %package -n machine-learning-agent
 Summary:    AI Service Daemon
 Group:		Machine Learning/ML Framework
-Requires:	capi-machine-learning-service = %{version}-%{release}
+Requires:	libmachine-learning-agent = %{version}-%{release}
 %description -n machine-learning-agent
 AI Service Daemon
 
@@ -481,6 +494,18 @@ install -m 0755 packaging/run-unittest.sh %{buildroot}%{_bindir}/tizen-unittests
 %{_includedir}/nnstreamer/nnstreamer-tizen-internal.h
 
 %if 0%{?enable_ml_service}
+%files -n libmachine-learning-agent
+%manifest machine-learning-agent.manifest
+%{_libdir}/libml-agentd.so.*
+
+#TODO: Need to provide a pkg-config file
+%files -n libmachine-learning-agent-devel
+%manifest machine-learning-agent.manifest
+%{_libdir}/libml-agentd.so
+%{_libdir}/libml-agentd.a
+%{_includedir}/ml-agentd/ml-agent-dbus-interface.h
+
+
 %files -n machine-learning-agent
 %manifest machine-learning-agent.manifest
 %attr(0755,root,root) %{_bindir}/machine-learning-agent

--- a/tests/capi/meson.build
+++ b/tests/capi/meson.build
@@ -34,10 +34,11 @@ test('unittest_capi_datatype_consistency', unittest_capi_datatype_consistency, e
 if get_option('enable-ml-service')
   unittest_capi_service_agent_client = executable('unittest_capi_service_agent_client',
     'unittest_capi_service_agent_client.cc',
-    dependencies: [unittest_common_dep, nns_capi_service_dep, gdbus_test_gen_dep],
+    link_with: nns_capi_service_lib,
+    dependencies: [unittest_common_dep, gdbus_gen_test_dep],
     install: get_option('install-test'),
     install_dir: unittest_install_dir,
-    include_directories: [nns_capi_include, nns_ml_agent_incs],
+    include_directories: [nns_capi_include, ml_agentd_incs],
   )
   test('unittest_capi_service_agent_client', unittest_capi_service_agent_client, env: testenv, timeout: 100)
 endif

--- a/tests/daemon/meson.build
+++ b/tests/daemon/meson.build
@@ -1,9 +1,9 @@
 unittest_ml_agent = executable('unittest_ml_agent',
   'unittest_ml_agent.cc',
-  dependencies: [unittest_common_dep, ai_service_daemon_deps, gdbus_test_gen_dep],
+  dependencies: [unittest_common_dep, ml_agentd_deps, gdbus_gen_test_dep],
   install: get_option('install-test'),
   install_dir: unittest_install_dir,
-  include_directories: [nns_capi_include, nns_ml_agent_incs]
+  include_directories: [nns_capi_include, ml_agentd_incs]
 )
 test('unittest_ml_agent', unittest_ml_agent, env: testenv, timeout: 100)
 
@@ -12,6 +12,6 @@ unittest_service_db = executable('unittest_service_db',
   dependencies: [unittest_common_dep, service_db_dep_for_test],
   install: get_option('install-test'),
   install_dir: unittest_install_dir,
-  include_directories: [nns_capi_include, nns_ml_agent_incs],
+  include_directories: [nns_capi_include, ml_agentd_incs],
 )
 test('unittest_service_db', unittest_service_db, env: testenv, timeout: 100)

--- a/tests/dbus/meson.build
+++ b/tests/dbus/meson.build
@@ -8,6 +8,6 @@ gdbus_gen_test_src = custom_target('gdbus-gencode-test',
             '--generate-c-code', 'test-dbus',
             '--output-directory', meson.current_build_dir(),
             '@INPUT@'])
-gdbus_test_gen_dep = declare_dependency(sources: gdbus_gen_test_src,
+gdbus_gen_test_dep = declare_dependency(sources: gdbus_gen_test_src,
     dependencies: gdbus_gen_header_dep)
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -26,20 +26,20 @@ if get_option('enable-ml-service')
 
   test_db_config_args = declare_dependency(
     compile_args: ['-DDB_PATH="."', daemon_cpp_db_key_prefix_arg])
-
-  nns_ml_agent_common_objs = nns_ml_agent_executable.extract_objects(nns_ml_agent_common_srcs)
+  ml_agentd_main_objs = ml_agent_executable.extract_objects(ml_agentd_main_file)
+  ml_agentd_common_objs = ml_agentd_lib.extract_objects(ml_agentd_lib_common_srcs)
   executable('machine-learning-agent-test',
-    [nns_ml_agent_service_db_srcs, test_dbus_impl_srcs],
-    dependencies: [ai_service_daemon_deps, gdbus_test_gen_dep, test_db_config_args],
-    include_directories: nns_ml_agent_incs,
+    [ml_agentd_lib_service_db_srcs, test_dbus_impl_srcs],
+    dependencies: [ml_agentd_deps, gdbus_gen_test_dep, test_db_config_args],
+    include_directories: ml_agentd_incs,
     link_with: lib_unittest_mock,
-    objects: [nns_ml_agent_common_objs]
+    objects: [ml_agentd_common_objs, ml_agentd_main_objs],
   )
 
   service_db_dep_for_test = declare_dependency(
-    sources: nns_ml_agent_service_db_srcs,
+    sources: ml_agentd_lib_service_db_srcs,
     dependencies: [glib_dep, sqlite_dep, test_db_config_args],
-    include_directories: nns_ml_agent_incs
+    include_directories: ml_agentd_incs
   )
 
   subdir('services')


### PR DESCRIPTION
This patch defines APIs of the ML Agent Daemon, whose backend is GDBus, and exports them to the outer space of the daemon so that the tightly coupled dependency between the libcapi-ml-service and daemon is eliminated.

Signed-off-by: Wook Song <wook16.song@samsung.com>

## TODOs
- [x] Rebase onto M1 Release
- [ ] Revise the internal library dependencies
- [x] Package the additional files related to libml-agentd