### PR TITLE
[C-API] revert fill dimension 1

### DIFF
--- a/c/src/ml-api-common.c
+++ b/c/src/ml-api-common.c
@@ -550,10 +550,6 @@ ml_tensors_info_get_tensor_dimension (ml_tensors_info_h info,
     dimension[i] = tensors_info->info[index].dimension[i];
   }
 
-  /* Fill remained dim (default value 1) */
-  for (i = valid_rank; i < ML_TENSOR_RANK_LIMIT; i++)
-    dimension[i] = 1;
-
   G_UNLOCK_UNLESS_NOLOCK (*tensors_info);
   return ML_ERROR_NONE;
 }


### PR DESCRIPTION
This patch reverts fill dimension to default value 1. 
In C# API, interop function ml_tensors_info_get_tensor_dimension is used with length 4 dimension array instead of 16.


```C#
/* int ml_tensors_info_get_tensor_dimension (ml_tensors_info_h info, unsigned int index, ml_tensor_dimension dimension) */
[DllImport(Libraries.MlCommon, EntryPoint = "ml_tensors_info_get_tensor_dimension", CallingConvention = CallingConvention.Cdecl)]
internal static extern NNStreamerError GetTensorDimension(IntPtr info, int index, [In, Out] uint[] dimension);
```

```C#
uint[] dim = new uint[Tensor.RankLimit];
.
.
.
ret = Interop.Util.GetTensorDimension(handle, i, dim);
NNStreamer.CheckException(ret, "Fail to get Tensor's dimension");
```

fill dimension using default value 1 will be added after C# API fixed.