### PR TITLE
[android] do not remove android-resource dir

### DIFF
--- a/java/build-nnstreamer-android.sh
+++ b/java/build-nnstreamer-android.sh
@@ -710,7 +710,6 @@ fi
 
 # Remove build directory
 rm -rf $build_dir
-rm -rf $nnstreamer_android_resource_dir
 
 popd
 cd ${nnstreamer_dir} && find -name nnstreamer_version.h -delete


### PR DESCRIPTION
nnstreamer-android-resource directory is changed not to download using scripts.
So it shouldn't be removed.