### PR TITLE
[ml-service] Add 'app_common_internal.h' to support Tizen v7.0

### DIFF
--- a/c/src/ml-api-service-agent-client.c
+++ b/c/src/ml-api-service-agent-client.c
@@ -23,6 +23,7 @@
 
 #if defined(__TIZEN__)
 #include <app_common.h>
+#include <app_common_internal.h>
 
 /**
  * @brief Parse app_info and update path (for model from rpk). Only for Tizen Applications.


### PR DESCRIPTION
In case of Tizen 7.0, `app_get_res_control_global_resource_path()` is defined in `app_common_internal.h`. 
So this patch includes `app_common_internal.h` to support both of Tizen 7.0 and latest Tizen.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>