### PR TITLE
[service/model] Check and parse app_info of tizen application (the caller)

### DIFF
--- a/c/src/meson.build
+++ b/c/src/meson.build
@@ -102,7 +102,7 @@ nns_capi_dep = declare_dependency(link_with: nns_capi_lib,
 if get_option('enable-ml-service')
   nns_capi_service_shared_lib = shared_library ('capi-ml-service',
     nns_capi_service_srcs,
-    dependencies: [nns_capi_dep, ai_service_daemon_deps, json_glib_dep],
+    dependencies: [nns_capi_dep, ai_service_daemon_deps, json_glib_dep, appfw_app_common_dep],
     include_directories: nns_capi_include,
     install: true,
     install_dir: api_install_libdir,
@@ -111,7 +111,7 @@ if get_option('enable-ml-service')
 
   nns_capi_service_static_lib = static_library ('capi-ml-service',
     nns_capi_service_srcs,
-    dependencies: [nns_capi_dep, ai_service_daemon_deps, json_glib_dep],
+    dependencies: [nns_capi_dep, ai_service_daemon_deps, json_glib_dep, appfw_app_common_dep],
     include_directories: nns_capi_include,
     install: true,
     install_dir: api_install_libdir,

--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,7 @@ if get_option('enable-ml-service')
 
   if get_option('enable-tizen')
     appfw_package_manager_dep = dependency('capi-appfw-package-manager')
+    appfw_app_common_dep = dependency('capi-appfw-app-common')
   endif
 endif
 

--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -159,6 +159,7 @@ BuildRequires:  pkgconfig(sqlite3)
 BuildRequires:  pkgconfig(json-glib-1.0)
 BuildRequires:  dbus
 BuildRequires:  pkgconfig(capi-appfw-package-manager)
+BuildRequires:	pkgconfig(capi-appfw-app-common)
 %endif
 
 %description


### PR DESCRIPTION
In a Tizen application context,
- `ml_service_model_register` fill app_info column. RPK cannot call this API, so the value of key `is_rpk` is always false.
- `ml_service_model_get*` APIs should parse the app_info and update the path in case of models from 'RPK'.