### PR TITLE
Tests: Add test cases for gdbus-util

### DIFF
--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -391,6 +391,7 @@ bash %{test_script} ./tests/capi/unittest_capi_datatype_consistency
 %if 0%{?enable_ml_service}
 bash %{test_script} ./tests/daemon/unittest_ml_agent
 bash %{test_script} ./tests/daemon/unittest_service_db
+bash %{test_script} ./tests/daemon/unittest_gdbus_util
 bash %{test_script} ./tests/capi/unittest_capi_service_agent_client
 %endif
 

--- a/tests/daemon/meson.build
+++ b/tests/daemon/meson.build
@@ -16,3 +16,13 @@ unittest_service_db = executable('unittest_service_db',
   include_directories: [nns_capi_include, ml_agentd_incs],
 )
 test('unittest_service_db', unittest_service_db, env: testenv, timeout: 100)
+
+unittest_gdbus_util = executable('unittest_gdbus_util',
+  'unittest_gdbus_util.cc',
+  dependencies: [unittest_common_dep],
+  link_with: ml_agentd_lib,
+  install: get_option('install-test'),
+  install_dir: unittest_install_dir,
+  include_directories: [ml_agentd_incs],
+)
+test('unittest_gdbus_util', unittest_gdbus_util, env: testenv, timeout: 100)

--- a/tests/daemon/unittest_gdbus_util.cc
+++ b/tests/daemon/unittest_gdbus_util.cc
@@ -1,0 +1,68 @@
+/**
+ * @file        unittest_gdbus_util.cc
+ * @date        2 May 2023
+ * @brief       Unit test for GDBus Utility functions
+ * @see         https://github.com/nnstreamer/api
+ * @author      Wook Song <wook16.song@samsung.com>
+ * @bug         No known bugs
+ */
+
+#include <gtest/gtest.h>
+
+#include "dbus-interface.h"
+#include "gdbus-util.h"
+
+/**
+ * @brief Negative test for the gdbus helper function, gdbus_export_interface
+ */
+TEST (gdbusInstanceNotInitialized, export_interface_n)
+{
+  int ret;
+
+  ret = gdbus_export_interface (nullptr, DBUS_PIPELINE_PATH);
+  EXPECT_EQ (-ENOSYS, ret);
+
+  ret = gdbus_export_interface (nullptr, DBUS_MODEL_PATH);
+  EXPECT_EQ (-ENOSYS, ret);
+
+  ret = gdbus_get_name (DBUS_ML_BUS_NAME);
+  EXPECT_EQ (-ENOSYS, ret);
+}
+
+/**
+ * @brief Negative test for the gdbus helper function, get_system_connection
+ */
+TEST (gdbusInstanceNotInitialized, get_system_connection_n)
+{
+  gboolean is_session = true;
+  int ret;
+
+  ret = gdbus_get_system_connection(is_session);
+  EXPECT_EQ (-ENOSYS, ret);
+
+  ret = gdbus_get_system_connection(!is_session);
+  EXPECT_EQ (-ENOSYS, ret);
+}
+
+/**
+ * @brief Main gtest
+ */
+int
+main (int argc, char **argv)
+{
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest (&argc, argv);
+  } catch (...) {
+    g_warning ("catch 'testing::internal::<unnamed>::ClassUniqueToAlwaysTrue'");
+  }
+
+  try {
+    result = RUN_ALL_TESTS ();
+  } catch (...) {
+    g_warning ("catch `testing::internal::GoogleTestFailureException`");
+  }
+
+  return result;
+}


### PR DESCRIPTION
This patch adds unit test cases for the helper functions in the gdbus-util.c file.

Signed-off-by: Wook Song <wook16.song@samsung.com>
