### PR TITLE
Change gbs repo from latest to reference

### DIFF
--- a/.TAOS-CI/.gbs.conf
+++ b/.TAOS-CI/.gbs.conf
@@ -27,10 +27,10 @@ buildroot = ~/GBS-ROOT-Snapshot/
 url = https://api.tizen.org
 
 [repo.base]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Base/latest/repos/standard/packages/
+url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Base/reference/repos/standard/packages/
 
 [repo.unified]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Unified/latest/repos/standard/packages/
+url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Unified/reference/repos/standard/packages/
 
 [repo.extra]
 url = http://download.tizen.org/live/devel:/Tizen:/6.0:/AI/Tizen_Unified_standard/


### PR DESCRIPTION
Change gbs repo from latest to reference.
the default location of the ".gbs.conf" file has the highest priority.