### PR TITLE
API/C: Add the missing header to the pipeline-internal header file

### DIFF
--- a/c/src/ml-api-inference-pipeline-internal.h
+++ b/c/src/ml-api-inference-pipeline-internal.h
@@ -18,6 +18,7 @@
 #include <gst/gst.h>
 #include <nnstreamer_internal.h>
 
+#include "nnstreamer.h"
 #include "ml-api-internal.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
This patch adds a missing internal header, 'nnstreamer.h', which defines data structures and types required by the
'ml-api-inference-pipeline-internal.h' file.

Signed-off-by: Wook Song <wook16.song@samsung.com>
