### PR TITLE
[Test/Service] add new test to get model from ml-agent

### DIFF
--- a/tests/test_models/config/config_pipeline_imgclf_key.conf
+++ b/tests/test_models/config/config_pipeline_imgclf_key.conf
@@ -1,0 +1,28 @@
+{
+    "pipeline" :
+    {
+        "key" : "test-pipeline-imgclf",
+        "input_node" : [
+          {
+            "name" : "input_img",
+            "info" : [
+              {
+                "type" : "uint8",
+                "dimension" : "3:224:224:1"
+              }
+            ]
+          }
+        ],
+        "output_node" : [
+          {
+            "name" : "result_clf",
+            "info" : [
+              {
+                "type" : "uint8",
+                "dimension" : "1001:1"
+              }
+            ]
+          }
+        ]
+    }
+}

--- a/tests/test_models/config/config_single_imgclf_key.conf
+++ b/tests/test_models/config/config_single_imgclf_key.conf
@@ -1,0 +1,11 @@
+{
+    "single" :
+    {
+        "key" : "test-single-imgclf"
+    },
+    "information" :
+    {
+        "threshold" : "0.5",
+        "description" : "Config file to run unittest for ml-extension."
+    }
+}


### PR DESCRIPTION
We can register new model (or pipeline) using ml-service API.
Add test for registered key from ml-agent.
