### PR TITLE
[clang-format] line-comment length

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -47,6 +47,7 @@ PenaltyBreakString: 100
 PenaltyExcessCharacter: 1
 PenaltyReturnTypeOnItsOwnLine: 20
 PointerBindsToType: false
+ReflowComments: false
 SpaceAfterCStyleCast: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: Always


### PR DESCRIPTION
clang-format, ignore line-comment length.