### PR TITLE
Tests/CAPI: Add more negative test cases

### DIFF
--- a/tests/capi/unittest_capi_inference.cc
+++ b/tests/capi/unittest_capi_inference.cc
@@ -2163,6 +2163,11 @@ TEST (nnstreamer_capi_util, availability_fail_01_n)
       ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_NPU_SR, &result);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (result, false);
+
+  status = ml_check_nnfw_availability (
+      ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_NPU_SLSI, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, false);
 }
 
 #ifdef ENABLE_TENSORFLOW

--- a/tests/capi/unittest_capi_inference_single.cc
+++ b/tests/capi/unittest_capi_inference_single.cc
@@ -4480,7 +4480,27 @@ TEST (nnstreamer_capi_internal, validate_model_file_01_n)
   status = _ml_validate_model_file (&test_model, 0, &nnfw);
   EXPECT_NE (status, ML_ERROR_NONE);
 
-  status = _ml_validate_model_file (&test_model, 1, NULL);
+  status = _ml_validate_model_file (&test_model, 1, &nnfw);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  nnfw = ML_NNFW_TYPE_MVNC;
+  status = _ml_validate_model_file (&test_model, 1, &nnfw);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  nnfw = ML_NNFW_TYPE_VD_AIFW;
+  status = _ml_validate_model_file (&test_model, 1, &nnfw);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  nnfw = ML_NNFW_TYPE_SNAP;
+  status = _ml_validate_model_file (&test_model, 1, &nnfw);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  nnfw = ML_NNFW_TYPE_ARMNN;
+  status = _ml_validate_model_file (&test_model, 1, &nnfw);
+  EXPECT_NE (status, ML_ERROR_NONE);
+
+  nnfw = ML_NNFW_TYPE_MXNET;
+  status = _ml_validate_model_file (&test_model, 1, &nnfw);
   EXPECT_NE (status, ML_ERROR_NONE);
 
 skip_test:


### PR DESCRIPTION
This is a trivial patch that adds more negative test cases for the inference C-APIs.

Signed-off-by: Wook Song <wook16.song@samsung.com>
