### PR TITLE
[option] Use ml_option_get to get value from ml_option_h

### DIFF
--- a/c/src/ml-api-inference-single.c
+++ b/c/src/ml-api-inference-single.c
@@ -1205,11 +1205,7 @@ ml_single_open_full (ml_single_h * single, const char *model,
 int
 ml_single_open_with_option (ml_single_h * single, const ml_option_h option)
 {
-  ml_option_s *_option;
-  GHashTable *table;
-  GHashTableIter iter;
-  gchar *key;
-  ml_option_value_s *_option_value;
+  void *value;
   ml_single_preset info = { 0, };
 
   check_feature_state (ML_FEATURE_INFERENCE);
@@ -1223,30 +1219,20 @@ ml_single_open_with_option (ml_single_h * single, const ml_option_h option)
     _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
         "The parameter, 'single' (ml_single_h), is NULL. It should be a valid ml_single_h instance, usually created by ml_single_open().");
 
-  _option = (ml_option_s *) option;
-  table = _option->option_table;
-
-  g_hash_table_iter_init (&iter, table);
-  while (g_hash_table_iter_next (&iter, (gpointer *) & key,
-          (gpointer *) & _option_value)) {
-    if (g_ascii_strcasecmp (key, "input_info") == 0) {
-      info.input_info = _option_value->value;
-    } else if (g_ascii_strcasecmp (key, "output_info") == 0) {
-      info.output_info = _option_value->value;
-    } else if (g_ascii_strcasecmp (key, "nnfw") == 0) {
-      info.nnfw = *((ml_nnfw_type_e *) _option_value->value);
-    } else if (g_ascii_strcasecmp (key, "hw") == 0) {
-      info.hw = *((ml_nnfw_hw_e *) _option_value->value);
-    } else if (g_ascii_strcasecmp (key, "models") == 0) {
-      info.models = (gchar *) _option_value->value;
-    } else if (g_ascii_strcasecmp (key, "custom") == 0) {
-      info.custom_option = (gchar *) _option_value->value;
-    } else if (g_ascii_strcasecmp (key, "framework_name") == 0) {
-      info.fw_name = (gchar *) _option_value->value;
-    } else {
-      _ml_logw ("Ignore unknown key for ml_option: %s", key);
-    }
-  }
+  if (ML_ERROR_NONE == ml_option_get (option, "input_info", &value))
+    info.input_info = value;
+  if (ML_ERROR_NONE == ml_option_get (option, "output_info", &value))
+    info.output_info = value;
+  if (ML_ERROR_NONE == ml_option_get (option, "nnfw", &value))
+    info.nnfw = *((ml_nnfw_type_e *) value);
+  if (ML_ERROR_NONE == ml_option_get (option, "hw", &value))
+    info.hw = *((ml_nnfw_hw_e *) value);
+  if (ML_ERROR_NONE == ml_option_get (option, "models", &value))
+    info.models = (gchar *) value;
+  if (ML_ERROR_NONE == ml_option_get (option, "custom", &value))
+    info.custom_option = (gchar *) value;
+  if (ML_ERROR_NONE == ml_option_get (option, "framework_name", &value))
+    info.fw_name = (gchar *) value;
 
   return ml_single_open_custom (single, &info);
 }

