### PR TITLE
[action] use action/setup-java instead of export JAVA_HOME

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,6 +18,11 @@ jobs:
       with:
         ndk-version: r25c
         link-to-sdk: true
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: 17
     - name: Get gstreamer-android
       run: |
         mkdir -p ~/android/gst_root_android/
@@ -52,7 +57,6 @@ jobs:
         export NNSTREAMER_EDGE_ROOT=${{ github.workspace }}/nnstreamer-edge
         export NNSTREAMER_ANDROID_RESOURCE=${{ github.workspace }}/nnstreamer-android-resource
         export ML_API_ROOT=${{ github.workspace }}/api
-        export JAVA_HOME=/usr/lib/jvm/temurin-17-jdk-amd64
         if [ ${{ matrix.abi }} == 'arm64-v8a' ]; then
           bash ${{ github.workspace }}/api/java/build-nnstreamer-android.sh --target_abi=${{ matrix.abi }}
         elif [ ${{ matrix.abi }} == 'armeabi-v7a' ]; then


### PR DESCRIPTION
This patch changes the way to set java version in github action.