### PR TITLE
[CodeClean] function name

### DIFF
--- a/c/include/nnstreamer-tizen-internal.h
+++ b/c/include/nnstreamer-tizen-internal.h
@@ -61,27 +61,6 @@ void ml_api_get_version (unsigned int *major, unsigned int *minor, unsigned int 
  */
 char * ml_api_get_version_string (void);
 
-
-typedef enum {
-  ML_SERVICE_TYPE_UNKNOWN = 0,
-  ML_SERVICE_TYPE_SERVER_PIPELINE,
-  ML_SERVICE_TYPE_CLIENT_QUERY,
-  ML_SERVICE_TYPE_REMOTE,
-
-  ML_SERVICE_TYPE_MAX
-} ml_service_type_e;
-
-typedef enum {
-  ML_REMOTE_SERVICE_TYPE_UNKNOWN = 0,
-  ML_REMOTE_SERVICE_TYPE_MODEL_RAW,
-  ML_REMOTE_SERVICE_TYPE_MODEL_URI,
-  ML_REMOTE_SERVICE_TYPE_PIPELINE_RAW,
-  ML_REMOTE_SERVICE_TYPE_PIPELINE_URI,
-
-  ML_REMOTE_SERVICE_TYPE_MAX
-} ml_remote_service_type_e;
-
-
 /**
  * @brief Creates ml remote service handle with given ml-option handle.
  * @since_tizen 8.0
@@ -98,7 +77,7 @@ typedef enum {
  * @retval #ML_ERROR_STREAMS_PIPE Failed to launch the pipeline.
  * @retval #ML_ERROR_TRY_AGAIN The pipeline is not ready yet.
  */
-int ml_remote_service_create (ml_option_h option, ml_service_h *handle);
+int ml_service_remote_create (ml_option_h option, ml_service_h *handle);
 
 /**
  * @todo DRAFT. API name should be determined later.
@@ -127,7 +106,7 @@ int ml_remote_service_create (ml_option_h option, ml_service_h *handle);
  * gchar *client_connect_type = g_strdup ("TCP");
  * ml_option_set (client_option_h, "connect-type", client_connect_type, g_free);
  *
- * status = ml_remote_service_create (client_option_h, &client_h);
+ * status = ml_service_remote_create (client_option_h, &client_h);
  *
  * // ================== Server side ==================
  * ml_service_h server_h;
@@ -143,7 +122,7 @@ int ml_remote_service_create (ml_option_h option, ml_service_h *handle);
  *  ml_option_set (server_option_h, "connect-type", server_connect_type, g_free);
  *
  * // Create ml-remote service.
- * ml_remote_service_create (server_option_h, &server_h)
+ * ml_service_remote_create (server_option_h, &server_h)
  *
  * // ================== Client side ==================
  * // Send neural network model url to the query server.
@@ -161,7 +140,7 @@ int ml_remote_service_create (ml_option_h option, ml_service_h *handle);
  * ml_option_set (client_option_h, "dest_host", dest_host, g_free);
  *
  * // Create query service.
- * ml_remote_service_create (client_option_h, &client_h);
+ * ml_service_remote_create (client_option_h, &client_h);
  *
  * ml_option_h query_option_h = NULL;
  * ml_option_create (&query_option_h);
@@ -186,7 +165,7 @@ int ml_remote_service_create (ml_option_h option, ml_service_h *handle);
  * gchar *name = g_strdup ("model_name.nnfw");
  * ml_option_set (remote_service_option_h, "name", name, g_free);
  *
- * ml_remote_service_register (client_h, remote_service_option_h, contents, len);
+ * ml_service_remote_register (client_h, remote_service_option_h, contents, len);
  *
  * ml_service_destroy (client_h);
  * ml_service_destroy (server_h);
@@ -196,7 +175,7 @@ int ml_remote_service_create (ml_option_h option, ml_service_h *handle);
  *
  * @endcode
  */
-int ml_remote_service_register (ml_service_h handle, ml_option_h option, void *data, size_t data_len);
+int ml_service_remote_register (ml_service_h handle, ml_option_h option, void *data, size_t data_len);
 
 #ifdef __cplusplus
 }

