### PR TITLE
[ACR][common/service] Add APIs for ml_information_h and ml_information_list_h

### DIFF
--- a/c/include/ml-api-common.h
+++ b/c/include/ml-api-common.h
@@ -512,6 +512,70 @@ typedef void *ml_information_h;
 typedef void *ml_information_list_h;
 
 /**
+ * @brief Destroys the ml-information instance.
+ * @details Note that, user should free the allocated values of ml-information in the case that destroy function is not given.
+ * @since_tizen 8.0
+ * @param[in] ml_info The ml_information handle to be destroyed.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
+ */
+int ml_information_destroy (ml_information_h ml_info);
+
+/**
+ * @brief Gets a value of key in ml-information instance.
+ * @details This returns the pointer of memory in the handle. If you modify the returned memory (value), the contents of value is updated.
+ * @since_tizen 8.0
+ * @remarks The @a value should not be released. The @a value is available until @a ml_info is destroyed using ml_information_destroy().
+ * @param[in] ml_info The handle of ml-information.
+ * @param[in] key The key to get the corresponding value.
+ * @param[out] value The value of the key.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
+ */
+int ml_information_get (ml_information_h ml_info, const char *key, void **value);
+
+/**
+ * @brief Destroys the ml-information-list instance.
+ * @details Note that, user should free the allocated values of ml-information-list in the case that destroy function is not given.
+ * @since_tizen 8.0
+ * @param[in] ml_info_list The ml-information-list handle to be destroyed.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
+ */
+int ml_information_list_destroy (ml_information_list_h ml_info_list);
+
+/**
+ * @brief Gets the number of ml-information in ml-information-list instance.
+ * @since_tizen 8.0
+ * @param[in] ml_info_list The handle of ml-information-list.
+ * @param[out] length The number of ml-information in ml-information-list.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
+ */
+int ml_information_list_length (ml_information_list_h ml_info_list, unsigned int *length);
+
+/**
+ * @brief Gets a ml-information in ml-information-list instance with given index.
+ * @since_tizen 8.0
+ * @remarks The @a ml_info should not be released. The @a ml_info is available until @a ml_info_list is destroyed using ml_information_list_destroy().
+ * @param[in] ml_info_list The handle of ml-information-list.
+ * @param[in] index The index of ml-information in ml-information-list.
+ * @param[out] ml_info The ml-information handle of given index.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
+ */
+int ml_information_list_get (ml_information_list_h ml_info_list, unsigned int index, ml_information_h *ml_info);
+/**
  * @}
  */
 #ifdef __cplusplus

