### PR TITLE
Formatting/CC: Apply .clang-format to the C++ source files @open sesame 05/02 19:25

### DIFF
--- a/daemon/model-dbus-impl.cc
+++ b/daemon/model-dbus-impl.cc
@@ -10,15 +10,15 @@
  * @bug No known bugs except for NYI items
  */
 
-#include <glib.h>
 #include <errno.h>
+#include <glib.h>
 
 #include "common.h"
-#include "modules.h"
-#include "gdbus-util.h"
 #include "dbus-interface.h"
-#include "model-dbus.h"
+#include "gdbus-util.h"
 #include "log.h"
+#include "model-dbus.h"
+#include "modules.h"
 #include "service-db.hh"
 
 static MachinelearningServiceModel *g_gdbus_instance = NULL;
@@ -54,17 +54,12 @@ gdbus_put_model_instance (MachinelearningServiceModel **instance)
  */
 static gboolean
 gdbus_cb_model_register (MachinelearningServiceModel *obj,
-    GDBusMethodInvocation *invoc,
-    const gchar *name,
-    const gchar *path,
-    const bool is_active,
-    const gchar *description,
-    const gchar *app_info
-    )
+    GDBusMethodInvocation *invoc, const gchar *name, const gchar *path,
+    const bool is_active, const gchar *description, const gchar *app_info)
 {
   int ret = 0;
   guint version = 0U;
-  MLServiceDB & db = MLServiceDB::getInstance ();
+  MLServiceDB &db = MLServiceDB::getInstance ();
 
   try {
     db.connectDB ();
@@ -95,13 +90,11 @@ gdbus_cb_model_register (MachinelearningServiceModel *obj,
  */
 static gboolean
 gdbus_cb_model_update_description (MachinelearningServiceModel *obj,
-    GDBusMethodInvocation *invoc,
-    const gchar *name,
-    const guint version,
+    GDBusMethodInvocation *invoc, const gchar *name, const guint version,
     const gchar *description)
 {
   int ret = 0;
-  MLServiceDB & db = MLServiceDB::getInstance ();
+  MLServiceDB &db = MLServiceDB::getInstance ();
 
   try {
     db.connectDB ();
@@ -131,12 +124,10 @@ gdbus_cb_model_update_description (MachinelearningServiceModel *obj,
  */
 static gboolean
 gdbus_cb_model_activate (MachinelearningServiceModel *obj,
-    GDBusMethodInvocation *invoc,
-    const gchar *name,
-    const guint version)
+    GDBusMethodInvocation *invoc, const gchar *name, const guint version)
 {
   int ret = 0;
-  MLServiceDB & db = MLServiceDB::getInstance ();
+  MLServiceDB &db = MLServiceDB::getInstance ();
 
   try {
     db.connectDB ();
@@ -165,13 +156,11 @@ gdbus_cb_model_activate (MachinelearningServiceModel *obj,
  */
 static gboolean
 gdbus_cb_model_get (MachinelearningServiceModel *obj,
-    GDBusMethodInvocation *invoc,
-    const gchar *name,
-    const guint version)
+    GDBusMethodInvocation *invoc, const gchar *name, const guint version)
 {
   int ret = 0;
   std::string model_info;
-  MLServiceDB & db = MLServiceDB::getInstance ();
+  MLServiceDB &db = MLServiceDB::getInstance ();
 
   try {
     db.connectDB ();
@@ -185,7 +174,8 @@ gdbus_cb_model_get (MachinelearningServiceModel *obj,
   }
 
   db.disconnectDB ();
-  machinelearning_service_model_complete_get_activated (obj, invoc, model_info.c_str (), ret);
+  machinelearning_service_model_complete_get_activated (
+      obj, invoc, model_info.c_str (), ret);
 
   return TRUE;
 }
@@ -200,12 +190,11 @@ gdbus_cb_model_get (MachinelearningServiceModel *obj,
  */
 static gboolean
 gdbus_cb_model_get_activated (MachinelearningServiceModel *obj,
-    GDBusMethodInvocation *invoc,
-    const gchar *name)
+    GDBusMethodInvocation *invoc, const gchar *name)
 {
   int ret = 0;
   std::string model_info;
-  MLServiceDB & db = MLServiceDB::getInstance ();
+  MLServiceDB &db = MLServiceDB::getInstance ();
 
   try {
     db.connectDB ();
@@ -219,7 +208,8 @@ gdbus_cb_model_get_activated (MachinelearningServiceModel *obj,
   }
 
   db.disconnectDB ();
-  machinelearning_service_model_complete_get_activated (obj, invoc, model_info.c_str (), ret);
+  machinelearning_service_model_complete_get_activated (
+      obj, invoc, model_info.c_str (), ret);
 
   return TRUE;
 }
@@ -234,11 +224,10 @@ gdbus_cb_model_get_activated (MachinelearningServiceModel *obj,
  */
 static gboolean
 gdbus_cb_model_get_all (MachinelearningServiceModel *obj,
-    GDBusMethodInvocation *invoc,
-    const gchar *name)
+    GDBusMethodInvocation *invoc, const gchar *name)
 {
   int ret = 0;
-  MLServiceDB & db = MLServiceDB::getInstance ();
+  MLServiceDB &db = MLServiceDB::getInstance ();
   std::string all_model_list;
 
   try {
@@ -270,12 +259,10 @@ gdbus_cb_model_get_all (MachinelearningServiceModel *obj,
  */
 static gboolean
 gdbus_cb_model_delete (MachinelearningServiceModel *obj,
-    GDBusMethodInvocation *invoc,
-    const gchar *name,
-    const guint version)
+    GDBusMethodInvocation *invoc, const gchar *name, const guint version)
 {
   int ret = 0;
-  MLServiceDB & db = MLServiceDB::getInstance ();
+  MLServiceDB &db = MLServiceDB::getInstance ();
 
   try {
     db.connectDB ();
@@ -299,41 +286,47 @@ gdbus_cb_model_delete (MachinelearningServiceModel *obj,
  */
 static struct gdbus_signal_info handler_infos[] = {
   {
-    .signal_name = DBUS_MODEL_I_HANDLER_REGISTER,
-    .cb = G_CALLBACK (gdbus_cb_model_register),
-    .cb_data = NULL,
-    .handler_id = 0,
-  }, {
-    .signal_name = DBUS_MODEL_I_HANDLER_UPDATE_DESCRIPTION,
-    .cb = G_CALLBACK (gdbus_cb_model_update_description),
-    .cb_data = NULL,
-    .handler_id = 0,
-  }, {
-    .signal_name = DBUS_MODEL_I_HANDLER_ACTIVATE,
-    .cb = G_CALLBACK (gdbus_cb_model_activate),
-    .cb_data = NULL,
-    .handler_id = 0,
-  }, {
-    .signal_name = DBUS_MODEL_I_HANDLER_GET,
-    .cb = G_CALLBACK (gdbus_cb_model_get),
-    .cb_data = NULL,
-    .handler_id = 0,
-  }, {
-    .signal_name = DBUS_MODEL_I_HANDLER_GET_ACTIVATED,
-    .cb = G_CALLBACK (gdbus_cb_model_get_activated),
-    .cb_data = NULL,
-    .handler_id = 0,
-  }, {
-    .signal_name = DBUS_MODEL_I_HANDLER_GET_ALL,
-    .cb = G_CALLBACK (gdbus_cb_model_get_all),
-    .cb_data = NULL,
-    .handler_id = 0,
-  }, {
-    .signal_name = DBUS_MODEL_I_HANDLER_DELETE,
-    .cb = G_CALLBACK (gdbus_cb_model_delete),
-    .cb_data = NULL,
-    .handler_id = 0,
-  }
+      .signal_name = DBUS_MODEL_I_HANDLER_REGISTER,
+      .cb = G_CALLBACK (gdbus_cb_model_register),
+      .cb_data = NULL,
+      .handler_id = 0,
+  },
+  {
+      .signal_name = DBUS_MODEL_I_HANDLER_UPDATE_DESCRIPTION,
+      .cb = G_CALLBACK (gdbus_cb_model_update_description),
+      .cb_data = NULL,
+      .handler_id = 0,
+  },
+  {
+      .signal_name = DBUS_MODEL_I_HANDLER_ACTIVATE,
+      .cb = G_CALLBACK (gdbus_cb_model_activate),
+      .cb_data = NULL,
+      .handler_id = 0,
+  },
+  {
+      .signal_name = DBUS_MODEL_I_HANDLER_GET,
+      .cb = G_CALLBACK (gdbus_cb_model_get),
+      .cb_data = NULL,
+      .handler_id = 0,
+  },
+  {
+      .signal_name = DBUS_MODEL_I_HANDLER_GET_ACTIVATED,
+      .cb = G_CALLBACK (gdbus_cb_model_get_activated),
+      .cb_data = NULL,
+      .handler_id = 0,
+  },
+  {
+      .signal_name = DBUS_MODEL_I_HANDLER_GET_ALL,
+      .cb = G_CALLBACK (gdbus_cb_model_get_all),
+      .cb_data = NULL,
+      .handler_id = 0,
+  },
+  {
+      .signal_name = DBUS_MODEL_I_HANDLER_DELETE,
+      .cb = G_CALLBACK (gdbus_cb_model_delete),
+      .cb_data = NULL,
+      .handler_id = 0,
+  },
 };
 
 /**
@@ -347,16 +340,13 @@ probe_model_module (void *data)
 
   g_gdbus_instance = gdbus_get_model_instance ();
   if (NULL == g_gdbus_instance) {
-    _E ("cannot get a dbus instance for the %s interface\n",
-        DBUS_MODEL_INTERFACE);
+    _E ("cannot get a dbus instance for the %s interface\n", DBUS_MODEL_INTERFACE);
     return -ENOSYS;
   }
 
-  ret = gdbus_connect_signal (g_gdbus_instance,
-      ARRAY_SIZE (handler_infos), handler_infos);
+  ret = gdbus_connect_signal (g_gdbus_instance, ARRAY_SIZE (handler_infos), handler_infos);
   if (ret < 0) {
-    _E ("cannot register callbacks as the dbus method invocation handlers\n ret: %d",
-        ret);
+    _E ("cannot register callbacks as the dbus method invocation handlers\n ret: %d", ret);
     ret = -ENOSYS;
     goto out;
   }
@@ -372,8 +362,7 @@ probe_model_module (void *data)
   return 0;
 
 out_disconnect:
-  gdbus_disconnect_signal (g_gdbus_instance,
-      ARRAY_SIZE (handler_infos), handler_infos);
+  gdbus_disconnect_signal (g_gdbus_instance, ARRAY_SIZE (handler_infos), handler_infos);
 
 out:
   gdbus_put_model_instance (&g_gdbus_instance);
@@ -395,8 +384,7 @@ init_model_module (void *data)
 static void
 exit_model_module (void *data)
 {
-  gdbus_disconnect_signal (g_gdbus_instance,
-      ARRAY_SIZE (handler_infos), handler_infos);
+  gdbus_disconnect_signal (g_gdbus_instance, ARRAY_SIZE (handler_infos), handler_infos);
   gdbus_put_model_instance (&g_gdbus_instance);
 }
 

--- a/tests/capi/unittest_capi_datatype_consistency.cc
+++ b/tests/capi/unittest_capi_datatype_consistency.cc
@@ -12,8 +12,8 @@
 #include <tensor_typedef.h>
 
 /* ML API Side */
-#include <nnstreamer.h>
 #include <ml-api-internal.h>
+#include <nnstreamer.h>
 
 /* GStreamer Side */
 #include <gst/gst.h>

--- a/tests/capi/unittest_capi_inference.cc
+++ b/tests/capi/unittest_capi_inference.cc
@@ -10,15 +10,15 @@
 #include <gtest/gtest.h>
 #include <glib.h>
 #include <glib/gstdio.h> /* GStatBuf */
-#include <nnstreamer.h>
-#include <nnstreamer_plugin_api.h>
-#include <nnstreamer_internal.h>
-#include <nnstreamer-tizen-internal.h>
-#include <ml-api-internal.h>
 #include <ml-api-inference-internal.h>
 #include <ml-api-inference-pipeline-internal.h>
+#include <ml-api-internal.h>
+#include <nnstreamer-tizen-internal.h>
+#include <nnstreamer.h>
+#include <nnstreamer_internal.h>
+#include <nnstreamer_plugin_api.h>
 
-#if defined (__APPLE__)
+#if defined(__APPLE__)
 #define SO_FILE_EXTENSION ".dylib"
 #else
 #define SO_FILE_EXTENSION ".so"
@@ -26,7 +26,7 @@
 
 static const unsigned int SINGLE_DEF_TIMEOUT_MSEC = 10000U;
 
-#if defined (ENABLE_TENSORFLOW_LITE) || defined (ENABLE_TENSORFLOW2_LITE)
+#if defined(ENABLE_TENSORFLOW_LITE) || defined(ENABLE_TENSORFLOW2_LITE)
 constexpr bool is_enabled_tensorflow_lite = true;
 #else
 constexpr bool is_enabled_tensorflow_lite = false;
@@ -43,31 +43,33 @@ typedef struct {
 /**
  * @brief Macro to wait for pipeline state.
  */
-#define wait_for_start(handle, state, status) do { \
-    int counter = 0; \
+#define wait_for_start(handle, state, status)                                      \
+  do {                                                                             \
+    int counter = 0;                                                               \
     while ((state == ML_PIPELINE_STATE_PAUSED || state == ML_PIPELINE_STATE_READY) \
-           && counter < 20) { \
-      g_usleep (50000); \
-      counter++; \
-      status = ml_pipeline_get_state (handle, &state); \
-      EXPECT_EQ (status, ML_ERROR_NONE); \
-    } \
+           && counter < 20) {                                                      \
+      g_usleep (50000);                                                            \
+      counter++;                                                                   \
+      status = ml_pipeline_get_state (handle, &state);                             \
+      EXPECT_EQ (status, ML_ERROR_NONE);                                           \
+    }                                                                              \
   } while (0)
 
 /**
  * @brief Macro to wait for expected buffers to arrive.
  */
-#define wait_pipeline_process_buffers(received, expected) do { \
-    guint timer = 0; \
-    while (received < expected) { \
-      g_usleep (10000); \
-      timer += 10; \
-      if (timer > SINGLE_DEF_TIMEOUT_MSEC) \
-        break; \
-    } \
+#define wait_pipeline_process_buffers(received, expected) \
+  do {                                                    \
+    guint timer = 0;                                      \
+    while (received < expected) {                         \
+      g_usleep (10000);                                   \
+      timer += 10;                                        \
+      if (timer > SINGLE_DEF_TIMEOUT_MSEC)                \
+        break;                                            \
+    }                                                     \
   } while (0)
 
-#if defined (__TIZEN__)
+#if defined(__TIZEN__)
 #if TIZENPPM
 /**
  * @brief Test NNStreamer pipeline construct with Tizen cam
@@ -229,8 +231,7 @@ TEST (nnstreamer_capi_playstop, dummy_01)
   status = ml_pipeline_start (handle);
   EXPECT_EQ (status, ML_ERROR_NONE);
   status = ml_pipeline_get_state (handle, &state);
-  EXPECT_EQ (status,
-      ML_ERROR_NONE); /* At this moment, it can be READY, PAUSED, or PLAYING */
+  EXPECT_EQ (status, ML_ERROR_NONE); /* At this moment, it can be READY, PAUSED, or PLAYING */
   EXPECT_NE (state, ML_PIPELINE_STATE_UNKNOWN);
   EXPECT_NE (state, ML_PIPELINE_STATE_NULL);
 
@@ -268,8 +269,7 @@ TEST (nnstreamer_capi_playstop, dummy_02)
   status = ml_pipeline_start (handle);
   EXPECT_EQ (status, ML_ERROR_NONE);
   status = ml_pipeline_get_state (handle, &state);
-  EXPECT_EQ (status,
-      ML_ERROR_NONE); /* At this moment, it can be READY, PAUSED, or PLAYING */
+  EXPECT_EQ (status, ML_ERROR_NONE); /* At this moment, it can be READY, PAUSED, or PLAYING */
   EXPECT_NE (state, ML_PIPELINE_STATE_UNKNOWN);
   EXPECT_NE (state, ML_PIPELINE_STATE_NULL);
 
@@ -315,7 +315,7 @@ TEST (nnstreamer_capi_valve, test01)
   const gchar *_tmpdir = g_get_tmp_dir ();
   const gchar *_dirname = "nns-tizen-XXXXXX";
   gchar *fullpath = g_build_path ("/", _tmpdir, _dirname, NULL);
-  gchar *dir = g_mkdtemp ((gchar *)fullpath);
+  gchar *dir = g_mkdtemp ((gchar *) fullpath);
   gchar *file1 = g_build_path ("/", dir, "valve1", NULL);
   gchar *pipeline = g_strdup_printf (
       "videotestsrc is-live=true ! videoconvert ! videoscale ! video/x-raw,format=RGBx,width=16,height=16,framerate=10/1 ! tensor_converter ! queue ! valve name=valve1 ! filesink location=\"%s\"",
@@ -342,8 +342,7 @@ TEST (nnstreamer_capi_valve, test01)
 
   g_usleep (50000); /* 50ms. Wait for the pipeline stgart. */
   status = ml_pipeline_get_state (handle, &state);
-  EXPECT_EQ (status,
-      ML_ERROR_NONE); /* At this moment, it can be READY, PAUSED, or PLAYING */
+  EXPECT_EQ (status, ML_ERROR_NONE); /* At this moment, it can be READY, PAUSED, or PLAYING */
   EXPECT_NE (state, ML_PIPELINE_STATE_UNKNOWN);
   EXPECT_NE (state, ML_PIPELINE_STATE_NULL);
 
@@ -507,7 +506,7 @@ static void
 test_sink_callback_dm01 (
     const ml_tensors_data_h data, const ml_tensors_info_h info, void *user_data)
 {
-  gchar *filepath = (gchar *)user_data;
+  gchar *filepath = (gchar *) user_data;
   unsigned int i, num = 0;
   void *data_ptr;
   size_t data_size;
@@ -537,7 +536,7 @@ static void
 test_sink_callback_count (
     const ml_tensors_data_h data, const ml_tensors_info_h info, void *user_data)
 {
-  guint *count = (guint *)user_data;
+  guint *count = (guint *) user_data;
 
   G_LOCK (callback_lock);
   *count = *count + 1;
@@ -553,17 +552,17 @@ test_pipe_state_callback (ml_pipeline_state_e state, void *user_data)
   TestPipeState *pipe_state;
 
   G_LOCK (callback_lock);
-  pipe_state = (TestPipeState *)user_data;
+  pipe_state = (TestPipeState *) user_data;
 
   switch (state) {
-  case ML_PIPELINE_STATE_PAUSED:
-    pipe_state->paused = TRUE;
-    break;
-  case ML_PIPELINE_STATE_PLAYING:
-    pipe_state->playing = TRUE;
-    break;
-  default:
-    break;
+    case ML_PIPELINE_STATE_PAUSED:
+      pipe_state->paused = TRUE;
+      break;
+    case ML_PIPELINE_STATE_PLAYING:
+      pipe_state->playing = TRUE;
+      break;
+    default:
+      break;
   }
   G_UNLOCK (callback_lock);
 }
@@ -634,9 +633,9 @@ TEST (nnstreamer_capi_sink, dummy_01)
   const gchar *_tmpdir = g_get_tmp_dir ();
   const gchar *_dirname = "nns-tizen-XXXXXX";
   gchar *fullpath = g_build_path ("/", _tmpdir, _dirname, NULL);
-  gchar *dir = g_mkdtemp ((gchar *)fullpath);
+  gchar *dir = g_mkdtemp ((gchar *) fullpath);
 
-  ASSERT_NE (dir, (gchar *)NULL);
+  ASSERT_NE (dir, (gchar *) NULL);
 
   gchar *file1 = g_build_path ("/", dir, "original", NULL);
   gchar *file2 = g_build_path ("/", dir, "sink", NULL);
@@ -698,11 +697,11 @@ TEST (nnstreamer_capi_sink, dummy_02)
   /* pipeline with appsink */
   pipeline = g_strdup ("videotestsrc num-buffers=3 ! videoconvert ! tensor_converter ! appsink name=sinkx sync=false");
 
-  count_sink = (guint *)g_malloc (sizeof (guint));
+  count_sink = (guint *) g_malloc (sizeof (guint));
   ASSERT_TRUE (count_sink != NULL);
   *count_sink = 0;
 
-  pipe_state = (TestPipeState *)g_new0 (TestPipeState, 1);
+  pipe_state = (TestPipeState *) g_new0 (TestPipeState, 1);
   ASSERT_TRUE (pipe_state != NULL);
 
   status = ml_pipeline_construct (pipeline, test_pipe_state_callback, pipe_state, &handle);
@@ -758,15 +757,15 @@ TEST (nnstreamer_capi_sink, register_duplicated)
 
   /* pipeline with appsink */
   pipeline = g_strdup ("videotestsrc num-buffers=3 ! videoconvert ! tensor_converter ! appsink name=sinkx sync=false");
-  count_sink0 = (guint *)g_malloc (sizeof (guint));
+  count_sink0 = (guint *) g_malloc (sizeof (guint));
   ASSERT_TRUE (count_sink0 != NULL);
   *count_sink0 = 0;
 
-  count_sink1 = (guint *)g_malloc (sizeof (guint));
+  count_sink1 = (guint *) g_malloc (sizeof (guint));
   ASSERT_TRUE (count_sink1 != NULL);
   *count_sink1 = 0;
 
-  pipe_state = (TestPipeState *)g_new0 (TestPipeState, 1);
+  pipe_state = (TestPipeState *) g_new0 (TestPipeState, 1);
   ASSERT_TRUE (pipe_state != NULL);
 
   status = ml_pipeline_construct (pipeline, test_pipe_state_callback, pipe_state, &handle);
@@ -817,7 +816,7 @@ TEST (nnstreamer_capi_sink, failure_01_n)
   int status;
   guint *count_sink;
 
-  count_sink = (guint *)g_malloc (sizeof (guint));
+  count_sink = (guint *) g_malloc (sizeof (guint));
   ASSERT_TRUE (count_sink != NULL);
   *count_sink = 0;
 
@@ -843,7 +842,7 @@ TEST (nnstreamer_capi_sink, failure_02_n)
 
   pipeline = g_strdup ("videotestsrc num-buffers=3 ! videoconvert ! valve name=valvex ! tensor_converter ! tensor_sink name=sinkx");
 
-  count_sink = (guint *)g_malloc (sizeof (guint));
+  count_sink = (guint *) g_malloc (sizeof (guint));
   ASSERT_TRUE (count_sink != NULL);
   *count_sink = 0;
 
@@ -873,7 +872,7 @@ TEST (nnstreamer_capi_sink, failure_03_n)
 
   pipeline = g_strdup ("videotestsrc num-buffers=3 ! videoconvert ! valve name=valvex ! tensor_converter ! tensor_sink name=sinkx");
 
-  count_sink = (guint *)g_malloc (sizeof (guint));
+  count_sink = (guint *) g_malloc (sizeof (guint));
   ASSERT_TRUE (count_sink != NULL);
   *count_sink = 0;
 
@@ -903,7 +902,7 @@ TEST (nnstreamer_capi_sink, failure_04_n)
 
   pipeline = g_strdup ("videotestsrc num-buffers=3 ! videoconvert ! valve name=valvex ! tensor_converter ! tensor_sink name=sinkx");
 
-  count_sink = (guint *)g_malloc (sizeof (guint));
+  count_sink = (guint *) g_malloc (sizeof (guint));
   ASSERT_TRUE (count_sink != NULL);
   *count_sink = 0;
 
@@ -933,7 +932,7 @@ TEST (nnstreamer_capi_sink, failure_05_n)
 
   pipeline = g_strdup ("videotestsrc num-buffers=3 ! videoconvert ! valve name=valvex ! tensor_converter ! tensor_sink name=sinkx");
 
-  count_sink = (guint *)g_malloc (sizeof (guint));
+  count_sink = (guint *) g_malloc (sizeof (guint));
   ASSERT_TRUE (count_sink != NULL);
   *count_sink = 0;
 
@@ -961,7 +960,7 @@ TEST (nnstreamer_capi_sink, failure_06_n)
 
   pipeline = g_strdup ("videotestsrc num-buffers=3 ! videoconvert ! valve name=valvex ! tensor_converter ! tensor_sink name=sinkx");
 
-  count_sink = (guint *)g_malloc (sizeof (guint));
+  count_sink = (guint *) g_malloc (sizeof (guint));
   ASSERT_TRUE (count_sink != NULL);
   *count_sink = 0;
 
@@ -985,7 +984,7 @@ TEST (nnstreamer_capi_src, dummy_01)
   const gchar *_tmpdir = g_get_tmp_dir ();
   const gchar *_dirname = "nns-tizen-XXXXXX";
   gchar *fullpath = g_build_path ("/", _tmpdir, _dirname, NULL);
-  gchar *dir = g_mkdtemp ((gchar *)fullpath);
+  gchar *dir = g_mkdtemp ((gchar *) fullpath);
   gchar *file1 = g_build_path ("/", dir, "output", NULL);
   gchar *pipeline = g_strdup_printf (
       "appsrc name=srcx ! other/tensor,dimension=(string)4:1:1:1,type=(string)uint8,framerate=(fraction)0/1 ! filesink location=\"%s\" buffer-mode=unbuffered",
@@ -1012,14 +1011,14 @@ TEST (nnstreamer_capi_src, dummy_01)
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (dir != NULL);
   for (i = 0; i < 10; i++) {
-    uintarray1[i] = (uint8_t *)g_malloc (4);
+    uintarray1[i] = (uint8_t *) g_malloc (4);
     ASSERT_TRUE (uintarray1[i] != NULL);
     uintarray1[i][0] = i + 4;
     uintarray1[i][1] = i + 1;
     uintarray1[i][2] = i + 3;
     uintarray1[i][3] = i + 2;
 
-    uintarray2[i] = (uint8_t *)g_malloc (4);
+    uintarray2[i] = (uint8_t *) g_malloc (4);
     ASSERT_TRUE (uintarray2[i] != NULL);
     uintarray2[i][0] = i + 3;
     uintarray2[i][1] = i + 2;
@@ -1033,8 +1032,7 @@ TEST (nnstreamer_capi_src, dummy_01)
   EXPECT_EQ (status, ML_ERROR_NONE);
   g_usleep (10000); /* 10ms. Wait a bit. */
   status = ml_pipeline_get_state (handle, &state);
-  EXPECT_EQ (status,
-      ML_ERROR_NONE); /* At this moment, it can be READY, PAUSED, or PLAYING */
+  EXPECT_EQ (status, ML_ERROR_NONE); /* At this moment, it can be READY, PAUSED, or PLAYING */
   EXPECT_NE (state, ML_PIPELINE_STATE_UNKNOWN);
   EXPECT_NE (state, ML_PIPELINE_STATE_NULL);
 
@@ -1122,7 +1120,7 @@ TEST (nnstreamer_capi_src, dummy_01)
 
   g_free (pipeline);
 
-  EXPECT_TRUE (g_file_get_contents (file1, (gchar **)&content, &len, NULL));
+  EXPECT_TRUE (g_file_get_contents (file1, (gchar **) &content, &len, NULL));
   EXPECT_EQ (len, 8U * 11);
   EXPECT_TRUE (content != nullptr);
 
@@ -1315,8 +1313,7 @@ test_src_cb_push_dummy (ml_pipeline_src_h src_handle)
  * @brief appsrc callback - need_data.
  */
 static void
-test_src_cb_need_data (ml_pipeline_src_h src_handle, unsigned int length,
-    void *user_data)
+test_src_cb_need_data (ml_pipeline_src_h src_handle, unsigned int length, void *user_data)
 {
   /* For test, push dummy if given src handles are same. */
   if (src_handle == user_data)
@@ -1332,7 +1329,9 @@ TEST (nnstreamer_capi_src, callback_replace)
   ml_pipeline_h handle;
   ml_pipeline_src_h srchandle1, srchandle2;
   ml_pipeline_sink_h sinkhandle;
-  ml_pipeline_src_callbacks_s callback = { 0, };
+  ml_pipeline_src_callbacks_s callback = {
+    0,
+  };
   guint *count_sink;
   int status;
 
@@ -1351,7 +1350,7 @@ TEST (nnstreamer_capi_src, callback_replace)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_pipeline_sink_register (
-    handle, "sinkx", test_sink_callback_count, count_sink, &sinkhandle);
+      handle, "sinkx", test_sink_callback_count, count_sink, &sinkhandle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_pipeline_start (handle);
@@ -1396,7 +1395,9 @@ TEST (nnstreamer_capi_src, callback_invalid_param_01_n)
   const char pipeline[] = "appsrc name=srcx ! other/tensor,dimension=(string)4:1:1:1,type=(string)uint8,framerate=(fraction)0/1 ! tensor_sink";
   ml_pipeline_h handle;
   ml_pipeline_src_h srchandle;
-  ml_pipeline_src_callbacks_s callback = { 0, };
+  ml_pipeline_src_callbacks_s callback = {
+    0,
+  };
   int status;
 
   callback.need_data = test_src_cb_need_data;
@@ -1460,7 +1461,8 @@ check_orange_output (const ml_tensors_data_h data, const ml_tensors_info_h info,
       root_path, "tests", "test_models", "data", "orange.raw", NULL);
   ASSERT_TRUE (g_file_test (orange_raw_file, G_FILE_TEST_EXISTS));
 
-  EXPECT_TRUE (g_file_get_contents (orange_raw_file, (gchar **) &raw_content, &raw_content_len, NULL));
+  EXPECT_TRUE (g_file_get_contents (
+      orange_raw_file, (gchar **) &raw_content, &raw_content_len, NULL));
 
   status = ml_tensors_data_get_tensor_data (data, 0, (void **) &data, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
@@ -1511,8 +1513,7 @@ TEST (nnstreamer_capi_src, pngfile)
   ASSERT_TRUE (g_file_test (orange_png_file, G_FILE_TEST_EXISTS));
 
   pipeline = g_strdup_printf (
-    "appsrc name=srcx caps=image/png ! pngdec ! videoconvert ! videoscale ! video/x-raw,format=RGB,width=224,height=224,framerate=0/1 ! tensor_converter ! tensor_sink name=sinkx sync=false async=false"
-  );
+      "appsrc name=srcx caps=image/png ! pngdec ! videoconvert ! videoscale ! video/x-raw,format=RGB,width=224,height=224,framerate=0/1 ! tensor_converter ! tensor_sink name=sinkx sync=false async=false");
 
   /* construct pipeline */
   status = ml_pipeline_construct (pipeline, NULL, NULL, &handle);
@@ -1608,11 +1609,11 @@ TEST (nnstreamer_capi_switch, dummy_01)
       "videotestsrc is-live=true ! videoconvert ! ins.sink_0 "
       "videotestsrc num-buffers=3 is-live=true ! videoconvert ! ins.sink_1");
 
-  count_sink = (guint *)g_malloc (sizeof (guint));
+  count_sink = (guint *) g_malloc (sizeof (guint));
   ASSERT_TRUE (count_sink != NULL);
   *count_sink = 0;
 
-  pipe_state = (TestPipeState *)g_new0 (TestPipeState, 1);
+  pipe_state = (TestPipeState *) g_new0 (TestPipeState, 1);
   ASSERT_TRUE (pipe_state != NULL);
 
   status = ml_pipeline_construct (pipeline, test_pipe_state_callback, pipe_state, &handle);
@@ -1705,11 +1706,11 @@ TEST (nnstreamer_capi_switch, dummy_02)
                        "outs.src_0 ! tensor_sink name=sink0 async=false "
                        "outs.src_1 ! tensor_sink name=sink1 async=false");
 
-  count_sink0 = (guint *)g_malloc (sizeof (guint));
+  count_sink0 = (guint *) g_malloc (sizeof (guint));
   ASSERT_TRUE (count_sink0 != NULL);
   *count_sink0 = 0;
 
-  count_sink1 = (guint *)g_malloc (sizeof (guint));
+  count_sink1 = (guint *) g_malloc (sizeof (guint));
   ASSERT_TRUE (count_sink1 != NULL);
   *count_sink1 = 0;
 
@@ -2043,7 +2044,8 @@ TEST (nnstreamer_capi_util, nnfw_availability_full_01)
   int status;
   bool result;
 
-  status = ml_check_nnfw_availability_full (ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_ANY, NULL, &result);
+  status = ml_check_nnfw_availability_full (
+      ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_ANY, NULL, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, is_enabled_tensorflow_lite);
 }
@@ -2055,7 +2057,8 @@ TEST (nnstreamer_capi_util, nnfw_availability_full_02_n)
 {
   int status;
 
-  status = ml_check_nnfw_availability_full (ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_ANY, NULL, NULL);
+  status = ml_check_nnfw_availability_full (
+      ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_ANY, NULL, NULL);
   EXPECT_NE (status, ML_ERROR_NONE);
 }
 
@@ -2091,38 +2094,34 @@ TEST (nnstreamer_capi_util, availability_01)
   bool result;
   int status;
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE,
-      ML_NNFW_HW_ANY, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_ANY, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, is_enabled_tensorflow_lite);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE,
-      ML_NNFW_HW_AUTO, &result);
+  status = ml_check_nnfw_availability (
+      ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_AUTO, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, is_enabled_tensorflow_lite);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE,
-      ML_NNFW_HW_CPU, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_CPU, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, is_enabled_tensorflow_lite);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE,
-      ML_NNFW_HW_CPU_NEON, &result);
+  status = ml_check_nnfw_availability (
+      ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_CPU_NEON, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, is_enabled_tensorflow_lite);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE,
-      ML_NNFW_HW_CPU_SIMD, &result);
+  status = ml_check_nnfw_availability (
+      ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_CPU_SIMD, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, is_enabled_tensorflow_lite);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE,
-      ML_NNFW_HW_GPU, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_GPU, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, is_enabled_tensorflow_lite);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE,
-      ML_NNFW_HW_NPU, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_NPU, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, is_enabled_tensorflow_lite);
 }
@@ -2135,23 +2134,23 @@ TEST (nnstreamer_capi_util, availability_fail_01_n)
   bool result;
   int status;
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE,
-      ML_NNFW_HW_NPU_MOVIDIUS, &result);
+  status = ml_check_nnfw_availability (
+      ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_NPU_MOVIDIUS, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, false);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE,
-      ML_NNFW_HW_NPU_EDGE_TPU, &result);
+  status = ml_check_nnfw_availability (
+      ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_NPU_EDGE_TPU, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, false);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE,
-      ML_NNFW_HW_NPU_VIVANTE, &result);
+  status = ml_check_nnfw_availability (
+      ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_NPU_VIVANTE, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, false);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE,
-      ML_NNFW_HW_NPU_SR, &result);
+  status = ml_check_nnfw_availability (
+      ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_NPU_SR, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, false);
 }
@@ -2165,13 +2164,11 @@ TEST (nnstreamer_capi_util, availability_02)
   bool result;
   int status;
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW,
-      ML_NNFW_HW_ANY, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW, ML_NNFW_HW_ANY, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, true);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW,
-      ML_NNFW_HW_AUTO, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW, ML_NNFW_HW_AUTO, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, true);
 }
