### PR TITLE
[android] fix typo in AndroidManifest

### DIFF
--- a/java/android/nnstreamer/src/main/AndroidManifest.xml
+++ b/java/android/nnstreamer/src/main/AndroidManifest.xml
@@ -5,6 +5,6 @@
     <application
         android:extractNativeLibs="true"
         android:largeHeap="true" >
-        <uses-libaray android:name="libOpenCL.so" android:required="false" />
+        <uses-library android:name="libOpenCL.so" android:required="false" />
     </application>
 </manifest>


### PR DESCRIPTION
This patch fixes typo in AndroidManifest.
uses-libaray -> uses-library