### PR TITLE
Daemon/Meson: Add a pkg-config file for ml-agentd

### DIFF
--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -141,3 +141,10 @@ configure_file(input: '../dbus/machine-learning-agent.service.in',
   install_dir: systemd_service_dir,
   configuration: systemd_conf
 )
+
+ml_agentd_conf = configuration_data()
+ml_agentd_conf.merge_from(api_conf)
+configure_file(input: 'ml-agentd.pc.in', output: 'ml-agentd.pc',
+  install_dir: join_paths(api_install_libdir, 'pkgconfig'),
+  configuration: ml_agentd_conf
+)

--- a/daemon/ml-agentd.pc.in
+++ b/daemon/ml-agentd.pc.in
@@ -1,0 +1,10 @@
+prefix=@PREFIX@
+exec_prefix=@PREFIX@
+libdir=@LIB_INSTALL_DIR@
+includedir=@INCLUDE_INSTALL_DIR@
+
+Name: ml-agent-service
+Description: Development headers and libraries for interfaces provided by Machine Learning Agent Service
+Version: @VERSION@
+Libs: -L${libdir} -lml-agentd
+Cflags: -I${includedir}/ml-agentd

--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -499,13 +499,12 @@ install -m 0755 packaging/run-unittest.sh %{buildroot}%{_bindir}/tizen-unittests
 %manifest machine-learning-agent.manifest
 %{_libdir}/libml-agentd.so.*
 
-#TODO: Need to provide a pkg-config file
 %files -n libmachine-learning-agent-devel
 %manifest machine-learning-agent.manifest
 %{_libdir}/libml-agentd.so
 %{_libdir}/libml-agentd.a
 %{_includedir}/ml-agentd/ml-agent-dbus-interface.h
-
+%{_libdir}/pkgconfig/ml-agentd.pc
 
 %files -n machine-learning-agent
 %manifest machine-learning-agent.manifest


### PR DESCRIPTION
This PR adds a pkg-config file that provides details for using the Machine Machine Learning Agent service interfaces and includes it in the Tizen package, libmachine-learning-agent-devel.

Signed-off-by: Wook Song <wook16.song@samsung.com>