@@ -2184,13 +2181,13 @@ TEST (nnstreamer_capi_util, availability_fail_02_n)
   bool result;
   int status;
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW,
-      ML_NNFW_HW_NPU_VIVANTE, &result);
+  status = ml_check_nnfw_availability (
+      ML_NNFW_TYPE_TENSORFLOW, ML_NNFW_HW_NPU_VIVANTE, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, false);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW,
-      ML_NNFW_HW_NPU_MOVIDIUS, &result);
+  status = ml_check_nnfw_availability (
+      ML_NNFW_TYPE_TENSORFLOW, ML_NNFW_HW_NPU_MOVIDIUS, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, false);
 }
@@ -2204,13 +2201,11 @@ TEST (nnstreamer_capi_util, availability_03)
   bool result;
   int status;
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_CUSTOM_FILTER,
-      ML_NNFW_HW_ANY, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_CUSTOM_FILTER, ML_NNFW_HW_ANY, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, true);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_CUSTOM_FILTER,
-      ML_NNFW_HW_AUTO, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_CUSTOM_FILTER, ML_NNFW_HW_AUTO, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, true);
 }
@@ -2223,13 +2218,11 @@ TEST (nnstreamer_capi_util, availability_fail_03_n)
   bool result;
   int status;
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_CUSTOM_FILTER,
-      ML_NNFW_HW_CPU, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_CUSTOM_FILTER, ML_NNFW_HW_CPU, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, false);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_CUSTOM_FILTER,
-      ML_NNFW_HW_GPU, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_CUSTOM_FILTER, ML_NNFW_HW_GPU, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, false);
 }