--- a/c/include/ml-api-service.h
+++ b/c/include/ml-api-service.h
@@ -241,6 +241,46 @@ int ml_service_query_request (ml_service_h handle, const ml_tensors_data_h input
  * @retval #ML_ERROR_PERMISSION_DENIED The application does not have the privilege to access to the storage.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  * @retval #ML_ERROR_IO_ERROR The operation of DB or filesystem has failed.
+ *
+ * Here is an example of the usage:
+ * @code
+ * // The machine-learning service API for model provides a method to share model files those can be used for ML application.
+ *
+ * /// Model Provider APP
+ * const gchar *key = "imgcls-mobilenet"; // The name shared among ML applications.
+ * gchar *model_path = g_strdup_printf ("%s/%s", app_get_shared_resource_path (), "mobilenet_v2.tflite"); // Provide the absolute file path.
+ * const bool is_active = true; // Parameter deciding whether to activate this model or not.
+ * const gchar *description = "This is the description of mobilenet_v2 model ..."; // Model description parameter.
+ * unsigned int version; // Out parameter for the version of registered model.
+ *
+ * // Register the model via ML Service API.
+ * int status;
+ * status = ml_service_model_register (key, model_path, is_active, description, &version);
+ * if (status != ML_ERROR_NONE) {
+ *   // Handle error case.
+ * }
+ *
+ * /// Model Consumer APP
+ * const gchar *key = "imgcls-mobilenet"; // The name shared among ML applications.
+ * gchar *model_path; // Out parameter for the path of registered model.
+ * ml_information_h activated_model_info; // The ml_information handle for the activated model.
+ *
+ * // Get the model which is registered and activated by ML Service API.
+ * int status;
+ * status = ml_service_model_get_activated (key, &activated_model_info);
+ * if (status == ML_ERROR_NONE) {
+ *   // Get the path of the model.
+ *   gchar *activated_model_path;
+ *   status = ml_information_get (activated_model_info, "path", (void **) &activated_model_path);
+ *   model_path = g_strdup (activated_model_path);
+ * } else {
+ *   // Handle error case.
+ * }
+ *
+ * ml_information_destroy (activated_model_info); // Release the information handle.
+ *
+ * // Do ML things with the variable `model_path`.
+ * @endcode
  */
 int ml_service_model_register (const char *name, const char *path, const bool activate, const char *description, unsigned int *version);
 
@@ -274,10 +314,10 @@ int ml_service_model_activate (const char *name, const unsigned int version);
 /**
  * @brief Gets the information of neural network model with given @a name and @a version.
  * @since_tizen 8.0
- * @remarks If the function succeeds, the @a info should be released using ml_option_destroy().
+ * @remarks If the function succeeds, the @a info should be released using ml_information_destroy().
  * @param[in] name The unique name to indicate the model.
  * @param[in] version The version of registered model.
- * @param[out] info The handle of model.
+ * @param[out] info The handle of model information.
  * @return 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
@@ -285,12 +325,12 @@ int ml_service_model_activate (const char *name, const unsigned int version);
  * @retval #ML_ERROR_IO_ERROR The operation of DB or filesystem has failed.
  * @retval #ML_ERROR_OUT_OF_MEMORY Failed to allocate required memory.
  */
-int ml_service_model_get (const char *name, const unsigned int version, ml_option_h *info);
+int ml_service_model_get (const char *name, const unsigned int version, ml_information_h *info);
 
 /**
  * @brief Gets the information of activated neural network model with given @a name.
  * @since_tizen 8.0
- * @remarks If the function succeeds, the @a info should be released using ml_option_destroy().
+ * @remarks If the function succeeds, the @a info should be released using ml_information_destroy().
  * @param[in] name The unique name to indicate the model.
  * @param[out] info The handle of activated model.
  * @return 0 on success. Otherwise a negative error value.
@@ -300,15 +340,14 @@ int ml_service_model_get (const char *name, const unsigned int version, ml_optio
  * @retval #ML_ERROR_IO_ERROR The operation of DB or filesystem has failed.
  * @retval #ML_ERROR_OUT_OF_MEMORY Failed to allocate required memory.
  */
-int ml_service_model_get_activated (const char *name, ml_option_h *info);
+int ml_service_model_get_activated (const char *name, ml_information_h *info);
 
 /**
  * @brief Gets the list of neural network model with given @a name.
  * @since_tizen 8.0
- * @remarks If the function succeeds, each handle in @a info_list should be released using ml_option_destroy().
+ * @remarks If the function succeeds, the @a info_list should be released using ml_information_list_destroy().
  * @param[in] name The unique name to indicate the model.
- * @param[out] info_list The handles of registered model.
- * @param[out] num Total number of registered model.
+ * @param[out] info_list The handle of list of registered models.
  * @return 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
@@ -316,7 +355,7 @@ int ml_service_model_get_activated (const char *name, ml_option_h *info);
  * @retval #ML_ERROR_IO_ERROR The operation of DB or filesystem has failed.
  * @retval #ML_ERROR_OUT_OF_MEMORY Failed to allocate required memory.
  */
-int ml_service_model_get_all (const char *name, ml_option_h *info_list[], unsigned int *num);
+int ml_service_model_get_all (const char *name, ml_information_list_h *info_list);
 
 /**
  * @brief Deletes a model information with given @a name and @a version from machine learning service.

--- a/c/src/ml-api-common.c
+++ b/c/src/ml-api-common.c
@@ -1647,3 +1647,208 @@ ml_option_get (ml_option_h option, const char *key, void **value)
 
   return _ml_info_get_value ((ml_info_s *) option, key, value);
 }
+
+/**
+ * @brief Creates an ml_information instance and returns the handle.
+ */
+int
+_ml_information_create (ml_information_h * info)
+{
+  ml_info_s *_info = NULL;
+
+  check_feature_state (ML_FEATURE);
+
+  if (!info) {
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'info' is NULL. It should be a valid ml_information_h");
+  }
+
+  _info = _ml_info_create (ML_INFO_MODEL);
+  if (!_info)
+    _ml_error_report_return (ML_ERROR_OUT_OF_MEMORY,
+        "Failed to allocate memory for the info handle. Out of memory?");
+
+  *info = (ml_information_h *) _info;
+  return ML_ERROR_NONE;
+}
+
+/**
+ * @brief Set key-value pair in given information handle.
+ * @note If duplicated key is given, the value is updated with the new one.
+ */
+int
+_ml_information_set (ml_information_h information, const char *key, void *value,
+    ml_data_destroy_cb destroy)
+{
+  check_feature_state (ML_FEATURE);
+
+  if (!information) {
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'information' is NULL. It should be a valid ml_information_h, which should be created by ml_information_create().");
+  }
+
+  if (!key) {
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'key' is NULL. It should be a valid const char*");
+  }
+
+  if (!value) {
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'value' is NULL. It should be a valid void*");
+  }
+
+  return _ml_info_set_value ((ml_info_s *) information, key, value, destroy);
+}
+
+/**
+ * @brief Frees the given handle of a ml_information.
+ */
+int
+ml_information_destroy (ml_information_h information)
+{
+  check_feature_state (ML_FEATURE);
+
+  if (!information) {
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'information' is NULL. It should be a valid ml_information_h, which should be created by ml_information_create().");
+  }
+
+  _ml_info_destroy ((ml_info_s *) information);
+
+  return ML_ERROR_NONE;
+}
+
+/**
+ * @brief Gets the value corresponding to the given key in ml_information instance.
+ */
+int
+ml_information_get (ml_information_h information, const char *key, void **value)
+{
+  check_feature_state (ML_FEATURE);
+
+  if (!information) {
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'information' is NULL. It should be a valid ml_information_h, which should be created by ml_information_create().");
+  }
+
+  if (!key) {
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'key' is NULL. It should be a valid const char*");
+  }
+
+  if (!value) {
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'value' is NULL. It should be a valid void**");
+  }
+
+  return _ml_info_get_value ((ml_info_s *) information, key, value);
+}
+
+/**
+ * @brief Internal function for destroy ml_info_list_s instance.
+ */
+static void
+_ml_info_list_destroy (ml_info_list_s * list)
+{
+  guint i;
+
+  for (i = 0; i < list->length; ++i) {
+    _ml_info_destroy (list->info[i]);
+  }
+
+  g_free (list->info);
+  g_free (list);
+}
+
+/**
+ * @brief Internal function for getting length of ml_info_list_s instance.
+ */
+static unsigned int
+_ml_info_list_length (ml_info_list_s * list)
+{
+  return list->length;
+}
+
+/**
+ * @brief Internal function for getting index-th ml_information_h instance in ml_info_list_s instance.
+ */
+static ml_info_s *
+_ml_info_list_get (ml_info_list_s * list, unsigned int index)
+{
+  if (index >= list->length)
+    return NULL;
+
+  return list->info[index];
+}
+
+/**
+ * @brief Destroys the ml-information-list instance.
+ */
+int
+ml_information_list_destroy (ml_information_list_h list)
+{
+  check_feature_state (ML_FEATURE);
+
+  if (!list) {
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'list' is NULL. It should be a valid ml_information_list_h, which should be created by ml_information_list_create().");
+  }
+
+  _ml_info_list_destroy ((ml_info_list_s *) list);
+
+  return ML_ERROR_NONE;
+}
+
+/**
+ * @brief Gets the number of ml-information in ml-information-list instance.
+ */
+int
+ml_information_list_length (ml_information_list_h list, unsigned int *length)
+{
+  check_feature_state (ML_FEATURE);
+
+  if (!list) {
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'list' is NULL. It should be a valid ml_information_list_h, which should be created by ml_information_list_create().");
+  }
+
+  if (!length) {
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'length' is NULL. It should be a valid unsigned int*");
+  }
+
+  *length = _ml_info_list_length ((ml_info_list_s *) list);
+
+  return ML_ERROR_NONE;
+}
+
+/**
+ * @brief Gets a ml-information in ml-information-list instance with given index.
+ */
+int
+ml_information_list_get (ml_information_list_h list, unsigned int index,
+    ml_information_h * information)
+{
+  ml_info_s *info_s;
+  check_feature_state (ML_FEATURE);
+
+  if (!list) {
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'list' is NULL. It should be a valid ml_information_list_h, which should be created by ml_information_list_create().");
+  }
+
+  if (!information) {
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'information' is NULL. It should be a valid ml_information_h*");
+  }
+
+  info_s = _ml_info_list_get ((ml_info_list_s *) list, index);
+  if (info_s == NULL) {
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "The parameter, 'index' is invalid. It should be less than the length of ml_information_list_h");
+  }
+
+  *information = (ml_information_h) info_s;
+
+  return ML_ERROR_NONE;
+}

