### PR TITLE
[android] Set libOpenCL.so dependency in AndroidManiest.xml

### DIFF
--- a/java/android/nnstreamer/src/main/AndroidManifest.xml
+++ b/java/android/nnstreamer/src/main/AndroidManifest.xml
@@ -5,5 +5,6 @@
     <application
         android:extractNativeLibs="true"
         android:largeHeap="true" >
+        <uses-libaray android:name="libOpenCL.so" android:required="false" />
     </application>
 </manifest>


### PR DESCRIPTION
- Recent android requires specifying certain shared libraries.
- libOpenCL.so is needed to check functionality of GPU delegates.

REF: https://github.com/tensorflow/tensorflow/issues/48001#issuecomment-1386958937