### PR TITLE
[lts][gbs] Fix gbs repo url to Tizen-7.0

### DIFF
--- a/.TAOS-CI/.gbs.conf
+++ b/.TAOS-CI/.gbs.conf
@@ -27,10 +27,7 @@ buildroot = ~/GBS-ROOT-Snapshot/
 url = https://api.tizen.org
 
 [repo.base]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Base/latest/repos/standard/packages/
+url = https://download.tizen.org/snapshots/TIZEN/Tizen-7.0/Tizen-7.0-Base/reference/repos/standard/packages/
 
 [repo.unified]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Unified/latest/repos/standard/packages/
-
-[repo.extra]
-url = http://download.tizen.org/live/devel:/Tizen:/6.0:/AI/Tizen_Unified_standard/
+url = https://download.tizen.org/snapshots/TIZEN/Tizen-7.0/Tizen-7.0-Unified/reference/repos/standard/packages/


### PR DESCRIPTION
- Change url from Tizen -> Tizen-7.0 for TAOS-CI gbs build test.