@@ -2272,13 +2265,11 @@ TEST (nnstreamer_capi_util, availability_fail_04_n)
   bool result;
   int status;
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_NNFW,
-      ML_NNFW_HW_NPU_SR, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_NNFW, ML_NNFW_HW_NPU_SR, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, false);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_NNFW,
-      ML_NNFW_HW_NPU_MOVIDIUS, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_NNFW, ML_NNFW_HW_NPU_MOVIDIUS, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, false);
 }
@@ -2293,23 +2284,19 @@ TEST (nnstreamer_capi_util, availability_05)
   bool result;
   int status;
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_MVNC,
-      ML_NNFW_HW_ANY, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_MVNC, ML_NNFW_HW_ANY, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, true);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_MVNC,
-      ML_NNFW_HW_AUTO, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_MVNC, ML_NNFW_HW_AUTO, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, true);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_MVNC,
-      ML_NNFW_HW_NPU, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_MVNC, ML_NNFW_HW_NPU, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, true);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_MVNC,
-      ML_NNFW_HW_NPU_MOVIDIUS, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_MVNC, ML_NNFW_HW_NPU_MOVIDIUS, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, true);
 }
@@ -2322,13 +2309,11 @@ TEST (nnstreamer_capi_util, availability_fail_05_n)
   bool result;
   int status;
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_MVNC,
-      ML_NNFW_HW_CPU, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_MVNC, ML_NNFW_HW_CPU, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, false);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_MVNC,
-      ML_NNFW_HW_GPU, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_MVNC, ML_NNFW_HW_GPU, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, false);
 }
@@ -2343,28 +2328,23 @@ TEST (nnstreamer_capi_util, availability_06)
   bool result;
   int status;
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN,
-      ML_NNFW_HW_ANY, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN, ML_NNFW_HW_ANY, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, true);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN,
-      ML_NNFW_HW_AUTO, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN, ML_NNFW_HW_AUTO, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, true);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN,
-      ML_NNFW_HW_CPU, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN, ML_NNFW_HW_CPU, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, true);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN,
-      ML_NNFW_HW_CPU_NEON, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN, ML_NNFW_HW_CPU_NEON, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, true);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN,
-      ML_NNFW_HW_GPU, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN, ML_NNFW_HW_GPU, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, true);
 }
@@ -2377,13 +2357,11 @@ TEST (nnstreamer_capi_util, availability_fail_06_n)
   bool result;
   int status;
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN,
-      ML_NNFW_HW_NPU, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN, ML_NNFW_HW_NPU, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, false);
 
-  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN,
-      ML_NNFW_HW_NPU_EDGE_TPU, &result);
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN, ML_NNFW_HW_NPU_EDGE_TPU, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, false);
 }
@@ -2395,19 +2373,20 @@ TEST (nnstreamer_capi_util, availability_fail_06_n)
 TEST (nnstreamer_capi_util, element_available_01_p)
 {
   bool available;
-  int status, n_elems,  i;
+  int status, n_elems, i;
   /**
    * If the allowed element list of nnstreamer is changed, this should also be changed.
    * https://github.com/nnstreamer/nnstreamer/blob/main/packaging/nnstreamer.spec#L642 (# Element allowance in Tizen)
    */
   const gchar *allowed = "tensor_converter tensor_filter tensor_query_serversrc capsfilter input-selector output-selector queue tee valve appsink appsrc audioconvert audiorate audioresample audiomixer videoconvert videocrop videorate videoscale videoflip videomixer compositor fakesrc fakesink filesrc filesink audiotestsrc videotestsrc jpegparse jpegenc jpegdec pngenc pngdec tcpclientsink tcpclientsrc tcpserversink tcpserversrc xvimagesink ximagesink evasimagesink evaspixmapsink glimagesink theoraenc lame vorbisenc wavenc volume oggmux avimux matroskamux v4l2src avsysvideosrc camerasrc tvcamerasrc pulsesrc fimcconvert tizenwlsink gdppay gdpdepay join rtpdec rtspsrc rtspclientsink zmqsrc zmqsink mqttsrc mqttsink udpsrc udpsink multiudpsink audioamplify audiochebband audiocheblimit audiodynamic audioecho audiofirfilter audioiirfilter audioinvert audiokaraoke audiopanorama audiowsincband audiowsinclimit scaletempo stereo";
   /** This not_allowed list is written only for testing. */
-  const gchar *not_allowed = "videobox videobalance aasink adder alpha alsasink x264enc ximagesrc webpenc wavescope v4l2sink v4l2radio urisourcebin uridecodebin typefind timeoverlay rtpstreampay rtpsession rtpgstpay queue2 fdsink fdsrc chromium capssetter cairooverlay autovideosink";
+  const gchar *not_allowed
+      = "videobox videobalance aasink adder alpha alsasink x264enc ximagesrc webpenc wavescope v4l2sink v4l2radio urisourcebin uridecodebin typefind timeoverlay rtpstreampay rtpsession rtpgstpay queue2 fdsink fdsrc chromium capssetter cairooverlay autovideosink";
   gchar **elements;
   gboolean restricted;
 
-  restricted = nnsconf_get_custom_value_bool ("element-restriction",
-      "enable_element_restriction", FALSE);
+  restricted = nnsconf_get_custom_value_bool (
+      "element-restriction", "enable_element_restriction", FALSE);
 
   /* element restriction is disabled */
   if (!restricted)
@@ -2589,7 +2568,7 @@ TEST (nnstreamer_capi_util, tensors_info_extended)
   status = ml_tensors_info_create_extended (&info);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  for (i = 0 ;i < ML_TENSOR_RANK_LIMIT ; i++) {
+  for (i = 0; i < ML_TENSOR_RANK_LIMIT; i++) {
     in_dim[i] = i % 4 + 1;
   }
 
@@ -2617,7 +2596,7 @@ TEST (nnstreamer_capi_util, tensors_info_extended)
   status = ml_tensors_info_get_tensor_dimension (info, 0, out_dim);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  for (i = 0 ;i < ML_TENSOR_RANK_LIMIT ; i++) {
+  for (i = 0; i < ML_TENSOR_RANK_LIMIT; i++) {
     EXPECT_EQ (out_dim[i], i % 4 + 1);
   }
 
@@ -2632,7 +2611,7 @@ TEST (nnstreamer_capi_util, tensors_info_extended)
   status = ml_tensors_info_get_tensor_dimension (info, 1, out_dim);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  for (i = 0 ;i < ML_TENSOR_RANK_LIMIT ; i++) {
+  for (i = 0; i < ML_TENSOR_RANK_LIMIT; i++) {
     EXPECT_EQ (out_dim[i], i % 4 + 1);
   }
 
@@ -2648,11 +2627,13 @@ TEST (nnstreamer_capi_util, tensors_info_extended)
 
   status = ml_tensors_info_get_tensor_size (info, 1, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  EXPECT_TRUE (data_size == ((2 * 3 * 4) * (2 * 3 * 4) * (2 * 3 * 4) * (2 * 3 * 4)* 8));
+  EXPECT_TRUE (data_size == ((2 * 3 * 4) * (2 * 3 * 4) * (2 * 3 * 4) * (2 * 3 * 4) * 8));
 
   status = ml_tensors_info_get_tensor_size (info, -1, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  EXPECT_TRUE (data_size == (((2 * 3 * 4) * (2 * 3 * 4) * (2 * 3 * 4) * (2 * 3 * 4)) + ((2 * 3 * 4) * (2 * 3 * 4) * (2 * 3 * 4) * (2 * 3 * 4)* 8)));
+  EXPECT_TRUE (data_size
+               == (((2 * 3 * 4) * (2 * 3 * 4) * (2 * 3 * 4) * (2 * 3 * 4))
+                   + ((2 * 3 * 4) * (2 * 3 * 4) * (2 * 3 * 4) * (2 * 3 * 4) * 8)));
 
   status = ml_tensors_info_destroy (info);
   EXPECT_EQ (status, ML_ERROR_NONE);
@@ -2723,7 +2704,7 @@ TEST (nnstreamer_capi_util, compare_info_extended)
   status = ml_tensors_info_create_extended (&info2);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  for (i = 0 ;i < ML_TENSOR_RANK_LIMIT ; i++) {
+  for (i = 0; i < ML_TENSOR_RANK_LIMIT; i++) {
     dim[i] = i + 1;
   }
 
@@ -2772,7 +2753,7 @@ TEST (nnstreamer_capi_util, compare_info_extended_n)
   status = ml_tensors_info_create (&info2);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  for (i = 0 ;i < ML_TENSOR_RANK_LIMIT ; i++) {
+  for (i = 0; i < ML_TENSOR_RANK_LIMIT; i++) {
     dim[i] = i + 1;
   }
 
@@ -2972,9 +2953,9 @@ TEST (nnstreamer_capi_util, info_comp_0)
   status = ml_tensors_info_create (&info2);
   ASSERT_EQ (status, ML_ERROR_NONE);
 
-  is = (ml_tensors_info_s *)info1;
+  is = (ml_tensors_info_s *) info1;
   is->num_tensors = 1;
-  is = (ml_tensors_info_s *)info2;
+  is = (ml_tensors_info_s *) info2;
   is->num_tensors = 2;
 
   status = _ml_tensors_info_compare (info1, info2, &equal);
@@ -3461,7 +3442,7 @@ TEST (nnstreamer_capi_util, info_clone_extended)
   status = ml_tensors_info_create_extended (&out_info);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  for (i = 0 ;i < ML_TENSOR_RANK_LIMIT ; i++) {
+  for (i = 0; i < ML_TENSOR_RANK_LIMIT; i++) {
     in_dim[i] = i + 1;
   }
 
@@ -3486,7 +3467,7 @@ TEST (nnstreamer_capi_util, info_clone_extended)
   status = ml_tensors_info_get_tensor_dimension (out_info, 0, out_dim);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  for (i = 0 ;i < ML_TENSOR_RANK_LIMIT ; i++) {
+  for (i = 0; i < ML_TENSOR_RANK_LIMIT; i++) {
     EXPECT_TRUE (in_dim[i] == out_dim[i]);
   }
 
@@ -6713,7 +6694,7 @@ TEST (nnstreamer_capi_element, scenario_02_p)
 
   pipeline = g_strdup ("videotestsrc is-live=true ! videoconvert ! tensor_converter ! appsink name=sinkx sync=false");
 
-  count_sink = (guint *)g_malloc (sizeof (guint));
+  count_sink = (guint *) g_malloc (sizeof (guint));
   ASSERT_TRUE (count_sink != NULL);
   *count_sink = 0;
 
@@ -6792,7 +6773,7 @@ TEST (nnstreamer_capi_internal, copy_from_gst)
   status = ml_tensors_info_create (&ml_info);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
+  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *) ml_info, &gst_info);
   status = ml_tensors_info_get_count (ml_info, &count);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (count, 2U);
@@ -6805,7 +6786,7 @@ TEST (nnstreamer_capi_internal, copy_from_gst)
 
   gst_info.info[0].type = _NNS_INT32;
   gst_info.info[1].type = _NNS_UINT32;
-  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
+  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *) ml_info, &gst_info);
   status = ml_tensors_info_get_tensor_type (ml_info, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (type, ML_TENSOR_TYPE_INT32);
@@ -6815,7 +6796,7 @@ TEST (nnstreamer_capi_internal, copy_from_gst)
 
   gst_info.info[0].type = _NNS_INT16;
   gst_info.info[1].type = _NNS_UINT16;
-  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
+  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *) ml_info, &gst_info);
   status = ml_tensors_info_get_tensor_type (ml_info, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (type, ML_TENSOR_TYPE_INT16);
@@ -6825,7 +6806,7 @@ TEST (nnstreamer_capi_internal, copy_from_gst)
 
   gst_info.info[0].type = _NNS_INT8;
   gst_info.info[1].type = _NNS_UINT8;
-  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
+  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *) ml_info, &gst_info);
   status = ml_tensors_info_get_tensor_type (ml_info, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (type, ML_TENSOR_TYPE_INT8);
@@ -6835,7 +6816,7 @@ TEST (nnstreamer_capi_internal, copy_from_gst)
 
   gst_info.info[0].type = _NNS_INT64;
   gst_info.info[1].type = _NNS_UINT64;
-  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
+  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *) ml_info, &gst_info);
   status = ml_tensors_info_get_tensor_type (ml_info, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (type, ML_TENSOR_TYPE_INT64);
@@ -6845,7 +6826,7 @@ TEST (nnstreamer_capi_internal, copy_from_gst)
 
   gst_info.info[0].type = _NNS_FLOAT64;
   gst_info.info[1].type = _NNS_FLOAT32;
-  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
+  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *) ml_info, &gst_info);
   status = ml_tensors_info_get_tensor_type (ml_info, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (type, ML_TENSOR_TYPE_FLOAT64);
@@ -6855,7 +6836,7 @@ TEST (nnstreamer_capi_internal, copy_from_gst)
 
   gst_info.info[0].name = g_strdup ("tn1");
   gst_info.info[1].name = g_strdup ("tn2");
-  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
+  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *) ml_info, &gst_info);
   status = ml_tensors_info_get_tensor_name (ml_info, 0, &name);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_STREQ (name, "tn1");
@@ -6896,7 +6877,7 @@ TEST (nnstreamer_capi_internal, copy_from_gst_extended)
   status = ml_tensors_info_create_extended (&ml_info);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *)ml_info, &gst_info);