--- a/c/src/meson.build
+++ b/c/src/meson.build
@@ -13,7 +13,7 @@ nns_capi_single_srcs = files('ml-api-inference-single.c')
 nns_capi_pipeline_srcs = files('ml-api-inference-pipeline.c')
 nns_capi_service_srcs = files('ml-api-service-common.c','ml-api-service-agent-client.c', 'ml-api-service-query-client.c')
 if support_remote_service
-  nns_capi_service_srcs += files('ml-api-remote-service.c')
+  nns_capi_service_srcs += files('ml-api-service-remote.c')
 endif
 
 # Build ML-API Common Lib First.

--- a/c/src/ml-api-service-private.h
+++ b/c/src/ml-api-service-private.h
@@ -28,6 +28,19 @@ extern "C" {
 #endif /* __cplusplus */
 
 /**
+ * @brief Enumeration for ml-service type.
+ */
+typedef enum
+{
+  ML_SERVICE_TYPE_UNKNOWN = 0,
+  ML_SERVICE_TYPE_SERVER_PIPELINE,
+  ML_SERVICE_TYPE_CLIENT_QUERY,
+  ML_SERVICE_TYPE_REMOTE,
+
+  ML_SERVICE_TYPE_MAX
+} ml_service_type_e;
+
+/**
  * @brief Structure for ml_remote_service_h
  */
 typedef struct

--- a/c/src/ml-api-service-remote.c
+++ b/c/src/ml-api-service-remote.c
@@ -2,9 +2,9 @@
 /**
  * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved.
  *
- * @file ml-api-remote-service.c
+ * @file ml-api-service-remote.c
  * @date 26 Jun 2023
- * @brief ml-remote-service of NNStreamer/Service C-API
+ * @brief ML remote service of NNStreamer/Service C-API
  * @see https://github.com/nnstreamer/nnstreamer
  * @author Gichan Jang <gichan2.jang@samsung.com>
  * @bug No known bugs except for NYI items
@@ -22,6 +22,20 @@
 #include "ml-api-service-private.h"
 
 #define MAX_PORT_NUM_LEN 6U
+
+/**
+ * @brief Enumeration for ml-remote service type.
+ */
+typedef enum
+{
+  ML_REMOTE_SERVICE_TYPE_UNKNOWN = 0,
+  ML_REMOTE_SERVICE_TYPE_MODEL_RAW,
+  ML_REMOTE_SERVICE_TYPE_MODEL_URI,
+  ML_REMOTE_SERVICE_TYPE_PIPELINE_RAW,
+  ML_REMOTE_SERVICE_TYPE_PIPELINE_URI,
+
+  ML_REMOTE_SERVICE_TYPE_MAX
+} ml_remote_service_type_e;
 
 /**
  * @brief Data struct for options.
@@ -470,7 +484,7 @@ _mlrs_create_edge_handle (nns_edge_h * edge_h, edge_info_s * edge_info)
  * @brief Creates ml-service handle with given ml-option handle.
  */
 int
-ml_remote_service_create (ml_option_h option, ml_service_h * handle)
+ml_service_remote_create (ml_option_h option, ml_service_h * handle)
 {
   ml_service_s *mls;
   _ml_remote_service_s *remote_s;
@@ -527,7 +541,7 @@ ml_remote_service_create (ml_option_h option, ml_service_h * handle)
  *  @brief Register new information, such as neural network models or pipeline descriptions, on a remote server.
 */
 int
-ml_remote_service_register (ml_service_h handle, ml_option_h option, void *data,
+ml_service_remote_register (ml_service_h handle, ml_option_h option, void *data,
     size_t data_len)
 {
   ml_service_s *mls = (ml_service_s *) handle;

--- a/tests/capi/unittest_capi_remote_service.cc
+++ b/tests/capi/unittest_capi_remote_service.cc
@@ -121,7 +121,7 @@ TEST_F (MLRemoteService, registerPipeline)
   status = ml_option_set (client_option_h, "topic", topic, NULL);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  status = ml_remote_service_create (client_option_h, &client_h);
+  status = ml_service_remote_create (client_option_h, &client_h);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
   /**============= Prepare server ============= **/
@@ -147,7 +147,7 @@ TEST_F (MLRemoteService, registerPipeline)
   status = ml_option_set (server_option_h, "connect-type", server_connect_type, g_free);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  status = ml_remote_service_create (server_option_h, &server_h);
+  status = ml_service_remote_create (server_option_h, &server_h);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
   ml_option_h remote_service_option_h = NULL;
@@ -163,7 +163,7 @@ TEST_F (MLRemoteService, registerPipeline)
 
   g_autofree gchar *pipeline_desc = g_strdup ("fakesrc ! fakesink");
 
-  status = ml_remote_service_register (client_h, remote_service_option_h,
+  status = ml_service_remote_register (client_h, remote_service_option_h,
       pipeline_desc, strlen (pipeline_desc) + 1);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
@@ -222,7 +222,7 @@ TEST_F (MLRemoteService, registerPipelineURI)
   status = ml_option_set (client_option_h, "topic", topic, NULL);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  status = ml_remote_service_create (client_option_h, &client_h);
+  status = ml_service_remote_create (client_option_h, &client_h);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
   /**============= Prepare server ============= **/
@@ -248,7 +248,7 @@ TEST_F (MLRemoteService, registerPipelineURI)
   status = ml_option_set (server_option_h, "connect-type", server_connect_type, g_free);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  status = ml_remote_service_create (server_option_h, &server_h);
+  status = ml_service_remote_create (server_option_h, &server_h);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
   ml_option_h remote_service_option_h = NULL;
@@ -271,7 +271,7 @@ TEST_F (MLRemoteService, registerPipelineURI)
   gchar *pipeline_uri = g_strdup_printf ("file://%s", test_file_path);
   g_free (test_file_path);
 
-  status = ml_remote_service_register (client_h, remote_service_option_h,
+  status = ml_service_remote_register (client_h, remote_service_option_h,
       pipeline_uri, strlen (pipeline_uri) + 1);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
@@ -301,7 +301,7 @@ TEST_F (MLRemoteService, registerPipelineURI)
 }
 
 /**
- * @brief Test ml_remote_service_create with invalid param.
+ * @brief Test ml_service_remote_create with invalid param.
  */
 TEST_F (MLRemoteService, createInvalidParam_n)
 {
@@ -312,10 +312,10 @@ TEST_F (MLRemoteService, createInvalidParam_n)
   status = ml_option_create (&option_h);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  status = ml_remote_service_create (NULL, &service_h);
+  status = ml_service_remote_create (NULL, &service_h);
   EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
 
-  status = ml_remote_service_create (option_h, NULL);
+  status = ml_service_remote_create (option_h, NULL);
   EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
 
   status = ml_option_destroy (option_h);
@@ -323,7 +323,7 @@ TEST_F (MLRemoteService, createInvalidParam_n)
 }
 
 /**
- * @brief Test ml_remote_service_register with invalid param.
+ * @brief Test ml_service_remote_register with invalid param.
  */
 TEST_F (MLRemoteService, registerInvalidParam_n)
 {
@@ -352,7 +352,7 @@ TEST_F (MLRemoteService, registerInvalidParam_n)
   status = ml_option_set (option_h, "connect-type", client_connect_type, g_free);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  status = ml_remote_service_create (option_h, &service_h);
+  status = ml_service_remote_create (option_h, &service_h);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
   status = ml_option_destroy (option_h);
@@ -369,16 +369,16 @@ TEST_F (MLRemoteService, registerInvalidParam_n)
   ml_option_set (remote_service_option_h, "service-key", service_key, g_free);
 
   g_autofree gchar *pipeline_desc = g_strdup ("fakesrc ! fakesink");
-  status = ml_remote_service_register (NULL, remote_service_option_h, str, len);
+  status = ml_service_remote_register (NULL, remote_service_option_h, str, len);
   EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
 
-  status = ml_remote_service_register (service_h, NULL, str, len);
+  status = ml_service_remote_register (service_h, NULL, str, len);
   EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
 
-  status = ml_remote_service_register (service_h, remote_service_option_h, NULL, len);
+  status = ml_service_remote_register (service_h, remote_service_option_h, NULL, len);
   EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
 
-  status = ml_remote_service_register (service_h, remote_service_option_h, str, 0);
+  status = ml_service_remote_register (service_h, remote_service_option_h, str, 0);
   EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
 
   status = ml_option_destroy (remote_service_option_h);
@@ -422,7 +422,7 @@ TEST_F (MLRemoteService, registerModel)
   status = ml_option_set (client_option_h, "topic", topic, NULL);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  status = ml_remote_service_create (client_option_h, &client_h);
+  status = ml_service_remote_create (client_option_h, &client_h);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
   /**============= Prepare server ============= **/
@@ -448,12 +448,12 @@ TEST_F (MLRemoteService, registerModel)
   status = ml_option_set (server_option_h, "connect-type", server_connect_type, g_free);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  status = ml_remote_service_create (server_option_h, &server_h);
+  status = ml_service_remote_create (server_option_h, &server_h);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
   /** Set service option */
   const gchar *root_path = g_getenv ("MLAPI_SOURCE_ROOT_PATH");
-  /* ml_remote_service_register () requires absolute path to model, ignore this case. */
+  /* ml_service_remote_register () requires absolute path to model, ignore this case. */
   if (root_path == NULL)
     return;
 
@@ -484,7 +484,7 @@ TEST_F (MLRemoteService, registerModel)
   gchar *name = g_strdup ("mobilenet_v1_1.0_224_quant.tflite");
   ml_option_set (remote_service_option_h, "name", name, g_free);
 
-  status = ml_remote_service_register (client_h, remote_service_option_h, contents, len);
+  status = ml_service_remote_register (client_h, remote_service_option_h, contents, len);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
   /** Wait for the server to register the pipeline. */
@@ -563,7 +563,7 @@ TEST_F (MLRemoteService, registerModelURI)
   status = ml_option_set (client_option_h, "topic", topic, NULL);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  status = ml_remote_service_create (client_option_h, &client_h);
+  status = ml_service_remote_create (client_option_h, &client_h);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
   /**============= Prepare server ============= **/
@@ -589,12 +589,12 @@ TEST_F (MLRemoteService, registerModelURI)
   status = ml_option_set (server_option_h, "connect-type", server_connect_type, g_free);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  status = ml_remote_service_create (server_option_h, &server_h);
+  status = ml_service_remote_create (server_option_h, &server_h);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
   /** Prepare model register service */
   const gchar *root_path = g_getenv ("MLAPI_SOURCE_ROOT_PATH");
-  /* ml_remote_service_register () requires absolute path to model, ignore this case. */
+  /* ml_service_remote_register () requires absolute path to model, ignore this case. */
   if (root_path == NULL)
     return;
 
@@ -623,7 +623,7 @@ TEST_F (MLRemoteService, registerModelURI)
   gchar *name = g_strdup ("mobilenet_v1_1.0_224_quant.tflite");
   ml_option_set (remote_service_option_h, "name", name, g_free);
 
-  status = ml_remote_service_register (
+  status = ml_service_remote_register (
       client_h, remote_service_option_h, model_uri, strlen (model_uri) + 1);
   EXPECT_EQ (ML_ERROR_NONE, status);
   g_free (model_uri);


### PR DESCRIPTION
1. Update ml-remote function name, prefix 'ml_service'.
2. Hide internal enum and struct.