### PR TITLE
Tests/PkgMgr: Add functions for emulation of Tizen's Pkg Manager APIs @open sesame 04/20 21:53

### DIFF
--- a/daemon/pkg-mgr.cc
+++ b/daemon/pkg-mgr.cc
@@ -21,6 +21,29 @@
 static package_manager_h pkg_mgr = NULL;
 
 /**
+ * @brief A simple package manager event handler for temporary use
+ * @param pkg_path The path where the target package is installed
+ */
+static inline void _pkg_mgr_echo_pkg_path_info(const gchar * pkg_path) {
+  GDir *dir;
+
+  if (g_file_test (pkg_path, G_FILE_TEST_IS_DIR)) {
+
+      _I ("package path: %s", pkg_path);
+
+      dir = g_dir_open (pkg_path, 0, NULL);
+      if (dir) {
+        const gchar *file_name;
+
+        while ((file_name = g_dir_read_name (dir))) {
+          _I ("- file: %s", file_name);
+        }
+        g_dir_close (dir);
+      }
+    }
+}
+
+/**
  * @brief Callback function to be invoked for resource package.
  * @param type the package type such as rpk, tpk, wgt, etc.
  * @param package_name the name of the package
@@ -36,7 +59,6 @@ _pkg_mgr_event_cb (const char *type, const char *package_name,
     package_manager_event_state_e event_state, int progress,
     package_manager_error_e error, void *user_data)
 {
-  GDir *dir;
   g_autofree gchar *pkg_path = NULL;
   package_info_h pkg_info = NULL;
   int ret;
@@ -174,36 +196,14 @@ _pkg_mgr_event_cb (const char *type, const char *package_name,
 
   } else if (event_type == PACKAGE_MANAGER_EVENT_TYPE_UNINSTALL &&
       event_state == PACKAGE_MANAGER_EVENT_STATE_STARTED) {
-
     _I ("resource package %s is being uninstalled", package_name);
-    /* TODO Need to invalid model */
-    if (g_file_test (pkg_path, G_FILE_TEST_IS_DIR)) {
-      _I ("package path: %s", pkg_path);
-      dir = g_dir_open (pkg_path, 0, NULL);
-      if (dir) {
-        const gchar *file_name;
-        while ((file_name = g_dir_read_name (dir))) {
-          _I ("- file: %s", file_name);
-        }
-        g_dir_close (dir);
-      }
-    }
+    _pkg_mgr_echo_pkg_path_info(pkg_path);
+    /* TODO: Invalidate models related to the package would be uninstalled */
   } else if (event_type == PACKAGE_MANAGER_EVENT_TYPE_UPDATE &&
       event_state == PACKAGE_MANAGER_EVENT_STATE_COMPLETED) {
     _I ("resource package %s is updated", package_name);
-
-    /* TODO Need to update database */
-    if (g_file_test (pkg_path, G_FILE_TEST_IS_DIR)) {
-      _I ("package path: %s", pkg_path);
-      dir = g_dir_open (pkg_path, 0, NULL);
-      if (dir) {
-        const gchar *file_name;
-        while ((file_name = g_dir_read_name (dir))) {
-          _I ("- file: %s", file_name);
-        }
-        g_dir_close (dir);
-      }
-    }
+    _pkg_mgr_echo_pkg_path_info(pkg_path);
+    /* TODO: Update database */
   } else {
     /* Do not consider other events: do nothing */
   }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -21,6 +21,7 @@ unittest_common_dep = declare_dependency(
 )
 
 if get_option('enable-ml-service')
+  subdir('mock')
   subdir('dbus')
 
   nns_ml_agent_common_objs = nns_ml_agent_executable.extract_objects(nns_ml_agent_common_srcs)
@@ -28,6 +29,7 @@ if get_option('enable-ml-service')
     [nns_ml_agent_service_db_srcs, test_dbus_impl_srcs],
     dependencies: [ai_service_daemon_deps, gdbus_test_gen_dep],
     include_directories: nns_ml_agent_incs,
+    link_with: lib_unittest_mock,
     objects: [nns_ml_agent_common_objs],
     cpp_args: [daemon_cpp_db_key_prefix_arg, '-DDB_PATH="."']
   )

--- a/tests/mock/meson.build
+++ b/tests/mock/meson.build
@@ -1,0 +1,4 @@
+lib_unittest_mock = shared_library('unittest_mock',
+    files('mock_package_manager.c'),
+    dependencies: glib_dep,
+)