+  _ml_tensors_info_copy_from_gst ((ml_tensors_info_s *) ml_info, &gst_info);
   status = ml_tensors_info_get_count (ml_info, &count);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (count, 2U);
@@ -6964,7 +6945,7 @@ TEST (nnstreamer_capi_internal, copy_from_ml)
   status = ml_tensors_info_set_tensor_dimension (ml_info, 1, dim);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
+  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *) ml_info);
   EXPECT_EQ (gst_info.num_tensors, 2U);
   EXPECT_EQ (gst_info.info[0].dimension[0], 1U);
   EXPECT_EQ (gst_info.info[0].dimension[1], 2U);
@@ -6975,7 +6956,7 @@ TEST (nnstreamer_capi_internal, copy_from_ml)
   EXPECT_EQ (status, ML_ERROR_NONE);
   status = ml_tensors_info_set_tensor_type (ml_info, 1, ML_TENSOR_TYPE_UINT32);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
+  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *) ml_info);
   EXPECT_EQ (gst_info.info[0].type, _NNS_INT32);
   EXPECT_EQ (gst_info.info[1].type, _NNS_UINT32);
 
@@ -6983,7 +6964,7 @@ TEST (nnstreamer_capi_internal, copy_from_ml)
   EXPECT_EQ (status, ML_ERROR_NONE);
   status = ml_tensors_info_set_tensor_type (ml_info, 1, ML_TENSOR_TYPE_UINT16);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
+  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *) ml_info);
   EXPECT_EQ (gst_info.info[0].type, _NNS_INT16);
   EXPECT_EQ (gst_info.info[1].type, _NNS_UINT16);
 
@@ -6991,7 +6972,7 @@ TEST (nnstreamer_capi_internal, copy_from_ml)
   EXPECT_EQ (status, ML_ERROR_NONE);
   status = ml_tensors_info_set_tensor_type (ml_info, 1, ML_TENSOR_TYPE_UINT8);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
+  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *) ml_info);
   EXPECT_EQ (gst_info.info[0].type, _NNS_INT8);
   EXPECT_EQ (gst_info.info[1].type, _NNS_UINT8);
 
@@ -6999,7 +6980,7 @@ TEST (nnstreamer_capi_internal, copy_from_ml)
   EXPECT_EQ (status, ML_ERROR_NONE);
   status = ml_tensors_info_set_tensor_type (ml_info, 1, ML_TENSOR_TYPE_UINT64);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
+  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *) ml_info);
   EXPECT_EQ (gst_info.info[0].type, _NNS_INT64);
   EXPECT_EQ (gst_info.info[1].type, _NNS_UINT64);
 
@@ -7007,7 +6988,7 @@ TEST (nnstreamer_capi_internal, copy_from_ml)
   EXPECT_EQ (status, ML_ERROR_NONE);
   status = ml_tensors_info_set_tensor_type (ml_info, 1, ML_TENSOR_TYPE_FLOAT32);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
+  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *) ml_info);
   EXPECT_EQ (gst_info.info[0].type, _NNS_FLOAT64);
   EXPECT_EQ (gst_info.info[1].type, _NNS_FLOAT32);
 
@@ -7015,7 +6996,7 @@ TEST (nnstreamer_capi_internal, copy_from_ml)
   EXPECT_EQ (status, ML_ERROR_NONE);
   status = ml_tensors_info_set_tensor_name (ml_info, 1, "tn2");
   EXPECT_EQ (status, ML_ERROR_NONE);
-  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *)ml_info);
+  _ml_tensors_info_copy_from_ml (&gst_info, (ml_tensors_info_s *) ml_info);
   EXPECT_STREQ (gst_info.info[0].name, "tn1");
   EXPECT_STREQ (gst_info.info[1].name, "tn2");
 
@@ -7059,13 +7040,12 @@ TEST (nnstreamer_capi_internal, copy_from_ml_02_n)
  * @brief Invoke callback for custom-easy filter.
  */
 static int
-test_custom_easy_cb (const ml_tensors_data_h in, ml_tensors_data_h out,
-    void *user_data)
+test_custom_easy_cb (const ml_tensors_data_h in, ml_tensors_data_h out, void *user_data)
 {
   /* test code, set data size. */
   if (user_data) {
     void *raw_data = NULL;
-    size_t *data_size = (size_t *)user_data;
+    size_t *data_size = (size_t *) user_data;
 
     ml_tensors_data_get_tensor_data (out, 0, &raw_data, data_size);
   }
@@ -7090,8 +7070,8 @@ TEST (nnstreamer_capi_custom, register_filter_01_p)
   gchar *pipeline = g_strdup_printf (
       "appsrc name=srcx ! other/tensor,dimension=(string)2:1:1:1,type=(string)int8,framerate=(fraction)0/1 ! tensor_filter framework=custom-easy model=%s ! tensor_sink name=sinkx",
       test_custom_filter);
-  guint *count_sink = (guint *)g_malloc0 (sizeof (guint));
-  size_t *filter_data_size = (size_t *)g_malloc0 (sizeof (size_t));
+  guint *count_sink = (guint *) g_malloc0 (sizeof (guint));
+  size_t *filter_data_size = (size_t *) g_malloc0 (sizeof (size_t));
   size_t data_size;
   guint i;
 
@@ -7505,7 +7485,7 @@ TEST (nnstreamer_capi_if, custom_01_p)
   const gchar *_tmpdir = g_get_tmp_dir ();
   const gchar *_dirname = "nns-tizen-XXXXXX";
   gchar *fullpath = g_build_path ("/", _tmpdir, _dirname, NULL);
-  gchar *dir = g_mkdtemp ((gchar *)fullpath);
+  gchar *dir = g_mkdtemp ((gchar *) fullpath);
   gchar *file = g_build_path ("/", dir, "output", NULL);
   ml_pipeline_h pipe;
   ml_pipeline_src_h srchandle;
@@ -7524,15 +7504,16 @@ TEST (nnstreamer_capi_if, custom_01_p)
       "appsrc name=appsrc ! other/tensor,dimension=(string)4:1:1:1, type=(string)uint8,framerate=(fraction)0/1 ! "
       "tensor_if name=tif compared-value=CUSTOM compared-value-option=tif_custom_cb_name then=PASSTHROUGH else=PASSTHROUGH "
       "tif.src_0 ! queue ! filesink location=\"%s\" buffer-mode=unbuffered "
-      "tif.src_1 ! queue ! tensor_sink name=sink_false sync=false async=false", file);
+      "tif.src_1 ! queue ! tensor_sink name=sink_false sync=false async=false",
+      file);
 
-  guint *count_sink = (guint *)g_malloc0 (sizeof (guint));
+  guint *count_sink = (guint *) g_malloc0 (sizeof (guint));
   ASSERT_TRUE (count_sink != NULL);
   *count_sink = 0;
 
   /* test code for tensor_if custom */
-  status = ml_pipeline_tensor_if_custom_register ("tif_custom_cb_name",
-      test_if_custom_cb, NULL, &custom);
+  status = ml_pipeline_tensor_if_custom_register (
+      "tif_custom_cb_name", test_if_custom_cb, NULL, &custom);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_pipeline_construct (pipeline, NULL, NULL, &pipe);
@@ -7549,7 +7530,7 @@ TEST (nnstreamer_capi_if, custom_01_p)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   for (i = 0; i < 10; i++) {
-    uintarray[i] = (uint8_t *)g_malloc (4);
+    uintarray[i] = (uint8_t *) g_malloc (4);
     ASSERT_TRUE (uintarray[i] != NULL);
     uintarray[i][0] = i + 4;
     uintarray[i][1] = i + 1;
@@ -7574,8 +7555,7 @@ TEST (nnstreamer_capi_if, custom_01_p)
     status = ml_tensors_data_set_tensor_data (data, 0, uintarray[i], 4);
     EXPECT_EQ (status, ML_ERROR_NONE);
 
-    status = ml_pipeline_src_input_data (srchandle, data,
-        ML_PIPELINE_BUF_POLICY_DO_NOT_FREE);
+    status = ml_pipeline_src_input_data (srchandle, data, ML_PIPELINE_BUF_POLICY_DO_NOT_FREE);
     EXPECT_EQ (status, ML_ERROR_NONE);
 
     g_usleep (50000); /* 50ms. Wait a bit. */
@@ -7596,7 +7576,7 @@ TEST (nnstreamer_capi_if, custom_01_p)
   status = ml_pipeline_tensor_if_custom_unregister (custom);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  EXPECT_TRUE (g_file_get_contents (file, (gchar **)&content, &len, NULL));
+  EXPECT_TRUE (g_file_get_contents (file, (gchar **) &content, &len, NULL));
   EXPECT_EQ (len, 4U * 5);
   EXPECT_TRUE (content != nullptr);
 
@@ -7635,8 +7615,7 @@ TEST (nnstreamer_capi_if, register_01_n)
   int status;
 
   /* test code with null param */
-  status = ml_pipeline_tensor_if_custom_register (NULL, test_if_custom_cb,
-      NULL, &custom);
+  status = ml_pipeline_tensor_if_custom_register (NULL, test_if_custom_cb, NULL, &custom);
   EXPECT_NE (status, ML_ERROR_NONE);
 }
 
@@ -7650,8 +7629,7 @@ TEST (nnstreamer_capi_if, register_02_n)
   int status;
 
   /* test code with null param */
-  status = ml_pipeline_tensor_if_custom_register ("tif_custom_cb_name",
-      NULL, NULL, &custom);
+  status = ml_pipeline_tensor_if_custom_register ("tif_custom_cb_name", NULL, NULL, &custom);
   EXPECT_NE (status, ML_ERROR_NONE);
 }
 
@@ -7664,8 +7642,8 @@ TEST (nnstreamer_capi_if, register_03_n)
   int status;
 
   /* test code with null param */
-  status = ml_pipeline_tensor_if_custom_register ("tif_custom_cb_name",
-      test_if_custom_cb, NULL, NULL);
+  status = ml_pipeline_tensor_if_custom_register (
+      "tif_custom_cb_name", test_if_custom_cb, NULL, NULL);
   EXPECT_NE (status, ML_ERROR_NONE);
 }
 
@@ -7678,13 +7656,13 @@ TEST (nnstreamer_capi_if, register_04_n)
   ml_pipeline_if_h custom1, custom2;
   int status;
 
-  status = ml_pipeline_tensor_if_custom_register ("tif_custom_cb_name",
-      test_if_custom_cb, NULL, &custom1);
+  status = ml_pipeline_tensor_if_custom_register (
+      "tif_custom_cb_name", test_if_custom_cb, NULL, &custom1);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* test to register tensor_if custom twice with same name */
-  status = ml_pipeline_tensor_if_custom_register ("tif_custom_cb_name",
-      test_if_custom_cb, NULL, &custom2);
+  status = ml_pipeline_tensor_if_custom_register (
+      "tif_custom_cb_name", test_if_custom_cb, NULL, &custom2);
   EXPECT_NE (status, ML_ERROR_NONE);
 
   status = ml_pipeline_tensor_if_custom_unregister (custom1);
@@ -7719,8 +7697,8 @@ TEST (nnstreamer_capi_if, unregister_02_n)
       "tif.src_0 ! queue ! tensor_sink name=sink_true sync=false async=false "
       "tif.src_1 ! queue ! tensor_sink name=sink_false sync=false async=false");
 
-  status = ml_pipeline_tensor_if_custom_register ("tif_unreg_test",
-      test_if_custom_cb, NULL, &custom);
+  status = ml_pipeline_tensor_if_custom_register (
+      "tif_unreg_test", test_if_custom_cb, NULL, &custom);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_pipeline_construct (pipeline, NULL, NULL, &pipe1);
@@ -7753,8 +7731,8 @@ TEST (nnstreamer_capi_if, unregister_02_n)
  * @brief A tensor-sink callback for sink handle in a pipeline
  */
 static void
