### PR TITLE
[Tizen] Update coverage auto measurement script

### DIFF
--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -438,7 +438,7 @@ popd
 builddir=$(basename $PWD)
 gcno_obj_dir=%{buildroot}%{_datadir}/gcov/obj/%{name}/"$builddir"
 mkdir -p "$gcno_obj_dir"
-find . -name '*.gcno' ! -path "*/tests/*" ! -name "meson-generated*" ! -name "sanitycheck*" -exec cp --parents '{}' "$gcno_obj_dir" ';'
+find . -name '*.gcno' ! -path "*/tests/*" ! -name "meson-generated*" ! -name "sanitycheck*" ! -path "*tizen*" -exec cp --parents '{}' "$gcno_obj_dir" ';'
 
 mkdir -p %{buildroot}%{_bindir}/tizen-unittests/%{name}
 install -m 0755 packaging/run-unittest.sh %{buildroot}%{_bindir}/tizen-unittests/%{name}

--- a/packaging/run-unittest.sh
+++ b/packaging/run-unittest.sh
@@ -8,6 +8,7 @@
 setup() {
     echo "setup start"
     export MLAPI_SOURCE_ROOT_PATH=/usr/bin/unittest-ml
+    pushd /usr/bin/unittest-ml
 }
 
 test_main() {
@@ -20,6 +21,7 @@ test_main() {
 
 teardown() {
     echo "teardown start"
+    popd
 }
 
 main() {


### PR DESCRIPTION
 - Exclude 'ml-api-common-tizen-feature-check.c' and 'ml-api-inference-tizen-privilege-check.c' from the coverage report.
 - Change test directory before running the tests.
```
Error:
[DEBUG]:[ RUN      ] [mMLAgentTest.call_method
Error : GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name org.tizen.machinelearning.service was not provided by any .service files
[DEBUG]:../tests/daemon/unittest_ml_agent.cc:87: Failure
```