--- a/tests/mock/mock_package_manager.c
+++ b/tests/mock/mock_package_manager.c
@@ -1,0 +1,90 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Copyright (C) 2023 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file    mock_package_manager.c
+ * @date    18 Apr 2023
+ * @brief   A set of helper functions for emulation of Tizen's Package Manager APIs
+ * @see     https://github.com/nnstreamer/api
+ * @author  Wook Song <wook16.song@samsung.com>
+ * @bug     No known bugs except for NYI items
+ *
+ * @details
+ *  This provides helper functions for the emulation of Tizen's Package Manager APIs
+ *  and utilities for unit test cases of ML Agent Service APIs.
+ */
+
+#include <tizen_error.h>
+#include <glib-2.0/glib.h>
+
+#include "mock_package_manager.h"
+
+/**
+ * @brief A mock implementation of the package_manager_create function
+ * @see https://docs.tizen.org/application/native/guides/app-management/package-manager/
+ */
+int
+package_manager_create (package_manager_h * manager)
+{
+  struct mock_package_manager *_manager;
+
+  if (manager == NULL) {
+    return PACKAGE_MANAGER_ERROR_INVALID_PARAMETER;
+  }
+
+  _manager = g_try_new0 (struct mock_package_manager, 1);
+  if (_manager == NULL) {
+    return PACKAGE_MANAGER_ERROR_OUT_OF_MEMORY;
+  }
+
+  _manager->events = -1;
+  _manager->event_cb = NULL;
+  *manager = _manager;
+
+  return PACKAGE_MANAGER_ERROR_NONE;
+}
+
+/**
+ * @brief A mock implementation of the package_manager_destroy function
+ * @see https://docs.tizen.org/application/native/guides/app-management/package-manager/
+ */
+int
+package_manager_destroy (package_manager_h manager)
+{
+  if (manager == NULL)
+    return PACKAGE_MANAGER_ERROR_INVALID_PARAMETER;
+
+  g_free(manager);
+  return PACKAGE_MANAGER_ERROR_NONE;
+}
+
+/**
+ * @brief A mock implementation of the package_manager_set_event_status function
+ * @see https://docs.tizen.org/application/native/guides/app-management/package-manager/
+ */
+int
+package_manager_set_event_status (package_manager_h manager, int status_type)
+{
+  if (!manager || status_type > 0x7FF || status_type < 0) {
+    return PACKAGE_MANAGER_ERROR_INVALID_PARAMETER;
+  }
+
+  manager->events = status_type;
+  return PACKAGE_MANAGER_ERROR_NONE;
+}
+
+/**
+ * @brief A mock implementation of the package_manager_set_event_cb function
+ * @see https://docs.tizen.org/application/native/guides/app-management/package-manager/
+ */
+int
+package_manager_set_event_cb (package_manager_h manager,
+    package_manager_event_cb callback, void *user_data)
+{
+  if (!callback)
+    return PACKAGE_MANAGER_ERROR_INVALID_PARAMETER;
+
+  manager->event_cb = callback;
+
+  return PACKAGE_MANAGER_ERROR_NONE;
+}

