### PR TITLE
[Tizen] Disable nnfw by default @open sesame 09/21 13:35

### DIFF
--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -141,10 +141,6 @@ BuildRequires:	pkgconfig(gles20)
 %if 0%{?nnfw_support}
 BuildRequires:	nnfw-devel
 BuildRequires:	nnstreamer-nnfw
-%ifarch %arm aarch64
-BuildRequires:	libarmcl
-BuildConflicts:	libarmcl-release
-%endif
 %endif
 
 %if 0%{?armnn_support}


### PR DESCRIPTION
Disable nnfw by default
 - To avoid armcl dependency problem on arm arch.