### PR TITLE
[Tizen] Update unittest build script

### DIFF
--- a/packaging/run-unittest.sh
+++ b/packaging/run-unittest.sh
@@ -7,8 +7,7 @@
 ##
 setup() {
     echo "setup start"
-    export MLAPI_SOURCE_ROOT_PATH=/usr/bin/unittest-ml
-    pushd /usr/bin/unittest-ml
+    pushd /usr/bin/unittest-ml/tests
 }
 
 test_main() {


### PR DESCRIPTION
Fix tizen auto coverage measurement failure.
Use default root path instead of environment variable. The model path of the config file is hard coded, so the wrong model path is passed to ml-service.

config_single_add.conf
```
{
    "single" :
    {
        "framework" : "tensorflow-lite",
        "model" : ["../tests/test_models/models/add.tflite"]
    }
}

```