--- a/tests/mock/mock_package_manager.h
+++ b/tests/mock/mock_package_manager.h
@@ -1,0 +1,97 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Copyright (C) 2023 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file    mock_package_manager.h
+ * @date    18 Apr 2023
+ * @brief   A set of helper functions for emulation of Tizen's Package Manager APIs
+ * @see     https://github.com/nnstreamer/api
+ * @author  Wook Song <wook16.song@samsung.com>
+ * @bug     No known bugs except for NYI items
+ *
+ * @details
+ *  This provides helper functions for the emulation of Tizen's Package Manager APIs
+ *  and utilities for unit test cases of ML Agent Service APIs.
+ */
+#ifndef __MOCK_PACKAGE_MANAGER_H__
+#define __MOCK_PACKAGE_MANAGER_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+typedef enum mock_package_manager_error_e
+{
+  PACKAGE_MANAGER_ERROR_NONE = TIZEN_ERROR_NONE,
+  PACKAGE_MANAGER_ERROR_INVALID_PARAMETER = TIZEN_ERROR_INVALID_PARAMETER,
+  PACKAGE_MANAGER_ERROR_OUT_OF_MEMORY = TIZEN_ERROR_OUT_OF_MEMORY,
+  PACKAGE_MANAGER_ERROR_IO_ERROR = TIZEN_ERROR_IO_ERROR,
+  PACKAGE_MANAGER_ERROR_NO_SUCH_PACKAGE = TIZEN_ERROR_PACKAGE_MANAGER | 0x71,
+  PACKAGE_MANAGER_ERROR_SYSTEM_ERROR = TIZEN_ERROR_PACKAGE_MANAGER | 0x72,
+  PACKAGE_MANAGER_ERROR_PERMISSION_DENIED = TIZEN_ERROR_PERMISSION_DENIED,
+} package_manager_error_e;
+
+typedef enum mock_package_manager_event_type_e
+{
+  PACKAGE_MANAGER_EVENT_TYPE_INSTALL = 0,
+  PACKAGE_MANAGER_EVENT_TYPE_UNINSTALL,
+  PACKAGE_MANAGER_EVENT_TYPE_UPDATE,
+  PACKAGE_MANAGER_EVENT_TYPE_MOVE,
+  PACKAGE_MANAGER_EVENT_TYPE_CLEAR,
+  PACKAGE_MANAGER_EVENT_TYPE_RES_COPY,
+  PACKAGE_MANAGER_EVENT_TYPE_RES_CREATE_DIR,
+  PACKAGE_MANAGER_EVENT_TYPE_RES_REMOVE,
+  PACKAGE_MANAGER_EVENT_TYPE_RES_UNINSTALL,
+} package_manager_event_type_e;
+
+typedef enum mock_package_manager_event_state_e
+{
+  PACKAGE_MANAGER_EVENT_STATE_STARTED = 0,
+  PACKAGE_MANAGER_EVENT_STATE_PROCESSING,
+  PACKAGE_MANAGER_EVENT_STATE_COMPLETED,
+  PACKAGE_MANAGER_EVENT_STATE_FAILED,
+} package_manager_event_state_e;
+
+typedef enum mock_package_manager_status_type_e
+{
+  PACKAGE_MANAGER_STATUS_TYPE_ALL = 0x00,
+  PACKAGE_MANAGER_STATUS_TYPE_INSTALL = 0x01,
+  PACKAGE_MANAGER_STATUS_TYPE_UNINSTALL = 0x02,
+  PACKAGE_MANAGER_STATUS_TYPE_UPGRADE = 0x04,
+  PACKAGE_MANAGER_STATUS_TYPE_MOVE = 0x08,
+  PACKAGE_MANAGER_STATUS_TYPE_CLEAR_DATA = 0x10,
+  PACKAGE_MANAGER_STATUS_TYPE_INSTALL_PROGRESS = 0x20,
+  PACKAGE_MANAGER_STATUS_TYPE_GET_SIZE = 0x40,
+  PACKAGE_MANAGER_STATUS_TYPE_RES_COPY = 0x80,
+  PACKAGE_MANAGER_STATUS_TYPE_RES_CREATE_DIR = 0x100,
+  PACKAGE_MANAGER_STATUS_TYPE_RES_REMOVE = 0x200,
+  PACKAGE_MANAGER_STATUS_TYPE_RES_UNINSTALL = 0x400,
+} package_manager_status_type_e;
+
+typedef void (*mock_event_cb) (const char *,
+    const char *,
+    package_manager_event_type_e,
+    package_manager_event_state_e, int, package_manager_error_e, void *);
+
+/**
+ * @brief A fake package manager handle for the mock Package Manager APIs
+ */
+struct mock_package_manager
+{
+  guint events;
+  mock_event_cb event_cb;
+};
+typedef mock_event_cb package_manager_event_cb;
+typedef struct mock_package_manager *package_manager_h;
+
+int package_manager_create (package_manager_h * manager);
+int package_manager_destroy (package_manager_h manager);
+int package_manager_set_event_status (package_manager_h manager,
+    int status_type);
+int package_manager_set_event_cb (package_manager_h manager,
+    package_manager_event_cb callback, void *user_data);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* __MOCK_PACKAGE_MANAGER_H__ */


### PR DESCRIPTION
This patch adds helper functions for the emulation of Tizen's Package Manager APIs and utilities for unit test cases of ML Agent Service APIs.

Signed-off-by: Wook Song <wook16.song@samsung.com>
