### PR TITLE
Daemon/Model: Add missing gst initialization

### DIFF
--- a/daemon/model-dbus-impl.cc
+++ b/daemon/model-dbus-impl.cc
@@ -12,6 +12,7 @@
 
 #include <errno.h>
 #include <glib.h>
+#include <gst/gst.h>
 
 #include "common.h"
 #include "dbus-interface.h"
@@ -376,6 +377,14 @@ out:
 static void
 init_model_module (void *data)
 {
+  GError *err = NULL;
+  gboolean ret;
+
+  ret = gst_init_check (NULL, NULL, &err);
+  if (!ret) {
+    _E ("Failed to initialize GStreamer with err msg (%s)", (err ? err->message : "NULL"));
+  }
+  g_clear_error (&err);
 }
 
 /**


### PR DESCRIPTION
This patch adds GStreamer initialization procedure into init_model_module. Without the initialization, D-Bus interfaces for the models inproperly work.

Signed-off-by: Wook Song <wook16.song@samsung.com>