### PR TITLE
[Dist/Tizen] Add omitted build dependency on libtzplatform-config

### DIFF
--- a/daemon/service-db.cc
+++ b/daemon/service-db.cc
@@ -167,7 +167,8 @@ MLServiceDB::connectDB ()
 
   rc = sqlite3_open (_path.c_str (), &_db);
   if (rc != SQLITE_OK) {
-    _E ("Failed to open database: %s (%d)", sqlite3_errmsg (_db), rc);
+    _E ("Failed to open database: %s (ret: %d, db_path_prefix: %s)",
+        sqlite3_errmsg (_db), rc, DB_PATH);
     goto error;
   }
 

--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -161,6 +161,7 @@ BuildRequires:  pkgconfig(json-glib-1.0)
 BuildRequires:  dbus
 BuildRequires:  pkgconfig(capi-appfw-package-manager)
 BuildRequires:	pkgconfig(capi-appfw-app-common)
+BuildRequires:	pkgconfig(libtzplatform-config)
 %endif
 
 %if 0%{?nnstreamer_edge_support}


### PR DESCRIPTION
This patch is a trivial bug fix that adds an omitted build dependency on libtzplatform-config to the Tizen RPM spec file.

CC: @jaeyun-jung 
Signed-off-by: Wook Song <wook16.song@samsung.com>