### PR TITLE
[Test] restore test

### DIFF
--- a/tests/capi/unittest_capi_datatype_consistency.cc
+++ b/tests/capi/unittest_capi_datatype_consistency.cc
@@ -26,8 +26,8 @@
 TEST (nnstreamer_datatypes, test_all_1)
 {
   EXPECT_EQ ((int) NNS_TENSOR_RANK_LIMIT, (int) ML_TENSOR_RANK_LIMIT);
-  /** @todo restore this TC when NNS_TENSOR_SIZE_LIMIT is changed to 256 */
-  // EXPECT_EQ ((int) NNS_TENSOR_SIZE_LIMIT, (int) ML_TENSOR_SIZE_LIMIT);
+  EXPECT_EQ ((int) NNS_TENSOR_SIZE_LIMIT, (int) ML_TENSOR_SIZE_LIMIT);
+  EXPECT_EQ (sizeof (tensor_dim), sizeof (ml_tensor_dimension));
   EXPECT_EQ (sizeof (tensor_dim[0]), sizeof (ml_tensor_dimension[0]));
   EXPECT_EQ ((int) _NNS_INT32, (int) ML_TENSOR_TYPE_INT32);
   EXPECT_EQ ((int) _NNS_UINT32, (int) ML_TENSOR_TYPE_UINT32);
@@ -53,10 +53,7 @@ TEST (nnstreamer_datatypes, test_all_2_n)
   ret = ml_tensors_info_create (&info);
   EXPECT_EQ (ret, ML_ERROR_NONE);
 
-  /** @todo restore this line when NNS_TENSOR_SIZE_LIMIT is changed to 256 */
-  // ret = ml_tensors_info_set_count (info, NNS_TENSOR_SIZE_LIMIT + 1);
-  ret = ml_tensors_info_set_count (
-      info, NNS_TENSOR_SIZE_LIMIT + NNS_TENSOR_SIZE_EXTRA_LIMIT + 1);
+  ret = ml_tensors_info_set_count (info, NNS_TENSOR_SIZE_LIMIT + 1);
   EXPECT_EQ (ret, ML_ERROR_INVALID_PARAMETER);
 
   ret = ml_tensors_info_destroy (info);


### PR DESCRIPTION
Code clean, now max number of tensors in nnstreamer and api repo is same.
Restore old test to compare the max tensors.