-test_sink_callback_flush (const ml_tensors_data_h data,
-    const ml_tensors_info_h info, void *user_data)
+test_sink_callback_flush (
+    const ml_tensors_data_h data, const ml_tensors_info_h info, void *user_data)
 {
   guint *count = (guint *) user_data;
 
@@ -7787,10 +7765,11 @@ TEST (nnstreamer_capi_flush, success_01_p)
   ml_tensors_data_h in_data;
   ml_tensor_dimension dim = { 10, 1, 1, 1 };
   int status;
-  gchar pipeline[] = "appsrc name=srcx ! "
-      "other/tensor,dimension=(string)10:1:1:1,type=(string)int32,framerate=(fraction)0/1 ! "
-      "tensor_aggregator frames-in=10 frames-out=3 frames-flush=3 frames-dim=0 ! "
-      "tensor_sink name=sinkx";
+  gchar pipeline[]
+      = "appsrc name=srcx ! "
+        "other/tensor,dimension=(string)10:1:1:1,type=(string)int32,framerate=(fraction)0/1 ! "
+        "tensor_aggregator frames-in=10 frames-out=3 frames-flush=3 frames-dim=0 ! "
+        "tensor_sink name=sinkx";
   gint test_data[10] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
   guint *count_sink = (guint *) g_malloc0 (sizeof (guint));
   ASSERT_TRUE (count_sink != NULL);
@@ -7811,8 +7790,8 @@ TEST (nnstreamer_capi_flush, success_01_p)
   status = ml_pipeline_src_get_handle (handle, "srcx", &srchandle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_sink_register (handle, "sinkx",
-      test_sink_callback_flush, count_sink, &sinkhandle);
+  status = ml_pipeline_sink_register (
+      handle, "sinkx", test_sink_callback_flush, count_sink, &sinkhandle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_pipeline_start (handle);
@@ -7820,8 +7799,7 @@ TEST (nnstreamer_capi_flush, success_01_p)
 
   /* push input data */
   *count_sink = 0;
-  status = ml_pipeline_src_input_data (srchandle, in_data,
-        ML_PIPELINE_BUF_POLICY_DO_NOT_FREE);
+  status = ml_pipeline_src_input_data (srchandle, in_data, ML_PIPELINE_BUF_POLICY_DO_NOT_FREE);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   wait_pipeline_process_buffers (*count_sink, 3);
@@ -7834,8 +7812,7 @@ TEST (nnstreamer_capi_flush, success_01_p)
 
   /* push input data again */
   *count_sink = 0;
-  status = ml_pipeline_src_input_data (srchandle, in_data,
-        ML_PIPELINE_BUF_POLICY_DO_NOT_FREE);
+  status = ml_pipeline_src_input_data (srchandle, in_data, ML_PIPELINE_BUF_POLICY_DO_NOT_FREE);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   wait_pipeline_process_buffers (*count_sink, 3);
@@ -7866,8 +7843,8 @@ TEST (nnstreamer_capi_flush, failure_02_n)
  * @brief A tensor-sink callback for sink handle in a pipeline
  */
 static void
-test_sink_callback_flex (const ml_tensors_data_h data,
-    const ml_tensors_info_h info, void *user_data)
+test_sink_callback_flex (
+    const ml_tensors_data_h data, const ml_tensors_info_h info, void *user_data)
 {
   guint *count = (guint *) user_data;
   gint status;
@@ -7912,9 +7889,10 @@ test_sink_callback_flex (const ml_tensors_data_h data,
  */
 TEST (nnstreamer_capi_flex, sink_multi)
 {
-  gchar pipeline[] = "appsrc name=srcx caps=application/octet-stream,framerate=(fraction)10/1 ! "
-      "tensor_converter input-dim=4,2,4 input-type=int32,int32,int32 ! "
-      "other/tensors,format=flexible ! tensor_sink name=sinkx sync=false";
+  gchar pipeline[]
+      = "appsrc name=srcx caps=application/octet-stream,framerate=(fraction)10/1 ! "
+        "tensor_converter input-dim=4,2,4 input-type=int32,int32,int32 ! "
+        "other/tensors,format=flexible ! tensor_sink name=sinkx sync=false";
   guint test_data[10] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
   ml_pipeline_h handle;
   ml_pipeline_src_h srchandle;
@@ -7944,8 +7922,8 @@ TEST (nnstreamer_capi_flex, sink_multi)
   status = ml_pipeline_src_get_handle (handle, "srcx", &srchandle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_sink_register (handle, "sinkx",
-      test_sink_callback_flex, count_sink, &sinkhandle);
+  status = ml_pipeline_sink_register (
+      handle, "sinkx", test_sink_callback_flex, count_sink, &sinkhandle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_pipeline_start (handle);
@@ -7955,8 +7933,7 @@ TEST (nnstreamer_capi_flex, sink_multi)
   *count_sink = 0;
   for (i = 0; i < 3; i++) {
     g_usleep (50000);
-    status = ml_pipeline_src_input_data (srchandle, in_data,
-          ML_PIPELINE_BUF_POLICY_DO_NOT_FREE);
+    status = ml_pipeline_src_input_data (srchandle, in_data, ML_PIPELINE_BUF_POLICY_DO_NOT_FREE);
     EXPECT_EQ (status, ML_ERROR_NONE);
   }
 
@@ -7978,8 +7955,8 @@ TEST (nnstreamer_capi_flex, sink_multi)
 TEST (nnstreamer_capi_flex, src_multi)
 {
   gchar pipeline[] = "appsrc name=srcx caps=other/tensors,format=flexible,framerate=(fraction)10/1 ! "
-      "tensor_converter input-dim=4,2,4 input-type=int32,int32,int32 ! "
-      "tensor_sink name=sinkx sync=false";
+                     "tensor_converter input-dim=4,2,4 input-type=int32,int32,int32 ! "
+                     "tensor_sink name=sinkx sync=false";
   guint test_data[10] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
   ml_pipeline_h handle;
   ml_pipeline_src_h srchandle;
@@ -8017,8 +7994,8 @@ TEST (nnstreamer_capi_flex, src_multi)
   status = ml_pipeline_src_get_handle (handle, "srcx", &srchandle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_sink_register (handle, "sinkx",
-      test_sink_callback_flex, count_sink, &sinkhandle);
+  status = ml_pipeline_sink_register (
+      handle, "sinkx", test_sink_callback_flex, count_sink, &sinkhandle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_pipeline_start (handle);
@@ -8028,8 +8005,7 @@ TEST (nnstreamer_capi_flex, src_multi)
   *count_sink = 0;
   for (i = 0; i < 3; i++) {
     g_usleep (50000);
-    status = ml_pipeline_src_input_data (srchandle, in_data,
-          ML_PIPELINE_BUF_POLICY_DO_NOT_FREE);
+    status = ml_pipeline_src_input_data (srchandle, in_data, ML_PIPELINE_BUF_POLICY_DO_NOT_FREE);
     EXPECT_EQ (status, ML_ERROR_NONE);
   }
 

--- a/tests/capi/unittest_capi_inference_latency.cc
+++ b/tests/capi/unittest_capi_inference_latency.cc
@@ -14,13 +14,13 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include <nnstreamer.h>
-#include <nnstreamer-single.h>
-#include <nnstreamer_plugin_api.h>
-#include <nnstreamer_plugin_api_filter.h>
-#include <ml-api-internal.h>
 #include <ml-api-inference-internal.h>
 #include <ml-api-inference-pipeline-internal.h>
+#include <ml-api-internal.h>
+#include <nnstreamer-single.h>
+#include <nnstreamer.h>
+#include <nnstreamer_plugin_api.h>
+#include <nnstreamer_plugin_api_filter.h>
 
 /**
  * @brief nnstreamer invoke latency testing base class
@@ -96,7 +96,7 @@ class nnstreamer_capi_singleshot_latency : public ::testing::Test
   {
     /** Find the framework */
     const GstTensorFilterFramework *sp = nnstreamer_filter_find (filter);
-    EXPECT_NE (sp, (void *)NULL);
+    EXPECT_NE (sp, (void *) NULL);
 
     /** Extract the statictics from the framework */
     EXPECT_TRUE (sp->statistics != NULL);
@@ -116,7 +116,7 @@ class nnstreamer_capi_singleshot_latency : public ::testing::Test
   void matchOutput (void *output_data, size_t size)
   {
     size_t idx, max_idx = 0;
-    guint8 *array = (guint8 *)output_data;
+    guint8 *array = (guint8 *) output_data;
     guint8 max_value = 0;
     for (idx = 0; idx < size; idx++) {
       if (max_value < array[idx]) {
@@ -168,12 +168,12 @@ class nnstreamer_capi_singleshot_latency : public ::testing::Test
     EXPECT_TRUE (input != NULL);
 
     /** Load input data into the buffer */
-    status = ml_tensors_data_get_tensor_data (input, 0, (void **)&data, &data_size);
+    status = ml_tensors_data_get_tensor_data (input, 0, (void **) &data, &data_size);
     EXPECT_EQ (status, ML_ERROR_NONE);
     if (fd >= 0) {
       resetDataFile ();
       data_read = read (fd, data, data_size);
-      EXPECT_EQ ((size_t)data_read, data_size);
+      EXPECT_EQ ((size_t) data_read, data_size);
     }
 
     /** Benchmark the invoke duration */
@@ -196,7 +196,7 @@ class nnstreamer_capi_singleshot_latency : public ::testing::Test
 
       /** Match output with the first run */
       if (idx == 0) {
-        status = ml_tensors_data_get_tensor_data (output, 0, (void **)&data, &data_size);
+        status = ml_tensors_data_get_tensor_data (output, 0, (void **) &data, &data_size);
         EXPECT_EQ (status, ML_ERROR_NONE);
         matchOutput (data, data_size);
       }

--- a/tests/capi/unittest_capi_inference_nnfw_runtime.cc
+++ b/tests/capi/unittest_capi_inference_nnfw_runtime.cc
@@ -9,18 +9,18 @@
 
 #include <gtest/gtest.h>
 #include <glib.h>
-#include <nnstreamer.h>
-#include <nnstreamer-single.h>
-#include <ml-api-internal.h>
 #include <ml-api-inference-internal.h>
 #include <ml-api-inference-pipeline-internal.h>
+#include <ml-api-internal.h>
+#include <nnstreamer-single.h>
+#include <nnstreamer.h>
 
 /**
  * @brief Test Fixture class for ML API of the NNFW Inference
  */
 class MLAPIInferenceNNFW : public ::testing::Test
 {
-protected:
+  protected:
   ml_single_h single_h;
   ml_pipeline_h pipeline_h;
   ml_tensors_info_h in_info, out_info;
@@ -34,13 +34,16 @@ protected:
    * @brief Get the valid model file for NNFW test
    * @return gchar* the path of the model file
    */
-  gchar *GetVaildModelFile () {
+  gchar *GetVaildModelFile ()
+  {
     gchar *model_file;
 
     /* nnfw needs a directory with model file and metadata in that directory */
-    g_autofree gchar *model_path = g_build_filename (root_path, "tests", "test_models", "models", NULL);
+    g_autofree gchar *model_path
+        = g_build_filename (root_path, "tests", "test_models", "models", NULL);
 
-    g_autofree gchar *meta_file = g_build_filename (model_path, "metadata", "MANIFEST", NULL);
+    g_autofree gchar *meta_file
+        = g_build_filename (model_path, "metadata", "MANIFEST", NULL);
     if (!g_file_test (meta_file, G_FILE_TEST_EXISTS)) {
       return NULL;
     }
@@ -53,14 +56,14 @@ protected:
     return model_file;
   }
 
-protected:
+  protected:
   /**
    * @brief Construct a new MLAPIInferenceNNFW object
    */
   MLAPIInferenceNNFW ()
-    : single_h(nullptr), pipeline_h(nullptr), in_info(nullptr), out_info(nullptr),
-      in_res(nullptr), out_res(nullptr), input(nullptr), input2(nullptr), output(nullptr),
-      root_path(nullptr), valid_model(nullptr)
+      : single_h (nullptr), pipeline_h (nullptr), in_info (nullptr),
+        out_info (nullptr), in_res (nullptr), out_res (nullptr), input (nullptr),
+        input2 (nullptr), output (nullptr), root_path (nullptr), valid_model (nullptr)
   {
     for (int i = 0; i < ML_TENSOR_RANK_LIMIT; ++i)
       in_dim[i] = out_dim[i] = res_dim[i] = 1;
@@ -81,7 +84,7 @@ protected:
     if (root_path == NULL) {
       root_path = "..";
     }
-    valid_model = GetVaildModelFile();
+    valid_model = GetVaildModelFile ();
   }
 
   /**
@@ -112,22 +115,22 @@ protected:
     ml_tensors_info_destroy (out_info);
     ml_tensors_info_destroy (in_res);
     ml_tensors_info_destroy (out_res);
-    g_free (const_cast<gchar *>(valid_model));
+    g_free (const_cast<gchar *> (valid_model));
   }
 
   /**
    * @brief Signal handler for new data of tensor_sink element
    * @note This handler checks the number of received tensor counts.
    */
-  static void
-  cb_new_data (const ml_tensors_data_h data, const ml_tensors_info_h info, void *user_data)
+  static void cb_new_data (const ml_tensors_data_h data,
+      const ml_tensors_info_h info, void *user_data)
   {
     int status;
     float *data_ptr;
     size_t data_size;
-    int *checks = (int *)user_data;
+    int *checks = (int *) user_data;
 
-    status = ml_tensors_data_get_tensor_data (data, 0, (void **)&data_ptr, &data_size);
+    status = ml_tensors_data_get_tensor_data (data, 0, (void **) &data_ptr, &data_size);
     EXPECT_EQ (status, ML_ERROR_NONE);
     EXPECT_FLOAT_EQ (*data_ptr, 12.0);
 
@@ -138,14 +141,14 @@ protected:
    * @brief Signal handler for new data of tensor_sink element and check its shape and payload.
    * @note This handler checks the rank, dimension, and payload of the received tensor.
    */
-  static void
-  cb_new_data_checker (const ml_tensors_data_h data, const ml_tensors_info_h info, void *user_data)
+  static void cb_new_data_checker (const ml_tensors_data_h data,
+      const ml_tensors_info_h info, void *user_data)
   {
     unsigned int cnt = 0;
     int status;
     float *data_ptr;
     size_t data_size;
-    int *checks = (int *)user_data;
+    int *checks = (int *) user_data;
     ml_tensor_dimension out_dim;
 
     ml_tensors_info_get_count (info, &cnt);
@@ -157,7 +160,7 @@ protected:
     EXPECT_EQ (out_dim[2], 1U);
     EXPECT_EQ (out_dim[3], 1U);
 
-    status = ml_tensors_data_get_tensor_data (data, 0, (void **)&data_ptr, &data_size);
+    status = ml_tensors_data_get_tensor_data (data, 0, (void **) &data_ptr, &data_size);
     EXPECT_EQ (status, ML_ERROR_NONE);
     EXPECT_EQ (data_size, 1001U);
 
@@ -167,8 +170,7 @@ protected:
   /**
    * @brief Synchronization function for the pipeline execution.
    */
-  static void
-  wait_for_sink (guint* call_cnt, const guint expected_cnt)
+  static void wait_for_sink (guint *call_cnt, const guint expected_cnt)
   {
     guint waiting_time = 0U;
     guint unit_time = 1000U * 1000; /* 1 second */
@@ -205,8 +207,8 @@ TEST_F (MLAPIInferenceNNFW, invoke_single_00)
   ml_tensors_info_set_tensor_type (out_info, 0, ML_TENSOR_TYPE_FLOAT32);
   ml_tensors_info_set_tensor_dimension (out_info, 0, out_dim);
 
-  status = ml_single_open (
-      &single_h, valid_model, in_info, out_info, ML_NNFW_TYPE_NNFW, ML_NNFW_HW_CPU);
+  status = ml_single_open (&single_h, valid_model, in_info, out_info,
+      ML_NNFW_TYPE_NNFW, ML_NNFW_HW_CPU);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* let's ignore timeout (30 sec) */
@@ -254,7 +256,7 @@ TEST_F (MLAPIInferenceNNFW, invoke_single_00)
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (input != NULL);
 
-  status = ml_tensors_data_get_tensor_data (input, 0, (void **)&data, &data_size);
+  status = ml_tensors_data_get_tensor_data (input, 0, (void **) &data, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (data_size, sizeof (float));
   *data = 10.0;
@@ -263,7 +265,7 @@ TEST_F (MLAPIInferenceNNFW, invoke_single_00)
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (output != NULL);
 
-  status = ml_tensors_data_get_tensor_data (output, 0, (void **)&data, &data_size);
+  status = ml_tensors_data_get_tensor_data (output, 0, (void **) &data, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (data_size, sizeof (float));
   EXPECT_FLOAT_EQ (*data, 12.0);
@@ -291,8 +293,8 @@ TEST_F (MLAPIInferenceNNFW, invoke_single_01_n)
   ml_tensors_info_set_tensor_type (out_info, 0, ML_TENSOR_TYPE_FLOAT32);
   ml_tensors_info_set_tensor_dimension (out_info, 0, out_dim);
 
-  status = ml_single_open (
-      &single_h, invalid_model, in_info, out_info, ML_NNFW_TYPE_NNFW, ML_NNFW_HW_ANY);
+  status = ml_single_open (&single_h, invalid_model, in_info, out_info,
+      ML_NNFW_TYPE_NNFW, ML_NNFW_HW_ANY);
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 
   /* generate data */
@@ -327,8 +329,8 @@ TEST_F (MLAPIInferenceNNFW, invoke_single_02_n)
   ml_tensors_info_set_tensor_dimension (out_info, 0, out_dim);
 
   /* Open model with proper dimension */
-  status = ml_single_open (
-      &single_h, valid_model, in_info, out_info, ML_NNFW_TYPE_NNFW, ML_NNFW_HW_ANY);
+  status = ml_single_open (&single_h, valid_model, in_info, out_info,
+      ML_NNFW_TYPE_NNFW, ML_NNFW_HW_ANY);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* let's ignore timeout (30 sec) */
@@ -361,7 +363,7 @@ TEST_F (MLAPIInferenceNNFW, invoke_single_02_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (input != NULL);
 
-  status = ml_tensors_data_get_tensor_data (input, 0, (void **)&data, &data_size);
+  status = ml_tensors_data_get_tensor_data (input, 0, (void **) &data, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (data_size, sizeof (float) * 16);
   data[0] = 10.0;
@@ -389,7 +391,8 @@ TEST_F (MLAPIInferenceNNFW, invoke_pipeline_00)
   pipeline = g_strdup_printf ("appsrc name=appsrc ! "
                               "other/tensor,dimension=(string)1:1:1:1,type=(string)float32,framerate=(fraction)0/1 ! "
                               "tensor_filter framework=nnfw model=%s ! "
-                              "tensor_sink name=tensor_sink", valid_model);
+                              "tensor_sink name=tensor_sink",
+      valid_model);
 
   status = ml_pipeline_construct (pipeline, NULL, NULL, &pipeline_h);
   EXPECT_EQ (status, ML_ERROR_NONE);
@@ -398,8 +401,8 @@ TEST_F (MLAPIInferenceNNFW, invoke_pipeline_00)
   status = ml_pipeline_src_get_handle (pipeline_h, "appsrc", &src_handle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_sink_register (
-      pipeline_h, "tensor_sink", MLAPIInferenceNNFW::cb_new_data, &call_cnt, &sink_handle);
+  status = ml_pipeline_sink_register (pipeline_h, "tensor_sink",
+      MLAPIInferenceNNFW::cb_new_data, &call_cnt, &sink_handle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   ml_tensors_info_set_count (in_info, 1);
@@ -419,7 +422,7 @@ TEST_F (MLAPIInferenceNNFW, invoke_pipeline_00)
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (input != NULL);
 
-  status = ml_tensors_data_get_tensor_data (input, 0, (void **)&data, &data_size);
+  status = ml_tensors_data_get_tensor_data (input, 0, (void **) &data, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (data_size, sizeof (float));
   *data = 10.0;
@@ -495,7 +498,7 @@ TEST_F (MLAPIInferenceNNFW, invoke_pipeline_02_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   ml_tensors_info_set_count (in_info, 1);
-    ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_UINT8);
+  ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_UINT8);
   ml_tensors_info_set_tensor_dimension (in_info, 0, in_dim);
 
   status = ml_pipeline_start (pipeline_h);
@@ -583,8 +586,8 @@ TEST_F (MLAPIInferenceNNFW, multimodal_01_p)
   status = ml_pipeline_src_get_handle (pipeline_h, "appsrc_1", &src_handle_1);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_sink_register (
-      pipeline_h, "tensor_sink", MLAPIInferenceNNFW::cb_new_data_checker, &call_cnt, &sink_handle);
+  status = ml_pipeline_sink_register (pipeline_h, "tensor_sink",
+      MLAPIInferenceNNFW::cb_new_data_checker, &call_cnt, &sink_handle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   in_dim[0] = 3;
@@ -608,14 +611,14 @@ TEST_F (MLAPIInferenceNNFW, multimodal_01_p)
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (input != NULL);
 
-  status = ml_tensors_data_get_tensor_data (input, 0, (void **)&data1, &data_size1);
+  status = ml_tensors_data_get_tensor_data (input, 0, (void **) &data1, &data_size1);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (data_size1, 3U * 112U * 224U);
 
   status = ml_tensors_data_create (in_info, &input2);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (input != NULL);
-  status = ml_tensors_data_get_tensor_data (input2, 0, (void **)&data2, &data_size2);
+  status = ml_tensors_data_get_tensor_data (input2, 0, (void **) &data2, &data_size2);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* Push data to the source pad */
@@ -664,11 +667,11 @@ TEST_F (MLAPIInferenceNNFW, multimodel_01_p)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* register call back function when new data is arrived on sink pad */
-  status = ml_pipeline_sink_register (
-      pipeline_h, "tensor_sink_0", MLAPIInferenceNNFW::cb_new_data, &call_cnt1, &sink_handle_0);
+  status = ml_pipeline_sink_register (pipeline_h, "tensor_sink_0",
+      MLAPIInferenceNNFW::cb_new_data, &call_cnt1, &sink_handle_0);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  status = ml_pipeline_sink_register (
-      pipeline_h, "tensor_sink_1", MLAPIInferenceNNFW::cb_new_data, &call_cnt2, &sink_handle_1);
+  status = ml_pipeline_sink_register (pipeline_h, "tensor_sink_1",
+      MLAPIInferenceNNFW::cb_new_data, &call_cnt2, &sink_handle_1);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   ml_tensors_info_set_count (in_info, 1);
@@ -688,7 +691,7 @@ TEST_F (MLAPIInferenceNNFW, multimodel_01_p)
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (input != NULL);
 
-  status = ml_tensors_data_get_tensor_data (input, 0, (void **)&data, &data_size);
+  status = ml_tensors_data_get_tensor_data (input, 0, (void **) &data, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (data_size, sizeof (float));
   *data = 10.0;
@@ -737,11 +740,11 @@ TEST_F (MLAPIInferenceNNFW, multimodel_02_p)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* register call back function when new data is arrived on sink pad */
-  status = ml_pipeline_sink_register (
-      pipeline_h, "tensor_sink_0", MLAPIInferenceNNFW::cb_new_data, &call_cnt1, &sink_handle_0);
+  status = ml_pipeline_sink_register (pipeline_h, "tensor_sink_0",
+      MLAPIInferenceNNFW::cb_new_data, &call_cnt1, &sink_handle_0);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  status = ml_pipeline_sink_register (
-      pipeline_h, "tensor_sink_1", MLAPIInferenceNNFW::cb_new_data, &call_cnt2, &sink_handle_1);
+  status = ml_pipeline_sink_register (pipeline_h, "tensor_sink_1",
+      MLAPIInferenceNNFW::cb_new_data, &call_cnt2, &sink_handle_1);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   ml_tensors_info_set_count (in_info, 1);
@@ -761,7 +764,7 @@ TEST_F (MLAPIInferenceNNFW, multimodel_02_p)
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (input != NULL);
 
-  status = ml_tensors_data_get_tensor_data (input, 0, (void **)&data, &data_size);
+  status = ml_tensors_data_get_tensor_data (input, 0, (void **) &data, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (data_size, sizeof (float));
   *data = 10.0;

--- a/tests/capi/unittest_capi_inference_single.cc
+++ b/tests/capi/unittest_capi_inference_single.cc
@@ -9,14 +9,14 @@
 
 #include <gtest/gtest.h>
 #include <glib.h>
-#include <nnstreamer.h>
-#include <nnstreamer-single.h>
-#include <nnstreamer_internal.h>
-#include <nnstreamer-tizen-internal.h>
 #include <ml-api-inference-internal.h>
 #include <ml-api-inference-single-internal.h>
+#include <nnstreamer-single.h>
+#include <nnstreamer-tizen-internal.h>
+#include <nnstreamer.h>
+#include <nnstreamer_internal.h>
 
-#if defined (__APPLE__)
+#if defined(__APPLE__)
 #define SO_FILE_EXTENSION ".dylib"
 #else
 #define SO_FILE_EXTENSION ".so"
@@ -24,7 +24,7 @@
 
 static const unsigned int SINGLE_DEF_TIMEOUT_MSEC = 10000U;
 
-#if defined (ENABLE_TENSORFLOW_LITE) || defined (ENABLE_TENSORFLOW2_LITE)
+#if defined(ENABLE_TENSORFLOW_LITE) || defined(ENABLE_TENSORFLOW2_LITE)
 constexpr bool is_enabled_tensorflow_lite = true;
 #else
 constexpr bool is_enabled_tensorflow_lite = false;
@@ -534,15 +534,15 @@ TEST (nnstreamer_capi_singleshot, invoke_03)
 
   for (i = 0; i < 10; i++) {
     int16_t i16 = (int16_t) (i + 1);
-    float f32 = (float)(i + .1);
+    float f32 = (float) (i + .1);
 
     status = ml_tensors_data_get_tensor_data (input, 0, &data_ptr, &data_size);
     EXPECT_EQ (status, ML_ERROR_NONE);
-    ((int16_t *)data_ptr)[i] = i16;
+    ((int16_t *) data_ptr)[i] = i16;
 
     status = ml_tensors_data_get_tensor_data (input, 1, &data_ptr, &data_size);
     EXPECT_EQ (status, ML_ERROR_NONE);
-    ((float *)data_ptr)[i] = f32;
+    ((float *) data_ptr)[i] = f32;
   }
 
   status = ml_single_set_timeout (single, SINGLE_DEF_TIMEOUT_MSEC);
@@ -554,15 +554,15 @@ TEST (nnstreamer_capi_singleshot, invoke_03)
 
   for (i = 0; i < 10; i++) {
     int16_t i16 = (int16_t) (i + 1);
-    float f32 = (float)(i + .1);
+    float f32 = (float) (i + .1);
 
     status = ml_tensors_data_get_tensor_data (output, 0, &data_ptr, &data_size);
     EXPECT_EQ (status, ML_ERROR_NONE);
-    EXPECT_EQ (((int16_t *)data_ptr)[i], i16);
+    EXPECT_EQ (((int16_t *) data_ptr)[i], i16);
 
     status = ml_tensors_data_get_tensor_data (output, 1, &data_ptr, &data_size);
     EXPECT_EQ (status, ML_ERROR_NONE);
-    EXPECT_FLOAT_EQ (((float *)data_ptr)[i], f32);
+    EXPECT_FLOAT_EQ (((float *) data_ptr)[i], f32);
   }
 
   status = ml_single_close (single);
@@ -611,8 +611,7 @@ TEST (nnstreamer_capi_singleshot, invoke_04)
       "conv_actions_frozen.pb", NULL);
   ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
 
-  test_file = g_build_filename (root_path, "tests", "test_models", "data",
-      "yes.wav", NULL);
+  test_file = g_build_filename (root_path, "tests", "test_models", "data", "yes.wav", NULL);
   ASSERT_TRUE (g_file_test (test_file, G_FILE_TEST_EXISTS));
 
   ml_tensors_info_create (&in_info);
@@ -718,7 +717,7 @@ TEST (nnstreamer_capi_singleshot, invoke_04)
   max_score = .0;
   max_score_index = 0;
   for (gint i = 0; i < 12; i++) {
-    score = ((float *)data_ptr)[i];
+    score = ((float *) data_ptr)[i];
     if (score > max_score) {
       max_score = score;
       max_score_index = i;
@@ -1049,7 +1048,7 @@ single_shot_loop_test (void *arg)
   guint i;
   int status = ML_ERROR_NONE;
   ml_single_h single;
-  single_shot_thread_data *ss_data = (single_shot_thread_data *)arg;
+  single_shot_thread_data *ss_data = (single_shot_thread_data *) arg;
   int timeout_cond, no_error_cond;
 
   status = ml_single_open (&single, ss_data->test_model, NULL, NULL,
@@ -1100,8 +1099,8 @@ single_shot_loop_test (void *arg)
       no_error_cond = status == ML_ERROR_NONE && output != NULL;
       if (ss_data->timeout < ss_data->min_time_to_run) {
         /** Default timeout can return timed out with many parallel runs */
-        timeout_cond = output == NULL && (status == ML_ERROR_TIMED_OUT
-                                             || status == ML_ERROR_TRY_AGAIN);
+        timeout_cond = output == NULL
+                       && (status == ML_ERROR_TIMED_OUT || status == ML_ERROR_TRY_AGAIN);
         EXPECT_TRUE (timeout_cond || no_error_cond);
       } else {
         EXPECT_TRUE (no_error_cond);
@@ -1255,7 +1254,7 @@ TEST (nnstreamer_capi_singleshot, parallel_runs)
   for (j = 0; j < num_cases; j++) {
     for (i = 0; i < num_threads; i++) {
       pthread_create (&thread[i + j * num_threads], NULL, single_shot_loop_test,
-          (void *)&ss_data[j]);
+          (void *) &ss_data[j]);
     }
   }
 
@@ -1297,7 +1296,7 @@ TEST (nnstreamer_capi_singleshot, close_while_running)
   ss_data.timeout = SINGLE_DEF_TIMEOUT_MSEC;
   ss_data.single = NULL;
 
-  pthread_create (&thread, NULL, single_shot_loop_test, (void *)&ss_data);
+  pthread_create (&thread, NULL, single_shot_loop_test, (void *) &ss_data);
 
   /** Start the thread and let the code start */
   g_usleep (100000); /** 100 msec */
@@ -1635,7 +1634,7 @@ TEST (nnstreamer_capi_singleshot, set_input_info_success_01)
     EXPECT_EQ (status, ML_ERROR_NONE);
     EXPECT_TRUE (input != NULL);
 
-    status = ml_tensors_data_get_tensor_data (input, 0, (void **)&data, &data_size);
+    status = ml_tensors_data_get_tensor_data (input, 0, (void **) &data, &data_size);
     EXPECT_EQ (status, ML_ERROR_NONE);
     EXPECT_EQ (data_size, tensor_size * sizeof (int));
     for (int idx = 0; idx < tensor_size; idx++)
@@ -1645,13 +1644,13 @@ TEST (nnstreamer_capi_singleshot, set_input_info_success_01)
     EXPECT_EQ (status, ML_ERROR_NONE);
     EXPECT_TRUE (output != NULL);
 
-    status = ml_tensors_data_get_tensor_data (input, 0, (void **)&data, &data_size);
+    status = ml_tensors_data_get_tensor_data (input, 0, (void **) &data, &data_size);
     EXPECT_EQ (status, ML_ERROR_NONE);
     EXPECT_EQ (data_size, tensor_size * sizeof (int));
     for (int idx = 0; idx < tensor_size; idx++)
       EXPECT_EQ (data[idx], idx);
 
-    status = ml_tensors_data_get_tensor_data (output, 0, (void **)&data, &data_size);
+    status = ml_tensors_data_get_tensor_data (output, 0, (void **) &data, &data_size);
     EXPECT_EQ (status, ML_ERROR_NONE);
     EXPECT_EQ (data_size, tensor_size * sizeof (int));
     for (int idx = 0; idx < tensor_size; idx++)
@@ -1681,12 +1680,12 @@ TEST (nnstreamer_capi_singleshot, set_input_info_extended_success)
   ml_tensors_info_h in_info, out_info;
   ml_tensors_info_h in_res = nullptr, out_res = nullptr;
   ml_tensors_data_h input, output;
-  ml_tensor_dimension in_dim = {4, 4, 4, 4, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
-  ml_tensor_dimension out_dim = {4, 4, 4, 4, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  ml_tensor_dimension in_dim = { 4, 4, 4, 4, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
+  ml_tensor_dimension out_dim = { 4, 4, 4, 4, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
   ml_tensor_dimension res_dim;
   ml_tensor_type_e type = ML_TENSOR_TYPE_UNKNOWN;
   unsigned int count = 0;
-  int status, i, tensor_size = 4*4*4*4*4;
+  int status, i, tensor_size = 4 * 4 * 4 * 4 * 4;
   size_t data_size;
   float *input0, *input1, *output0;
 
@@ -1774,35 +1773,35 @@ TEST (nnstreamer_capi_singleshot, set_input_info_extended_success)
     EXPECT_EQ (status, ML_ERROR_NONE);
     EXPECT_TRUE (input != NULL);
 
-    status = ml_tensors_data_get_tensor_data (input, 0, (void **)&input0, &data_size);
+    status = ml_tensors_data_get_tensor_data (input, 0, (void **) &input0, &data_size);
     EXPECT_EQ (status, ML_ERROR_NONE);
     EXPECT_EQ (data_size, tensor_size * sizeof (float));
     for (int idx = 0; idx < tensor_size; idx++)
       input0[idx] = idx;
 
-    status = ml_tensors_data_get_tensor_data (input, 1, (void **)&input1, &data_size);
+    status = ml_tensors_data_get_tensor_data (input, 1, (void **) &input1, &data_size);
     EXPECT_EQ (status, ML_ERROR_NONE);
     EXPECT_EQ (data_size, tensor_size * sizeof (float));
     for (int idx = 0; idx < tensor_size; idx++)
-      input1[idx] = idx+1;
+      input1[idx] = idx + 1;
 
     status = ml_single_invoke (single, input, &output);
     EXPECT_EQ (status, ML_ERROR_NONE);
     EXPECT_TRUE (output != NULL);
 
-    status = ml_tensors_data_get_tensor_data (input, 0, (void **)&input0, &data_size);
+    status = ml_tensors_data_get_tensor_data (input, 0, (void **) &input0, &data_size);
     EXPECT_EQ (status, ML_ERROR_NONE);
     EXPECT_EQ (data_size, tensor_size * sizeof (float));
     for (int idx = 0; idx < tensor_size; idx++)
       EXPECT_EQ (input0[idx], idx);
 
-    status = ml_tensors_data_get_tensor_data (input, 1, (void **)&input1, &data_size);
+    status = ml_tensors_data_get_tensor_data (input, 1, (void **) &input1, &data_size);
     EXPECT_EQ (status, ML_ERROR_NONE);
     EXPECT_EQ (data_size, tensor_size * sizeof (float));
     for (int idx = 0; idx < tensor_size; idx++)
-      EXPECT_EQ (input1[idx], idx+1);
+      EXPECT_EQ (input1[idx], idx + 1);
 
-    status = ml_tensors_data_get_tensor_data (output, 0, (void **)&output0, &data_size);
+    status = ml_tensors_data_get_tensor_data (output, 0, (void **) &output0, &data_size);
     EXPECT_EQ (status, ML_ERROR_NONE);
     EXPECT_EQ (data_size, tensor_size * sizeof (float));
     for (int idx = 0; idx < tensor_size; idx++)
@@ -1909,7 +1908,7 @@ TEST (nnstreamer_capi_singleshot, property_01_p)
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (output != NULL);
 
-  status = ml_tensors_data_get_tensor_data (output, 0, (void **)&data, &data_size);
+  status = ml_tensors_data_get_tensor_data (output, 0, (void **) &data, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (data_size, 1001U);
 
@@ -2098,7 +2097,7 @@ TEST (nnstreamer_capi_singleshot, property_03_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (output != NULL);
 
-  status = ml_tensors_data_get_tensor_data (output, 0, (void **)&data, &data_size);
+  status = ml_tensors_data_get_tensor_data (output, 0, (void **) &data, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (data_size, 1001U);
 
@@ -2186,7 +2185,7 @@ TEST (nnstreamer_capi_singleshot, property_04_p)
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (input != NULL);
 
-  status = ml_tensors_data_get_tensor_data (input, 0, (void **)&data, &data_size);
+  status = ml_tensors_data_get_tensor_data (input, 0, (void **) &data, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (data_size, 5 * sizeof (float));
   for (int idx = 0; idx < 5; idx++)
@@ -2196,7 +2195,7 @@ TEST (nnstreamer_capi_singleshot, property_04_p)
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (output != NULL);
 
-  status = ml_tensors_data_get_tensor_data (output, 0, (void **)&data, &data_size);
+  status = ml_tensors_data_get_tensor_data (output, 0, (void **) &data, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (data_size, 5 * sizeof (float));
   for (int idx = 0; idx < 5; idx++)
@@ -2529,14 +2528,14 @@ TEST (nnstreamer_capi_singleshot, invoke_06)
   ml_tensors_info_set_tensor_type (out_info, 0, ML_TENSOR_TYPE_FLOAT32);
   ml_tensors_info_set_tensor_dimension (out_info, 0, out_dim);
 
-  ASSERT_TRUE (g_file_get_contents (test_file, (gchar **)&contents_uint8, &len, NULL));
+  ASSERT_TRUE (g_file_get_contents (test_file, (gchar **) &contents_uint8, &len, NULL));
   status = ml_tensors_info_get_tensor_size (in_info, 0, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   ASSERT_TRUE (len == data_size / sizeof (float));
 
   /** Convert uint8 data with range [0, 255] to float with range [-1, 1] */
-  contents_float = (gfloat *)g_malloc (data_size);
+  contents_float = (gfloat *) g_malloc (data_size);
   for (unsigned int idx = 0; idx < len; idx++) {
     contents_float[idx] = static_cast<float> (contents_uint8[idx]);
     contents_float[idx] -= 127.5;
@@ -2619,7 +2618,7 @@ TEST (nnstreamer_capi_singleshot, invoke_06)
   max_score = .0;
   max_score_index = 0;
   for (gint i = 0; i < 10; i++) {
-    score = ((float *)data_ptr)[i];
+    score = ((float *) data_ptr)[i];
     if (score > max_score) {
       max_score = score;
       max_score_index = i;
@@ -2748,7 +2747,7 @@ TEST (nnstreamer_capi_singleshot, invoke_07)
 
   status = ml_tensors_data_get_tensor_data (input, 0, &data_ptr, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  ((float *)data_ptr)[0] = 10.0;
+  ((float *) data_ptr)[0] = 10.0;
 
   status = ml_single_set_timeout (single, SINGLE_DEF_TIMEOUT_MSEC);
   EXPECT_TRUE (status == ML_ERROR_NOT_SUPPORTED || status == ML_ERROR_NONE);
@@ -2759,7 +2758,7 @@ TEST (nnstreamer_capi_singleshot, invoke_07)
 
   status = ml_tensors_data_get_tensor_data (output, 0, &data_ptr, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  EXPECT_EQ (((float *)data_ptr)[0], 12.0);
+  EXPECT_EQ (((float *) data_ptr)[0], 12.0);
 
   status = ml_single_close (single);
   EXPECT_EQ (status, ML_ERROR_NONE);
@@ -2906,7 +2905,7 @@ TEST (nnstreamer_capi_singleshot, invoke_08_n)
 
   status = ml_tensors_info_get_tensor_size (in_info, 0, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  contents_float = (gfloat *)g_malloc (data_size);
+  contents_float = (gfloat *) g_malloc (data_size);
   status = ml_tensors_data_set_tensor_data (input, 0, contents_float, data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
@@ -2990,7 +2989,7 @@ TEST (nnstreamer_capi_singleshot, invoke_09_n)
 
   status = ml_tensors_info_get_tensor_size (out_info, 0, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
-  contents_float = (gfloat *)g_malloc (data_size);
+  contents_float = (gfloat *) g_malloc (data_size);
   status = ml_tensors_data_set_tensor_data (input, 0, contents_float, data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
@@ -3073,7 +3072,7 @@ TEST (nnstreamer_capi_singleshot, invoke_10_p)
   status = ml_tensors_data_get_tensor_data (input, 0, &data_ptr, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
   for (i = 0; i < 10; i++) {
-    ((int16_t *)data_ptr)[i] = (int16_t) (i + 1);
+    ((int16_t *) data_ptr)[i] = (int16_t) (i + 1);
   }
 
   status = ml_single_invoke (single, input, &output);
@@ -3158,7 +3157,7 @@ TEST (nnstreamer_capi_singleshot, invoke_11_p)
   status = ml_tensors_data_get_tensor_data (input, 0, &data_ptr, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
   for (i = 0; i < 10; i++) {
-    ((int16_t *)data_ptr)[i] = (int16_t) (i + 1);
+    ((int16_t *) data_ptr)[i] = (int16_t) (i + 1);
   }
 
   status = ml_single_invoke (single, input, &output);
@@ -3245,7 +3244,7 @@ TEST (nnstreamer_capi_singleshot, invoke_12_p)
   status = ml_tensors_data_get_tensor_data (input, 0, &data_ptr, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
   for (i = 0; i < 10; i++) {
-    ((int16_t *)data_ptr)[i] = (int16_t) (i + 1);
+    ((int16_t *) data_ptr)[i] = (int16_t) (i + 1);
   }
 
   status = ml_single_invoke (single, input, &output1);
@@ -3495,7 +3494,7 @@ TEST (nnstreamer_capi_singleshot, invoke_dynamic_success_01_p)
     status = ml_single_invoke_dynamic (single, input, in_info, &output, &out_info);
     EXPECT_EQ (status, ML_ERROR_NONE);
 
-    ml_tensors_data_get_tensor_data (output, 0, (void **)&output_buf, &data_size);
+    ml_tensors_data_get_tensor_data (output, 0, (void **) &output_buf, &data_size);
 
     EXPECT_FLOAT_EQ (output_buf[0], 3.0f);
     EXPECT_EQ (data_size, sizeof (float));
@@ -3545,7 +3544,7 @@ TEST (nnstreamer_capi_singleshot, invoke_dynamic_success_01_p)
     status = ml_single_invoke_dynamic (single, input, in_info, &output, &out_info);
     EXPECT_EQ (status, ML_ERROR_NONE);
 
-    ml_tensors_data_get_tensor_data (output, 0, (void **)&output_buf2, &data_size);
+    ml_tensors_data_get_tensor_data (output, 0, (void **) &output_buf2, &data_size);
 
     EXPECT_FLOAT_EQ (output_buf2[0], 3.0f);
     EXPECT_FLOAT_EQ (output_buf2[1], 4.0f);
@@ -3640,7 +3639,7 @@ TEST (nnstreamer_capi_singleshot, invoke_dynamic_success_02_p)
     status = ml_single_invoke_dynamic (single, input, in_info, &output, &out_info);
     EXPECT_EQ (status, ML_ERROR_NONE);
 
-    ml_tensors_data_get_tensor_data (output, 0, (void **)&output_buf, &data_size);
+    ml_tensors_data_get_tensor_data (output, 0, (void **) &output_buf, &data_size);
     EXPECT_FLOAT_EQ (output_buf[0], 3.0f);
     EXPECT_EQ (data_size, sizeof (float));
 
@@ -3694,7 +3693,7 @@ TEST (nnstreamer_capi_singleshot, invoke_dynamic_success_02_p)
     status = ml_single_invoke_dynamic (single, input, in_info, &output, &out_info);
     EXPECT_EQ (status, ML_ERROR_NONE);
 
-    ml_tensors_data_get_tensor_data (output, 0, (void **)&output_buf2, &data_size);
+    ml_tensors_data_get_tensor_data (output, 0, (void **) &output_buf2, &data_size);
 
     EXPECT_FLOAT_EQ (output_buf2[0], 3.0f);
     EXPECT_FLOAT_EQ (output_buf2[1], 4.0f);
@@ -3990,7 +3989,7 @@ skip_test:
   g_free (test_model);
 }
 
-#if defined (ENABLE_TENSORFLOW_LITE) && defined (ENABLE_TENSORFLOW2_LITE)
+#if defined(ENABLE_TENSORFLOW_LITE) && defined(ENABLE_TENSORFLOW2_LITE)
 /**
  * @brief Test ml_option with tensorflow1-lite (manually set by ml_option_se, NULLt)
  */
@@ -4094,7 +4093,8 @@ TEST (nnstreamer_capi_ml_option, tensorflow1_lite)
 TEST (nnstreamer_capi_util, nnfw_name_01_p)
 {
   EXPECT_STREQ (_ml_get_nnfw_subplugin_name (ML_NNFW_TYPE_TENSORFLOW_LITE), "tensorflow-lite");
-  EXPECT_EQ (_ml_get_nnfw_type_by_subplugin_name ("tensorflow-lite"), ML_NNFW_TYPE_TENSORFLOW_LITE);
+  EXPECT_EQ (_ml_get_nnfw_type_by_subplugin_name ("tensorflow-lite"),
+      ML_NNFW_TYPE_TENSORFLOW_LITE);
   EXPECT_STREQ (_ml_get_nnfw_subplugin_name (ML_NNFW_TYPE_TENSORFLOW), "tensorflow");
   EXPECT_EQ (_ml_get_nnfw_type_by_subplugin_name ("tensorflow"), ML_NNFW_TYPE_TENSORFLOW);
   EXPECT_STREQ (_ml_get_nnfw_subplugin_name (ML_NNFW_TYPE_NNFW), "nnfw");

--- a/tests/capi/unittest_capi_service_agent_client.cc
+++ b/tests/capi/unittest_capi_service_agent_client.cc
@@ -7,25 +7,25 @@
  * @bug         No known bugs
  */
 
-#include <gio/gio.h>
 #include <gtest/gtest.h>
-#include <ml-api-internal.h>
-#include <ml-api-service.h>
-#include <ml-api-service-private.h>
+#include <gio/gio.h>
 #include <ml-api-inference-pipeline-internal.h>
+#include <ml-api-internal.h>
+#include <ml-api-service-private.h>
+#include <ml-api-service.h>
 
-#include <netinet/tcp.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 
 /**
  * @brief Test base class for Database of ML Service API.
  */
-class MLServiceAgentTest : public::testing::Test
+class MLServiceAgentTest : public ::testing::Test
 {
-protected:
+  protected:
   GTestDBus *dbus;
 
-public:
+  public:
   /**
    * @brief Setup method for each test case.
    */
@@ -66,7 +66,7 @@ public:
 
     sin.sin_family = AF_INET;
     sin.sin_addr.s_addr = INADDR_ANY;
-    sin.sin_port = htons(0);
+    sin.sin_port = htons (0);
 
     sock = socket (AF_INET, SOCK_STREAM, 0);
     EXPECT_TRUE (sock > 0);
@@ -98,7 +98,9 @@ TEST_F (MLServiceAgentTest, usecase_00)
   guint port = _get_available_port ();
 
   /* create server pipeline */
-  pipeline_desc = g_strdup_printf ("tensor_query_serversrc port=%u num-buffers=10 ! other/tensors,num_tensors=1,dimensions=3:4:4:1,types=uint8,format=static,framerate=0/1 ! tensor_query_serversink async=false", port);
+  pipeline_desc = g_strdup_printf (
+      "tensor_query_serversrc port=%u num-buffers=10 ! other/tensors,num_tensors=1,dimensions=3:4:4:1,types=uint8,format=static,framerate=0/1 ! tensor_query_serversink async=false",
+      port);
 
   status = ml_service_set_pipeline (service_name, pipeline_desc);
   EXPECT_EQ (ML_ERROR_NONE, status);
@@ -126,7 +128,9 @@ TEST_F (MLServiceAgentTest, usecase_00)
 
   /* create client pipeline */
   guint sink_port = _get_available_port ();
-  gchar *client_pipeline_desc = g_strdup_printf ("videotestsrc num-buffers=10 ! videoconvert ! videoscale ! video/x-raw,width=4,height=4,format=RGB,framerate=10/1 ! tensor_converter ! other/tensors,num_tensors=1,format=static ! tensor_query_client dest-port=%u port=%u ! fakesink sync=true", port, sink_port);
+  gchar *client_pipeline_desc = g_strdup_printf (
+      "videotestsrc num-buffers=10 ! videoconvert ! videoscale ! video/x-raw,width=4,height=4,format=RGB,framerate=10/1 ! tensor_converter ! other/tensors,num_tensors=1,format=static ! tensor_query_client dest-port=%u port=%u ! fakesink sync=true",
+      port, sink_port);
 
   status = ml_service_set_pipeline ("client", client_pipeline_desc);
   EXPECT_EQ (ML_ERROR_NONE, status);
@@ -190,7 +194,9 @@ TEST_F (MLServiceAgentTest, usecase_01)
   guint port = _get_available_port ();
 
   /* create server pipeline */
-  pipeline_desc = g_strdup_printf ("tensor_query_serversrc port=%u num-buffers=10 ! other/tensors,num_tensors=1,dimensions=3:4:4:1,types=uint8,format=static,framerate=0/1 ! tensor_query_serversink async=false", port);
+  pipeline_desc = g_strdup_printf (
+      "tensor_query_serversrc port=%u num-buffers=10 ! other/tensors,num_tensors=1,dimensions=3:4:4:1,types=uint8,format=static,framerate=0/1 ! tensor_query_serversink async=false",
+      port);
 
   status = ml_service_set_pipeline (service_name, pipeline_desc);
   EXPECT_EQ (ML_ERROR_NONE, status);
@@ -218,7 +224,9 @@ TEST_F (MLServiceAgentTest, usecase_01)
 
   /* create client pipeline */
   guint sink_port = _get_available_port ();
-  gchar *client_pipeline_desc = g_strdup_printf ("videotestsrc num-buffers=10 ! videoconvert ! videoscale ! video/x-raw,width=4,height=4,format=RGB,framerate=10/1 ! tensor_converter ! other/tensors,num_tensors=1,format=static ! tensor_query_client dest-port=%u port=%u ! fakesink sync=true", port, sink_port);
+  gchar *client_pipeline_desc = g_strdup_printf (
+      "videotestsrc num-buffers=10 ! videoconvert ! videoscale ! video/x-raw,width=4,height=4,format=RGB,framerate=10/1 ! tensor_converter ! other/tensors,num_tensors=1,format=static ! tensor_query_client dest-port=%u port=%u ! fakesink sync=true",
+      port, sink_port);
 
   ml_pipeline_h client;
   status = ml_pipeline_construct (client_pipeline_desc, NULL, NULL, &client);
@@ -538,7 +546,9 @@ TEST_F (MLServiceAgentTest, query_client)
   const gchar *service_name = "simple_query_server_for_test";
   int num_buffers = 5;
   guint server_port = _get_available_port ();
-  gchar *server_pipeline_desc = g_strdup_printf ("tensor_query_serversrc port=%u num-buffers=%d ! other/tensors,num_tensors=1,dimensions=3:4:4:1,types=uint8,format=static,framerate=0/1 ! tensor_query_serversink async=false sync=false", server_port, num_buffers);
+  gchar *server_pipeline_desc = g_strdup_printf (
+      "tensor_query_serversrc port=%u num-buffers=%d ! other/tensors,num_tensors=1,dimensions=3:4:4:1,types=uint8,format=static,framerate=0/1 ! tensor_query_serversink async=false sync=false",
+      server_port, num_buffers);
 
   status = ml_service_set_pipeline (service_name, server_pipeline_desc);
   EXPECT_EQ (ML_ERROR_NONE, status);
@@ -595,7 +605,8 @@ TEST_F (MLServiceAgentTest, query_client)
   status = ml_option_set (query_client_option, "timeout", &timeout, NULL);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  gchar *caps_str = g_strdup ("other/tensors,num_tensors=1,format=static,types=uint8,dimensions=3:4:4:1,framerate=0/1");
+  gchar *caps_str = g_strdup (
+      "other/tensors,num_tensors=1,format=static,types=uint8,dimensions=3:4:4:1,framerate=0/1");
   status = ml_option_set (query_client_option, "caps", caps_str, g_free);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
@@ -986,8 +997,8 @@ TEST_F (MLServiceAgentTest, model_ml_option_get_01_n)
   if (root_path == NULL)
     return;
 
-  gchar *test_model = g_build_filename (root_path, "tests", "test_models", "models",
-      "mobilenet_v1_1.0_224_quant.tflite", NULL);
+  gchar *test_model = g_build_filename (root_path, "tests", "test_models",
+      "models", "mobilenet_v1_1.0_224_quant.tflite", NULL);
   ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
 
   const gchar *key = "some_invalid_key";
@@ -1064,11 +1075,12 @@ TEST_F (MLServiceAgentTest, model_scenario)
   status = ml_service_model_update_description (key, 32U, "updated description");
   EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
 
-  test_model2 = g_build_filename (root_path, "tests", "test_models", "models",
-      "add.tflite", NULL);
+  test_model2 = g_build_filename (
+      root_path, "tests", "test_models", "models", "add.tflite", NULL);
   ASSERT_TRUE (g_file_test (test_model2, G_FILE_TEST_EXISTS));
 
-  status = ml_service_model_register (key, test_model2, false, "this is the temp tflite model", &version);
+  status = ml_service_model_register (
+      key, test_model2, false, "this is the temp tflite model", &version);
   EXPECT_EQ (ML_ERROR_NONE, status);
   EXPECT_EQ (version, 2U);
 
@@ -1184,10 +1196,10 @@ TEST_F (MLServiceAgentTest, pipeline_gdbus_call_n)
   int ret;
   GError *error = NULL;
 
-  MachinelearningServicePipeline *proxy_for_pipeline = machinelearning_service_pipeline_proxy_new_for_bus_sync (
-    G_BUS_TYPE_SESSION, G_DBUS_PROXY_FLAGS_NONE,
-    "org.tizen.machinelearning.service",
-    "/Org/Tizen/MachineLearning/Service/Pipeline", NULL, &error);
+  MachinelearningServicePipeline *proxy_for_pipeline
+      = machinelearning_service_pipeline_proxy_new_for_bus_sync (G_BUS_TYPE_SESSION,
+          G_DBUS_PROXY_FLAGS_NONE, "org.tizen.machinelearning.service",
+          "/Org/Tizen/MachineLearning/Service/Pipeline", NULL, &error);
 
   if (!proxy_for_pipeline || error) {
     g_critical ("Failed to create proxy_for_pipeline for machinelearning service pipeline");
@@ -1200,7 +1212,7 @@ TEST_F (MLServiceAgentTest, pipeline_gdbus_call_n)
 
   /* gdbus call with empty string */
   machinelearning_service_pipeline_call_set_pipeline_sync (
-    proxy_for_pipeline, "", "", &ret, nullptr, nullptr);
+      proxy_for_pipeline, "", "", &ret, nullptr, nullptr);
   EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, ret);
 }
 
@@ -1212,10 +1224,10 @@ TEST_F (MLServiceAgentTest, model_gdbus_call_n)
   int ret;
   GError *error = NULL;
 
-  MachinelearningServiceModel *proxy_for_model = machinelearning_service_model_proxy_new_for_bus_sync (
-    G_BUS_TYPE_SESSION, G_DBUS_PROXY_FLAGS_NONE,
-    "org.tizen.machinelearning.service",
-    "/Org/Tizen/MachineLearning/Service/Model", NULL, &error);
+  MachinelearningServiceModel *proxy_for_model
+      = machinelearning_service_model_proxy_new_for_bus_sync (G_BUS_TYPE_SESSION,
+          G_DBUS_PROXY_FLAGS_NONE, "org.tizen.machinelearning.service",
+          "/Org/Tizen/MachineLearning/Service/Model", NULL, &error);
 
   if (!proxy_for_model || error) {
     g_critical ("Failed to create proxy_for_model for machinelearning service model");
@@ -1228,12 +1240,12 @@ TEST_F (MLServiceAgentTest, model_gdbus_call_n)
 
   /* empty string */
   machinelearning_service_model_call_register_sync (
-    proxy_for_model, "", "", false, "test", "", NULL, &ret, nullptr, nullptr);
+      proxy_for_model, "", "", false, "test", "", NULL, &ret, nullptr, nullptr);
   EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, ret);
 
   /* empty string */
   machinelearning_service_model_call_get_all_sync (
-    proxy_for_model, "", NULL, &ret, nullptr, nullptr);
+      proxy_for_model, "", NULL, &ret, nullptr, nullptr);
   EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, ret);
 
   g_object_unref (proxy_for_model);
@@ -1297,8 +1309,8 @@ TEST (MLServiceAgentTestDbusUnconnected, model_n)
   if (root_path == NULL)
     return;
 
-  gchar *test_model = g_build_filename (root_path, "tests", "test_models", "models",
-      "mobilenet_v1_1.0_224_quant.tflite", NULL);
+  gchar *test_model = g_build_filename (root_path, "tests", "test_models",
+      "models", "mobilenet_v1_1.0_224_quant.tflite", NULL);
   ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
 
   status = ml_service_model_register ("test", test_model, false, "test", &version);

--- a/tests/daemon/unittest_gdbus_util.cc
+++ b/tests/daemon/unittest_gdbus_util.cc
@@ -37,10 +37,10 @@ TEST (gdbusInstanceNotInitialized, get_system_connection_n)
   gboolean is_session = true;
   int ret;
 
-  ret = gdbus_get_system_connection(is_session);
+  ret = gdbus_get_system_connection (is_session);
   EXPECT_EQ (-ENOSYS, ret);
 
-  ret = gdbus_get_system_connection(!is_session);
+  ret = gdbus_get_system_connection (!is_session);
   EXPECT_EQ (-ENOSYS, ret);
 }
 

--- a/tests/daemon/unittest_ml_agent.cc
+++ b/tests/daemon/unittest_ml_agent.cc
@@ -7,27 +7,27 @@
  * @bug         No known bugs
  */
 
-#include <gio/gio.h>
 #include <gtest/gtest.h>
+#include <gio/gio.h>
 
-#include "test-dbus.h"
-#include "dbus-interface.h"
 #include "../dbus/test-dbus-interface.h"
+#include "dbus-interface.h"
+#include "test-dbus.h"
 
 /**
  * @brief Test base class for ML Agent Daemon
  */
-class MLAgentTest : public::testing::Test
+class MLAgentTest : public ::testing::Test
 {
-protected:
+  protected:
   GTestDBus *dbus;
   GDBusProxy *proxy;
 
-public:
+  public:
   /**
    * @brief Setup method for each test case.
    */
-  void SetUp() override
+  void SetUp () override
   {
     gchar *services_dir = g_build_filename (g_get_current_dir (), "tests/services", NULL);
     dbus = g_test_dbus_new (G_TEST_DBUS_NONE);
@@ -35,15 +35,8 @@ public:
     g_test_dbus_up (dbus);
 
     GError *error = NULL;
-    proxy = g_dbus_proxy_new_for_bus_sync (
-      G_BUS_TYPE_SESSION,
-      G_DBUS_PROXY_FLAGS_NONE,
-      NULL,
-      DBUS_ML_BUS_NAME,
-      DBUS_TEST_PATH,
-      DBUS_TEST_INTERFACE,
-      NULL,
-      &error);
+    proxy = g_dbus_proxy_new_for_bus_sync (G_BUS_TYPE_SESSION, G_DBUS_PROXY_FLAGS_NONE,
+        NULL, DBUS_ML_BUS_NAME, DBUS_TEST_PATH, DBUS_TEST_INTERFACE, NULL, &error);
 
     if (!proxy || error) {
       if (error) {
@@ -58,7 +51,7 @@ public:
   /**
    * @brief Teardown method for each test case.
    */
-  void TearDown() override
+  void TearDown () override
   {
     if (proxy)
       g_object_unref (proxy);
@@ -79,15 +72,11 @@ TEST_F (MLAgentTest, call_method)
   int result = 0;
 
   /* Test : Connect to the DBus Interface */
-  proxy = machinelearning_service_test_proxy_new_for_bus_sync (
-    G_BUS_TYPE_SESSION,
-    G_DBUS_PROXY_FLAGS_NONE,
-    DBUS_ML_BUS_NAME,
-    DBUS_TEST_PATH,
-    NULL, &error);
+  proxy = machinelearning_service_test_proxy_new_for_bus_sync (G_BUS_TYPE_SESSION,
+      G_DBUS_PROXY_FLAGS_NONE, DBUS_ML_BUS_NAME, DBUS_TEST_PATH, NULL, &error);
   if (error != NULL) {
     g_error_free (error);
-    FAIL();
+    FAIL ();
   }
 
   /* Test: Call the DBus method */
@@ -95,7 +84,7 @@ TEST_F (MLAgentTest, call_method)
   if (error != NULL) {
     g_critical ("Error : %s", error->message);
     g_error_free (error);
-    FAIL();
+    FAIL ();
   }
 
   /* Check the return value */

--- a/tests/daemon/unittest_service_db.cc
+++ b/tests/daemon/unittest_service_db.cc
@@ -7,8 +7,8 @@
  * @bug         No known bugs
  */
 
-#include <gio/gio.h>
 #include <gtest/gtest.h>
+#include <gio/gio.h>
 
 #include "service-db.hh"
 
@@ -20,7 +20,7 @@ TEST (serviceDB, set_pipeline_n)
   MLServiceDB &db = MLServiceDB::getInstance ();
   int gotException = 0;
 
-  db.connectDB();
+  db.connectDB ();
   try {
     db.set_pipeline ("", "videotestsrc ! fakesink");
   } catch (const std::exception &e) {
@@ -37,7 +37,7 @@ TEST (serviceDB, set_pipeline_n)
     gotException = 1;
   }
   EXPECT_EQ (gotException, 1);
-  db.disconnectDB();
+  db.disconnectDB ();
 }
 
 /**
@@ -47,7 +47,7 @@ TEST (serviceDB, get_pipeline_n)
 {
   MLServiceDB &db = MLServiceDB::getInstance ();
   int gotException = 0;
-  db.connectDB();
+  db.connectDB ();
 
   try {
     std::string pipeline_description;
@@ -57,8 +57,7 @@ TEST (serviceDB, get_pipeline_n)
     gotException = 1;
   }
   EXPECT_EQ (gotException, 1);
-  db.disconnectDB();
-
+  db.disconnectDB ();
 }
 
 /**
@@ -68,7 +67,7 @@ TEST (serviceDB, delete_pipeline_n)
 {
   MLServiceDB &db = MLServiceDB::getInstance ();
   int gotException = 0;
-  db.connectDB();
+  db.connectDB ();
 
   try {
     db.delete_pipeline ("");
@@ -77,7 +76,7 @@ TEST (serviceDB, delete_pipeline_n)
     gotException = 1;
   }
   EXPECT_EQ (gotException, 1);
-  db.disconnectDB();
+  db.disconnectDB ();
 }
 
 /**
@@ -89,7 +88,7 @@ TEST (serviceDB, set_model_n)
   int gotException = 0;
   guint version;
 
-  db.connectDB();
+  db.connectDB ();
   try {
     db.set_model ("", "model", true, "description", "", &version);
   } catch (const std::exception &e) {
@@ -115,7 +114,7 @@ TEST (serviceDB, set_model_n)
     gotException = 1;
   }
   EXPECT_EQ (gotException, 1);
-  db.disconnectDB();
+  db.disconnectDB ();
 }
 
 /**
@@ -125,7 +124,7 @@ TEST (serviceDB, get_model_n)
 {
   MLServiceDB &db = MLServiceDB::getInstance ();
   int gotException = 0;
-  db.connectDB();
+  db.connectDB ();
 
   try {
     std::string model_description;
@@ -145,7 +144,7 @@ TEST (serviceDB, get_model_n)
     gotException = 1;
   }
   EXPECT_EQ (gotException, 1);
-  db.disconnectDB();
+  db.disconnectDB ();
 }
 
 /**
@@ -155,7 +154,7 @@ TEST (serviceDB, update_model_description_n)
 {
   MLServiceDB &db = MLServiceDB::getInstance ();
   int gotException = 0;
-  db.connectDB();
+  db.connectDB ();
 
   try {
     db.update_model_description ("", 0, "description");
@@ -173,7 +172,7 @@ TEST (serviceDB, update_model_description_n)
     gotException = 1;
   }
   EXPECT_EQ (gotException, 1);
-  db.disconnectDB();
+  db.disconnectDB ();
 }
 
 /**
@@ -183,7 +182,7 @@ TEST (serviceDB, activate_model_n)
 {
   MLServiceDB &db = MLServiceDB::getInstance ();
   int gotException = 0;
-  db.connectDB();
+  db.connectDB ();
 
   try {
     db.activate_model ("", 0);
@@ -192,7 +191,7 @@ TEST (serviceDB, activate_model_n)
     gotException = 1;
   }
   EXPECT_EQ (gotException, 1);
-  db.disconnectDB();
+  db.disconnectDB ();
 }
 
 /**
@@ -202,7 +201,7 @@ TEST (serviceDB, delete_model_n)
 {
   MLServiceDB &db = MLServiceDB::getInstance ();
   int gotException = 0;
-  db.connectDB();
+  db.connectDB ();
 
   try {
     db.delete_model ("", 0);
@@ -211,8 +210,7 @@ TEST (serviceDB, delete_model_n)
     gotException = 1;
   }
   EXPECT_EQ (gotException, 1);
-  db.disconnectDB();
-
+  db.disconnectDB ();
 }
 
 /**


### PR DESCRIPTION
This patch applies .clang-format to all of the .cc files, which are source files written in C++.

find . -name "*.cc" -exec clang-format-15 --style=file:.clang-format {} \;

Signed-off-by: Wook Song <wook16.song@samsung.com>