--- a/c/src/ml-api-internal.h
+++ b/c/src/ml-api-internal.h
@@ -157,23 +157,41 @@ typedef struct {
 } ml_tensors_info_s;
 
 /**
- * @brief Data structure for value of ml_option.
- * @since_tizen 7.0
+ * @brief Enumeration for ml_info.
+ */
+typedef enum {
+  ML_INFO_OPTION = 0,
+  ML_INFO_MODEL,
+
+  ML_INFO_MAX
+} ml_info_type_e;
+
+/**
+ * @brief Data structure for value of ml_info.
  */
 typedef struct
 {
   void *value; /**< The data given by user. */
   ml_data_destroy_cb destroy; /**< The destroy func given by user. */
-} ml_option_value_s;
+} ml_info_value_s;
 
 /**
- * @brief Data structure for ml_option.
- * @since_tizen 7.0
+ * @brief Data structure for ml_info.
  */
 typedef struct
 {
-  GHashTable *option_table; /**< hash table used by ml_option. */
-} ml_option_s;
+  ml_info_type_e type; /**< The type of ml_info. */
+  GHashTable *table; /**< hash table used by ml_info. */
+} ml_info_s;
+
+/**
+ * @brief Data structure for ml_info_list.
+ */
+typedef struct
+{
+  unsigned int length; /**< The length of data. */
+  ml_info_s **info; /**< array of ml_info. */
+} ml_info_list_s;
 
 /**
  * @brief Macro to control private lock with nolock condition (lock)

--- a/c/src/ml-api-service-query-client.c
+++ b/c/src/ml-api-service-query-client.c
@@ -67,11 +67,7 @@ ml_service_query_create (ml_option_h option, ml_service_h * h)
   int status = ML_ERROR_NONE;
 
   gchar *description = NULL;
-
-  ml_option_s *_option;
-  GHashTableIter iter;
-  gchar *key;
-  ml_option_value_s *_option_value;
+  void *value;
 
   GString *tensor_query_client_prop;
   gchar *prop = NULL;
@@ -98,45 +94,42 @@ ml_service_query_create (ml_option_h option, ml_service_h * h)
         "The parameter, 'h' (ml_service_h), is NULL. It should be a valid ml_service_h.");
   }
 
-  _option = (ml_option_s *) option;
-  g_hash_table_iter_init (&iter, _option->option_table);
   tensor_query_client_prop = g_string_new (NULL);
-  while (g_hash_table_iter_next (&iter, (gpointer *) & key,
-          (gpointer *) & _option_value)) {
-    if (0 == g_ascii_strcasecmp (key, "host")) {
-      g_string_append_printf (tensor_query_client_prop, " host=%s ",
-          (gchar *) _option_value->value);
-    } else if (0 == g_ascii_strcasecmp (key, "port")) {
-      g_string_append_printf (tensor_query_client_prop, " port=%u ",
-          *((guint *) _option_value->value));
-    } else if (0 == g_ascii_strcasecmp (key, "dest-host")) {
-      g_string_append_printf (tensor_query_client_prop, " dest-host=%s ",
-          (gchar *) _option_value->value);
-    } else if (0 == g_ascii_strcasecmp (key, "dest-port")) {
-      g_string_append_printf (tensor_query_client_prop, " dest-port=%u ",
-          *((guint *) _option_value->value));
-    } else if (0 == g_ascii_strcasecmp (key, "connect-type")) {
-      g_string_append_printf (tensor_query_client_prop, " connect-type=%s ",
-          (gchar *) _option_value->value);
-    } else if (0 == g_ascii_strcasecmp (key, "topic")) {
-      g_string_append_printf (tensor_query_client_prop, " topic=%s ",
-          (gchar *) _option_value->value);
-    } else if (0 == g_ascii_strcasecmp (key, "timeout")) {
-      g_string_append_printf (tensor_query_client_prop, " timeout=%u ",
-          *((guint *) _option_value->value));
-      timeout = *((guint *) _option_value->value);
-    } else if (0 == g_ascii_strcasecmp (key, "caps")) {
-      caps = g_strdup (_option_value->value);
-    } else {
-      _ml_logw ("Ignore unknown key for ml_option: %s", key);
-    }
-  }
 
-  if (!caps) {
+  if (ML_ERROR_NONE == ml_option_get (option, "host", &value))
+    g_string_append_printf (tensor_query_client_prop, " host=%s ",
+        (gchar *) value);
+
+  if (ML_ERROR_NONE == ml_option_get (option, "port", &value))
+    g_string_append_printf (tensor_query_client_prop, " port=%u ",
+        *((guint *) value));
+
+  if (ML_ERROR_NONE == ml_option_get (option, "dest-host", &value))
+    g_string_append_printf (tensor_query_client_prop, " dest-host=%s ",
+        (gchar *) value);
+
+  if (ML_ERROR_NONE == ml_option_get (option, "dest-port", &value))
+    g_string_append_printf (tensor_query_client_prop, " dest-port=%u ",
+        *((guint *) value));
+
+  if (ML_ERROR_NONE == ml_option_get (option, "connect-type", &value))
+    g_string_append_printf (tensor_query_client_prop, " connect-type=%s ",
+        (gchar *) value);
+
+  if (ML_ERROR_NONE == ml_option_get (option, "topic", &value))
+    g_string_append_printf (tensor_query_client_prop, " topic=%s ",
+        (gchar *) value);
+
+  if (ML_ERROR_NONE == ml_option_get (option, "timeout", &value))
+    g_string_append_printf (tensor_query_client_prop, " timeout=%u ",
+        *((guint *) value));
+
+  if (ML_ERROR_NONE != ml_option_get (option, "caps", &value)) {
     g_string_free (tensor_query_client_prop, TRUE);
     _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
         "The option 'caps' must be set before call ml_service_query_create.");
   }
+  caps = g_strdup ((gchar *) value);
 
   prop = g_string_free (tensor_query_client_prop, FALSE);
   description =


### PR DESCRIPTION
- Use ml_option API rather than accessing internal structure.
- Declare ml_info and related enum and structures. And add internal functions for create, destroy, set, get.
- Replace ml_option_s with the new internal structure in ml_option API.