--- a/c/src/ml-api-internal.h
+++ b/c/src/ml-api-internal.h
@@ -395,6 +395,34 @@ int _ml_tensors_data_destroy_internal (ml_tensors_data_h data, gboolean free_dat
  */
 int _ml_tensors_data_create_no_alloc (const ml_tensors_info_h info, ml_tensors_data_h *data);
 
+/**
+ * @brief Creates ml-information instance.
+ * @since_tizen 8.0
+ * @remarks The @a ml_info should be released using ml_information_destroy().
+ * @param[out] ml_info Newly created ml_info handle is returned.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
+ * @retval #ML_ERROR_OUT_OF_MEMORY Failed to allocate required memory.
+ */
+int _ml_information_create (ml_information_h *ml_info);
+
+/**
+ * @brief Sets a new key-value in ml-information instance.
+ * @details Note that the @a value should be valid during single task and be freed after destroying the ml-information instance unless proper @a destroy function is given. When duplicated @a key is given, the corresponding @a value is updated with the new one.
+ * @since_tizen 8.0
+ * @param[in] ml_info The handle of ml-information.
+ * @param[in] key The key to be set.
+ * @param[in] value The value to be set.
+ * @param[in] destroy The function to destroy the value. It is called when the ml-information instance is destroyed.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
+ */
+int _ml_information_set (ml_information_h ml_info, const char *key, void *value, ml_data_destroy_cb destroy);
+
 #if defined (__TIZEN__)
 /****** TIZEN CHECK FEATURE BEGINS *****/
 /**

--- a/c/src/ml-api-service-agent-client.c
+++ b/c/src/ml-api-service-agent-client.c
@@ -22,10 +22,10 @@
         "It is highly suggested that `%s` before it is set."
 
 /**
- * @brief Build ml_option_h from json cstring.
+ * @brief Build ml_information_h from json cstring.
  */
 static gint
-_build_ml_opt_from_json_cstr (const gchar * jcstring, ml_option_h * opt)
+_build_ml_info_from_json_cstr (const gchar * jcstring, ml_information_h * _info)
 {
   g_autoptr (GError) err = NULL;
   g_autoptr (JsonParser) parser = NULL;
@@ -35,14 +35,14 @@ _build_ml_opt_from_json_cstr (const gchar * jcstring, ml_option_h * opt)
   GList *l;
   gint ret;
 
-  if (NULL == opt) {
+  if (NULL == _info) {
     _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
         "The argument for 'opt' should not be NULL.");
   }
 
-  if (NULL != *opt) {
+  if (NULL != *_info) {
     _ml_logw (WARN_MSG_DPTR_SET_OVER, "opt");
-    *opt = NULL;
+    *_info = NULL;
   }
 
   parser = json_parser_new ();
@@ -64,7 +64,7 @@ _build_ml_opt_from_json_cstr (const gchar * jcstring, ml_option_h * opt)
     return ML_ERROR_INVALID_PARAMETER;
   }
 
-  ret = ml_option_create (opt);
+  ret = _ml_information_create (_info);
   if (ML_ERROR_NONE != ret) {
     return ret;
   }
@@ -75,7 +75,7 @@ _build_ml_opt_from_json_cstr (const gchar * jcstring, ml_option_h * opt)
     const gchar *key = l->data;
     const gchar *val = json_object_get_string_member (jobj, key);
 
-    ml_option_set (*opt, key, g_strdup (val), g_free);
+    _ml_information_set (*_info, key, g_strdup (val), g_free);
   }
 
   return ML_ERROR_NONE;
@@ -89,7 +89,7 @@ _build_ml_opt_from_json_cstr (const gchar * jcstring, ml_option_h * opt)
  * @brief Parse app_info and update path (for model from rpk). Only for Tizen Applications.
  */
 static int
-_parse_app_info_and_update_path (ml_option_h ml_info)
+_parse_app_info_and_update_path (ml_information_h ml_info)
 {
   int ret = ML_ERROR_NONE;
 
@@ -100,7 +100,7 @@ _parse_app_info_and_update_path (ml_option_h ml_info)
   JsonObject *j_object;
 
   /* parsing app_info and fill path (for rpk) */
-  ret = ml_option_get (ml_info, "app_info", (void **) &app_info);
+  ret = ml_information_get (ml_info, "app_info", (void **) &app_info);
   if (ret != ML_ERROR_NONE) {
     _ml_error_report ("Failed to get app_info from the model info.");
     return ret;
@@ -128,7 +128,7 @@ _parse_app_info_and_update_path (ml_option_h ml_info)
     const gchar *res_type =
         json_object_get_string_member (j_object, "res_type");
 
-    ret = ml_option_get (ml_info, "path", (void **) &ori_path);
+    ret = ml_information_get (ml_info, "path", (void **) &ori_path);
     if (ret != ML_ERROR_NONE) {
       _ml_error_report ("Failed to get path from the model info.");
       return ret;
@@ -144,7 +144,7 @@ _parse_app_info_and_update_path (ml_option_h ml_info)
     }
 
     new_path = g_strdup_printf ("%s/%s", global_resource_path, ori_path);
-    ret = ml_option_set (ml_info, "path", new_path, g_free);
+    ret = _ml_information_set (ml_info, "path", new_path, g_free);
     if (ret != ML_ERROR_NONE) {
       _ml_error_report ("Failed to set path to the model info.");
       return ret;
@@ -598,10 +598,10 @@ ml_service_model_activate (const char *name, const unsigned int version)
  */
 int
 ml_service_model_get (const char *name, const unsigned int version,
-    ml_option_h * info)
+    ml_information_h * info)
 {
   int ret = ML_ERROR_NONE;
-  ml_option_h _info = NULL;
+  ml_information_h _info = NULL;
   g_autoptr (GError) err = NULL;
   g_autofree gchar *description = NULL;
 
@@ -618,7 +618,7 @@ ml_service_model_get (const char *name, const unsigned int version,
   }
 
   if (*info != NULL) {
-    _ml_logw (WARN_MSG_DPTR_SET_OVER, "ml_option_h info = NULL");
+    _ml_logw (WARN_MSG_DPTR_SET_OVER, "ml_information_h info = NULL");
   }
   *info = NULL;
 
@@ -629,9 +629,9 @@ ml_service_model_get (const char *name, const unsigned int version,
     return ret;
   }
 
-  ret = _build_ml_opt_from_json_cstr (description, &_info);
+  ret = _build_ml_info_from_json_cstr (description, &_info);
   if (ML_ERROR_NONE != ret) {
-    _ml_error_report ("Failed to convert json string to ml_option_h.");
+    _ml_error_report ("Failed to convert json string to ml_information_h.");
     goto error;
   }
 
@@ -645,7 +645,7 @@ ml_service_model_get (const char *name, const unsigned int version,
 
 error:
   if (ML_ERROR_NONE != ret && _info) {
-    ml_option_destroy (_info);
+    ml_information_destroy (_info);
   }
 
   return ret;
@@ -655,11 +655,11 @@ error:
  * @brief Gets the information of activated neural network model with given @a name.
  */
 int
-ml_service_model_get_activated (const char *name, ml_option_h * info)
+ml_service_model_get_activated (const char *name, ml_information_h * info)
 {
   int ret = ML_ERROR_NONE;
 
-  ml_option_h _info = NULL;
+  ml_information_h _info = NULL;
   g_autoptr (GError) err = NULL;
   g_autofree gchar *description = NULL;
 
@@ -676,7 +676,7 @@ ml_service_model_get_activated (const char *name, ml_option_h * info)
   }
 
   if (*info != NULL) {
-    _ml_logw (WARN_MSG_DPTR_SET_OVER, "ml_option_h info = NULL");
+    _ml_logw (WARN_MSG_DPTR_SET_OVER, "ml_information_h info = NULL");
   }
   *info = NULL;
 
@@ -687,9 +687,9 @@ ml_service_model_get_activated (const char *name, ml_option_h * info)
     return ret;
   }
 
-  ret = _build_ml_opt_from_json_cstr (description, &_info);
+  ret = _build_ml_info_from_json_cstr (description, &_info);
   if (ML_ERROR_NONE != ret) {
-    _ml_error_report ("Failed to convert json string to ml_option_h.");
+    _ml_error_report ("Failed to convert json string to ml_information_h.");
     goto error;
   }
 
@@ -703,7 +703,7 @@ ml_service_model_get_activated (const char *name, ml_option_h * info)
 
 error:
   if (ret != ML_ERROR_NONE && _info) {
-    ml_option_destroy (_info);
+    ml_information_destroy (_info);
   }
 
   return ret;
@@ -713,12 +713,11 @@ error:
  * @brief Gets the list of neural network model with given @a name.
  */
 int
-ml_service_model_get_all (const char *name, ml_option_h * info_list[],
-    unsigned int *num)
+ml_service_model_get_all (const char *name, ml_information_list_h * info_list)
 {
   g_autofree gchar *description = NULL;
   g_autoptr (GError) err = NULL;
-  ml_option_h *_info_list = NULL;
+  ml_info_list_s *_info_list = NULL;
   int ret = ML_ERROR_NONE;
   guint i, n;
 
@@ -735,17 +734,17 @@ ml_service_model_get_all (const char *name, ml_option_h * info_list[],
   }
   *info_list = NULL;
 
-  if (NULL == num) {
-    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
-        "The parameter 'num' should not be NULL.");
-  }
-  *num = 0;
-
   ret = ml_agent_dbus_interface_model_get_all (name, &description, &err);
   if (ML_ERROR_NONE != ret || !description) {
     _ml_error_report ("Failed to invoke the method model_get_all (%s).",
         err ? err->message : "Unknown error");
     return ret;
+  }
+
+  _info_list = g_try_new0 (ml_info_list_s, 1);
+  if (NULL == _info_list) {
+    _ml_error_report ("Failed to allocate memory for ml_info_list.");
+    return ML_ERROR_OUT_OF_MEMORY;
   }
 
   {
@@ -784,20 +783,23 @@ ml_service_model_get_all (const char *name, ml_option_h * info_list[],
           "Failed to retrieve the length of the json array.");
     }
 
-    _info_list = g_try_new0 (ml_option_h, n);
-    if (!_info_list) {
+    _info_list->info = g_try_new0 (ml_info_s *, n);
+    if (!_info_list->info) {
+      g_free (_info_list);
       _ml_error_report_return (ML_ERROR_OUT_OF_MEMORY,
-          "Failed to allocate memory for list of ml_option_h. Out of memory?");
+          "Failed to allocate memory for list of ml_information_h. Out of memory?");
     }
+    _info_list->length = n;
 
     for (i = 0; i < n; i++) {
       g_autoptr (GList) members = NULL;
       JsonObject *jobj = NULL;
       GList *l;
 
-      if (ML_ERROR_NONE != ml_option_create (&_info_list[i])) {
+      if (ML_ERROR_NONE !=
+          _ml_information_create ((ml_information_h *) & _info_list->info[i])) {
         _ml_error_report
-            ("Failed to allocate memory for ml_option_h. Out of memory?");
+            ("Failed to allocate memory for ml_information. Out of memory?");
         n = i;
         ret = ML_ERROR_OUT_OF_MEMORY;
         goto error;
@@ -809,10 +811,11 @@ ml_service_model_get_all (const char *name, ml_option_h * info_list[],
         const gchar *key = l->data;
         const gchar *val = json_object_get_string_member (jobj, key);
 
-        ml_option_set (_info_list[i], key, g_strdup (val), g_free);
+        _ml_information_set (_info_list->info[i], key, g_strdup (val), g_free);
       }
 
-      if (_parse_app_info_and_update_path (_info_list[i]) != 0) {
+      if (_parse_app_info_and_update_path ((ml_information_h)
+              _info_list->info[i]) != 0) {
         _ml_error_report ("Failed to parse app_info and update path.");
         ret = ML_ERROR_INVALID_PARAMETER;
         goto error;
@@ -821,18 +824,18 @@ ml_service_model_get_all (const char *name, ml_option_h * info_list[],
   }
 
   *info_list = _info_list;
-  *num = n;
 
   return ML_ERROR_NONE;
 
 error:
   if (_info_list) {
     for (i = 0; i < n; i++) {
-      if (_info_list[i]) {
-        ml_option_destroy (_info_list[i]);
+      if (_info_list->info[i]) {
+        ml_information_destroy (_info_list->info[i]);
       }
     }
 
+    g_free (_info_list->info);
     g_free (_info_list);
   }
 


### PR DESCRIPTION
- Define `ml_information_h` and `ml_information_list_h`.
- Add related APIs
  `ml_information_(destroy/get)`
  `ml_information_list_(destroy/length/get)`
- Replace ml_option with ml_information in service/model APIs
- Since the signature of APIs (`ml_service_model_get*`) are changed, fix related test code.