### PR TITLE
[C-Api/Pipeline] create handle before calling sink callback

### DIFF
--- a/c/src/ml-api-common.c
+++ b/c/src/ml-api-common.c
@@ -961,7 +961,8 @@ _ml_tensors_data_destroy_internal (ml_tensors_data_h data, gboolean free_data)
     }
   }
 
-  ml_tensors_info_destroy (_data->info);
+  if (_data->info)
+    ml_tensors_info_destroy (_data->info);
 
   G_UNLOCK_UNLESS_NOLOCK (*_data);
   g_mutex_clear (&_data->lock);

--- a/c/src/ml-api-inference-pipeline-internal.h
+++ b/c/src/ml-api-inference-pipeline-internal.h
@@ -144,7 +144,6 @@ typedef struct _ml_pipeline_element {
   GstPad *src;
   GstPad *sink; /**< Unref this at destroy */
   ml_tensors_info_s tensors_info;
-  size_t size;
 
   GList *handles;
   int maxid; /**< to allocate id for each handle */

--- a/c/src/ml-api-inference-pipeline-internal.h
+++ b/c/src/ml-api-inference-pipeline-internal.h
@@ -143,7 +143,7 @@ typedef struct _ml_pipeline_element {
   ml_pipeline_element_e type;
   GstPad *src;
   GstPad *sink; /**< Unref this at destroy */
-  ml_tensors_info_s tensors_info;
+  GstTensorsInfo tensors_info;
 
   GList *handles;
   int maxid; /**< to allocate id for each handle */

--- a/c/src/ml-api-inference-single.c
+++ b/c/src/ml-api-inference-single.c
@@ -413,7 +413,7 @@ __invoke (ml_single * single_h, ml_tensors_data_h in, ml_tensors_data_h out)
   in_tensors = (GstTensorMemory *) in_data->tensors;
   out_tensors = (GstTensorMemory *) out_data->tensors;
 
-  /** invoke the thread */
+  /* Invoke the thread. */
   if (!single_h->klass->invoke (single_h->filter, in_tensors, out_tensors,
           single_h->free_output)) {
     const char *fw_name = _ml_get_nnfw_subplugin_name (single_h->nnfw);

--- a/tests/capi/unittest_capi_inference_nnfw_runtime.cc
+++ b/tests/capi/unittest_capi_inference_nnfw_runtime.cc
@@ -270,7 +270,6 @@ TEST_F (MLAPIInferenceNNFW, invoke_single_00)
   EXPECT_FLOAT_EQ (*data, 12.0);
 }
 
-
 /**
  * @brief Test nnfw subplugin with unsuccessful invoke (single ML-API)
  * @detail Model is not found

--- a/tests/capi/unittest_capi_inference_single.cc
+++ b/tests/capi/unittest_capi_inference_single.cc
@@ -395,7 +395,7 @@ benchmark_single (const gboolean no_alloc, const gboolean no_timeout, const int 
   ml_tensors_info_set_tensor_type (out_info, 0, ML_TENSOR_TYPE_UINT8);
   ml_tensors_info_set_tensor_dimension (out_info, 0, out_dim);
 
-  /** Initial run to warm up the cache */
+  /* Initial run to warm up the cache */
   status = ml_single_open (&single, test_model, in_info, out_info,
       ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_ANY);
   if (is_enabled_tensorflow_lite) {
@@ -1099,7 +1099,7 @@ single_shot_loop_test (void *arg)
     if (ss_data->expect) {
       no_error_cond = status == ML_ERROR_NONE && output != NULL;
       if (ss_data->timeout < ss_data->min_time_to_run) {
-        /** Default timeout can return timed out with many parallel runs */
+        /* Default timeout can return timed out with many parallel runs */
         timeout_cond = output == NULL
                        && (status == ML_ERROR_TIMED_OUT || status == ML_ERROR_TRY_AGAIN);
         EXPECT_TRUE (timeout_cond || no_error_cond);
@@ -1189,7 +1189,7 @@ TEST (nnstreamer_capi_singleshot, invoke_timeout)
     /* set timeout 10 s */
     status = ml_single_set_timeout (single, SINGLE_DEF_TIMEOUT_MSEC);
     /* clear out previous buffers */
-    g_usleep (SINGLE_DEF_TIMEOUT_MSEC * 1000); /** 10 sec */
+    g_usleep (SINGLE_DEF_TIMEOUT_MSEC * 1000); /* 10 sec */
 
     status = ml_single_invoke (single, input, &output);
     EXPECT_EQ (status, ML_ERROR_NONE);
@@ -1237,15 +1237,15 @@ TEST (nnstreamer_capi_singleshot, parallel_runs)
   for (i = 0; i < num_cases; i++) {
     ss_data[i].test_model = test_model;
     ss_data[i].num_runs = 3;
-    ss_data[i].min_time_to_run = 10; /** 10 msec */
+    ss_data[i].min_time_to_run = 10; /* 10 msec */
     ss_data[i].expect = TRUE;
   }
 
-  /** Default timeout runs */
+  /* Default timeout runs */
   ss_data[0].timeout = 0;
-  /** small timeout runs */
+  /* small timeout runs */
   ss_data[1].timeout = 5;
-  /** large timeout runs - increases with each run as tests run in parallel */
+  /* large timeout runs - increases with each run as tests run in parallel */
   ss_data[2].timeout = SINGLE_DEF_TIMEOUT_MSEC * num_cases * num_threads;
 
   /**
@@ -1292,15 +1292,15 @@ TEST (nnstreamer_capi_singleshot, close_while_running)
 
   ss_data.test_model = test_model;
   ss_data.num_runs = 10;
-  ss_data.min_time_to_run = 10; /** 10 msec */
+  ss_data.min_time_to_run = 10; /* 10 msec */
   ss_data.expect = FALSE;
   ss_data.timeout = SINGLE_DEF_TIMEOUT_MSEC;
   ss_data.single = NULL;
 
   pthread_create (&thread, NULL, single_shot_loop_test, (void *) &ss_data);
 
-  /** Start the thread and let the code start */
-  g_usleep (100000); /** 100 msec */
+  /* Start the thread and let the code start */
+  g_usleep (100000); /* 100 msec */
 
   /**
    * Call single API functions while its running. One run takes 100ms on
@@ -1361,7 +1361,7 @@ TEST (nnstreamer_capi_singleshot, set_input_info_fail_01_n)
   ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_UINT8);
   ml_tensors_info_set_tensor_dimension (in_info, 0, in_dim);
 
-  /** mobilenet model does not support setting different input dimension */
+  /* mobilenet model does not support setting different input dimension */
   status = ml_single_set_input_info (single, in_info);
   EXPECT_TRUE (status == ML_ERROR_NOT_SUPPORTED || status == ML_ERROR_INVALID_PARAMETER);
 
@@ -1394,7 +1394,7 @@ TEST (nnstreamer_capi_singleshot, set_input_info_fail_02_n)
   if (root_path == NULL)
     root_path = "..";
 
-  /** add.tflite adds value 2 to all the values in the input */
+  /* add.tflite adds value 2 to all the values in the input */
   test_model = g_build_filename (
       root_path, "tests", "test_models", "models", "add.tflite", NULL);
   ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
@@ -1414,7 +1414,7 @@ TEST (nnstreamer_capi_singleshot, set_input_info_fail_02_n)
   status = ml_tensors_info_get_count (in_info, &count);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  /** changing the count of number of tensors is not allowed */
+  /* changing the count of number of tensors is not allowed */
   ml_tensors_info_set_count (in_info, count + 1);
   status = ml_single_set_input_info (single, in_info);
   EXPECT_NE (status, ML_ERROR_NONE);
@@ -1424,7 +1424,7 @@ TEST (nnstreamer_capi_singleshot, set_input_info_fail_02_n)
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (type, ML_TENSOR_TYPE_FLOAT32);
 
-  /** changing the type of input tensors is not allowed */
+  /* changing the type of input tensors is not allowed */
   ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_INT32);
   status = ml_single_set_input_info (single, in_info);
   EXPECT_NE (status, ML_ERROR_NONE);
@@ -1485,7 +1485,7 @@ TEST (nnstreamer_capi_singleshot, set_input_info_success)
   ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_UINT8);
   ml_tensors_info_set_tensor_dimension (in_info, 0, in_dim);
 
-  /** set the same original input dimension */
+  /* set the same original input dimension */
   status = ml_single_set_input_info (single, in_info);
   EXPECT_TRUE (status == ML_ERROR_NOT_SUPPORTED || status == ML_ERROR_NONE);
 
@@ -1536,7 +1536,7 @@ TEST (nnstreamer_capi_singleshot, set_input_info_success_01)
   if (root_path == NULL)
     root_path = "..";
 
-  /** add.tflite adds value 2 to all the values in the input */
+  /* add.tflite adds value 2 to all the values in the input */
   test_model = g_build_filename (
       root_path, "tests", "test_models", "models", "add.tflite", NULL);
   ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
@@ -1584,11 +1584,10 @@ TEST (nnstreamer_capi_singleshot, set_input_info_success_01)
    * 3. run the model file with the updated input dimensions
    * 4. verify the output
    */
-
   ml_tensors_info_get_tensor_dimension (in_res, 0, res_dim);
   EXPECT_FALSE (gst_tensor_dimension_is_equal (in_dim, res_dim));
 
-  /** set the same original input dimension */
+  /* set the same original input dimension */
   status = ml_single_set_input_info (single, in_info);
   EXPECT_TRUE (status == ML_ERROR_NOT_SUPPORTED || status == ML_ERROR_NONE);
   if (status == ML_ERROR_NONE) {
@@ -1691,7 +1690,7 @@ TEST (nnstreamer_capi_singleshot, set_input_info_extended_success)
   if (root_path == NULL)
     root_path = "..";
 
-  /** add_extended.tflite adds two input tensors and makes one output tensor */
+  /* add_extended.tflite adds two input tensors and makes one output tensor */
   test_model = g_build_filename (
       root_path, "tests", "test_models", "models", "add_extended.tflite", NULL);
   ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
@@ -2143,7 +2142,7 @@ TEST (nnstreamer_capi_singleshot, property_04_p)
   if (root_path == NULL)
     root_path = "..";
 
-  /** add.tflite adds value 2 to all the values in the input */
+  /* add.tflite adds value 2 to all the values in the input */
   test_model = g_build_filename (
       root_path, "tests", "test_models", "models", "add.tflite", NULL);
   ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
@@ -2239,7 +2238,7 @@ TEST (nnstreamer_capi_singleshot, property_05_p)
   if (root_path == NULL)
     root_path = "..";
 
-  /** add.tflite adds value 2 to all the values in the input */
+  /* add.tflite adds value 2 to all the values in the input */
   test_model = g_build_filename (
       root_path, "tests", "test_models", "models", "add.tflite", NULL);
   ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
@@ -2447,7 +2446,6 @@ TEST (nnstreamer_capi_singleshot, open_dir)
 
   g_free (test_model);
 }
-
 #endif /* ENABLE_NNFW_RUNTIME */
 
 #ifdef ENABLE_ARMNN
@@ -2514,7 +2512,7 @@ TEST (nnstreamer_capi_singleshot, invoke_06)
 
   ASSERT_TRUE (len == data_size / sizeof (float));
 
-  /** Convert uint8 data with range [0, 255] to float with range [-1, 1] */
+  /* Convert uint8 data with range [0, 255] to float with range [-1, 1] */
   contents_float = (gfloat *) g_malloc (data_size);
   for (unsigned int idx = 0; idx < len; idx++) {
     contents_float[idx] = static_cast<float> (contents_uint8[idx]);
@@ -2777,7 +2775,7 @@ TEST (nnstreamer_capi_singleshot, open_fail_03_n)
   ml_tensors_info_create (&in_info);
   ml_tensors_info_create (&out_info);
 
-  /** Set the correct input/output info */
+  /* Set the correct input/output info */
   in_dim[0] = 28;
   in_dim[1] = 28;
   in_dim[2] = 1;
@@ -2796,7 +2794,7 @@ TEST (nnstreamer_capi_singleshot, open_fail_03_n)
   ml_tensors_info_set_tensor_type (out_info, 0, ML_TENSOR_TYPE_FLOAT32);
   ml_tensors_info_set_tensor_dimension (out_info, 0, out_dim);
 
-  /** Modify the input or output name to be wrong and open */
+  /* Modify the input or output name to be wrong and open */
   ml_tensors_info_set_tensor_name (in_info, 0, "data1");
   status = ml_single_open (&single, test_model, in_info, out_info,
       ML_NNFW_TYPE_ARMNN, ML_NNFW_HW_ANY);
@@ -3147,14 +3145,14 @@ TEST (nnstreamer_capi_singleshot, invoke_11_p)
   status = ml_tensors_data_destroy (input);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  /** Access data before destroy works */
+  /* Access data before destroy works */
   status = ml_tensors_data_get_tensor_data (output, 0, &data_ptr, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_tensors_data_destroy (output);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  /** Close handle works normally */
+  /* Close handle works normally */
   status = ml_single_close (single);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
@@ -3241,7 +3239,7 @@ TEST (nnstreamer_capi_singleshot, invoke_12_p)
   status = ml_tensors_data_destroy (output1);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  /** Destroy the other data by closing the handle */
+  /* Destroy the other data by closing the handle */
   status = ml_single_close (single);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
@@ -3322,7 +3320,7 @@ TEST (nnstreamer_capi_singleshot, set_input_info_success_02)
   ml_tensors_data_destroy (output);
   ml_tensors_data_destroy (input);
 
-  /** modify input/output info and run again */
+  /* modify input/output info and run again */
   in_dim[0] = 10;
   ml_tensors_info_set_tensor_dimension (in_info, 0, in_dim);
   out_dim[0] = 10;
@@ -3337,14 +3335,13 @@ TEST (nnstreamer_capi_singleshot, set_input_info_success_02)
    * 3. run the model file with the updated input dimensions
    * 4. verify the output
    */
-
   ml_tensors_info_get_tensor_dimension (in_res, 0, res_dim);
   EXPECT_FALSE (in_dim[0] == res_dim[0]);
   EXPECT_TRUE (in_dim[1] == res_dim[1]);
   EXPECT_TRUE (in_dim[2] == res_dim[2]);
   EXPECT_TRUE (in_dim[3] == res_dim[3]);
 
-  /** set the same original input dimension */
+  /* set the same original input dimension */
   status = ml_single_set_input_info (single, in_info);
   EXPECT_TRUE (status == ML_ERROR_NOT_SUPPORTED || status == ML_ERROR_NONE);
   if (status == ML_ERROR_NONE) {

--- a/tests/capi/unittest_capi_remote_service.cc
+++ b/tests/capi/unittest_capi_remote_service.cc
@@ -207,19 +207,17 @@ TEST_F (MLRemoteService, registerPipeline)
   status = ml_option_create (&remote_service_option_h);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-
   gchar *service_type = g_strdup ("pipeline_raw");
   ml_option_set (remote_service_option_h, "service-type", service_type, g_free);
 
   gchar *service_key = g_strdup ("pipeline_test_key");
   ml_option_set (remote_service_option_h, "service-key", service_key, g_free);
 
-
   status = ml_service_remote_register (client_h, remote_service_option_h,
       pipeline_desc, strlen (pipeline_desc) + 1);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  /** Wait for the server to register and check the result. */
+  /* Wait for the server to register and check the result. */
   g_usleep (1000000);
 
   status = ml_service_destroy (server_h);
@@ -314,7 +312,6 @@ TEST_F (MLRemoteService, registerPipelineURI)
   g_autofree gchar *test_file_path
       = g_build_path ("/", current_dir, "test.pipeline", NULL);
 
-
   EXPECT_TRUE (g_file_set_contents (
       test_file_path, pipeline_desc, strlen (pipeline_desc) + 1, NULL));
 
@@ -324,7 +321,7 @@ TEST_F (MLRemoteService, registerPipelineURI)
       pipeline_uri, strlen (pipeline_uri) + 1);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  /** Wait for the server to register and check the result. */
+  /* Wait for the server to register and check the result. */
   g_usleep (1000000);
 
   status = ml_service_delete_pipeline (service_key);
@@ -429,7 +426,6 @@ TEST_F (MLRemoteService, registerInvalidParam_n)
   EXPECT_EQ (ML_ERROR_NONE, status);
 }
 
-
 /**
  * @brief use case of model registration using ml remote service.
  */
@@ -507,7 +503,7 @@ TEST_F (MLRemoteService, registerModel)
       server_option_h, _ml_service_event_cb, contents, &server_h);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  /** Set service option */
+  /* Set service option */
   ml_option_h remote_service_option_h = NULL;
   status = ml_option_create (&remote_service_option_h);
   EXPECT_EQ (ML_ERROR_NONE, status);
@@ -530,7 +526,7 @@ TEST_F (MLRemoteService, registerModel)
   status = ml_service_remote_register (client_h, remote_service_option_h, contents, len);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  /** Wait for the server to register and check the result. */
+  /* Wait for the server to register and check the result. */
   g_usleep (1000000);
 
   status = ml_service_model_delete (service_key, 0U);
@@ -625,7 +621,7 @@ TEST_F (MLRemoteService, registerModelURI)
       server_option_h, _ml_service_event_cb, contents, &server_h);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  /** Prepare model register service */
+  /* Prepare model register service */
   ml_option_h remote_service_option_h = NULL;
   status = ml_option_create (&remote_service_option_h);
   EXPECT_EQ (ML_ERROR_NONE, status);
@@ -651,7 +647,7 @@ TEST_F (MLRemoteService, registerModelURI)
       client_h, remote_service_option_h, model_uri, strlen (model_uri) + 1);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  /** Wait for the server to register and check the result. */
+  /* Wait for the server to register and check the result. */
   g_usleep (1000000);
 
   status = ml_service_model_delete (service_key, 0U);

--- a/tests/capi/unittest_capi_service_agent_client.cc
+++ b/tests/capi/unittest_capi_service_agent_client.cc
@@ -174,15 +174,15 @@ TEST_F (MLServiceAgentTest, usecase_00)
   EXPECT_EQ (ML_ERROR_NONE, status);
   EXPECT_EQ (ML_PIPELINE_STATE_PAUSED, state);
 
-  /** destroy the pipeline */
+  /* destroy the pipeline */
   status = ml_service_destroy (service);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  /** delete finished service */
+  /* delete finished service */
   status = ml_service_delete_pipeline (service_name);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  /** it would fail if get the removed service */
+  /* it would fail if get the removed service */
   status = ml_service_get_pipeline (service_name, &ret_pipeline);
   EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
 
@@ -267,15 +267,15 @@ TEST_F (MLServiceAgentTest, usecase_01)
   EXPECT_EQ (ML_ERROR_NONE, status);
   EXPECT_EQ (ML_PIPELINE_STATE_PAUSED, state);
 
-  /** destroy the pipeline */
+  /* destroy the pipeline */
   status = ml_service_destroy (service);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  /** delete finished service */
+  /* delete finished service */
   status = ml_service_delete_pipeline (service_name);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  /** it would fail if get the removed service */
+  /* it would fail if get the removed service */
   status = ml_service_get_pipeline (service_name, &ret_pipeline);
   EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
 
@@ -551,7 +551,7 @@ TEST_F (MLServiceAgentTest, query_client)
 {
   int status;
 
-  /** Set server pipeline and launch it */
+  /* Set server pipeline and launch it */
   const gchar *service_name = "simple_query_server_for_test";
   int num_buffers = 5;
   guint server_port = _get_available_port ();
@@ -666,11 +666,11 @@ TEST_F (MLServiceAgentTest, query_client)
     EXPECT_EQ (ML_ERROR_NONE, status);
   }
 
-  /** destroy client ml_service_h */
+  /* destroy client ml_service_h */
   status = ml_service_destroy (client);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  /** destroy server pipeline */
+  /* destroy server pipeline */
   status = ml_service_stop_pipeline (service);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
@@ -681,11 +681,11 @@ TEST_F (MLServiceAgentTest, query_client)
   status = ml_service_destroy (service);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  /** delete finished service */
+  /* delete finished service */
   status = ml_service_delete_pipeline (service_name);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
-  /** it would fail if get the removed service */
+  /* it would fail if get the removed service */
   status = ml_service_get_pipeline (service_name, &ret_pipeline);
   EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
 


### PR DESCRIPTION
1. Create tensors-info handle before calling sink callback.
2. We do not need to use ml-info in pipeline elem struct. Use gst-info instead.