### PR TITLE
Daemon/DBus: Replace NULL with "" for the DBus out parameters

### DIFF
--- a/daemon/pipeline-dbus-impl.cc
+++ b/daemon/pipeline-dbus-impl.cc
@@ -147,8 +147,6 @@ dbus_cb_core_get_pipeline (MachinelearningServicePipeline *obj,
 
   if (result) {
     _E ("Failed to get pipeline description of %s", service_name);
-    machinelearning_service_pipeline_complete_get_pipeline (obj, invoc, result, NULL);
-    return TRUE;
   }
 
   machinelearning_service_pipeline_complete_get_pipeline (


### PR DESCRIPTION
When the out parameter type is set to "s" (which means a string type value), it should not be a NULL value. This patch fixes such a case in the DBus callback implementation for the pipeline.

Signed-off-by: Wook Song <wook16.song@samsung.com>
