### PR TITLE
[android] fix build-android scripts

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -60,6 +60,12 @@ jobs:
         else
           bash ${{ github.workspace }}/api/java/build-nnstreamer-android.sh --target_abi=${{ matrix.abi }} --enable_nnfw=no --enable_tflite=no
         fi
+
+        result=$?
+        if [[ ${result} -ne 0 ]]; then
+          echo "NDK build failed"
+          exit 1
+        fi
     - name: Upload android library
       uses: actions/upload-artifact@v4
       with:

--- a/java/build-nnstreamer-android.sh
+++ b/java/build-nnstreamer-android.sh
@@ -616,14 +616,12 @@ echo "Starting gradle build for Android library."
 # Build Android library.
 chmod +x gradlew
 sh ./gradlew nnstreamer:build
-
+android_lib_build_res=$?
 # Check if build procedure is done.
 nnstreamer_android_api_lib=./nnstreamer/build/outputs/aar/nnstreamer-release.aar
 
-android_lib_build_res=1
-if [[ -e "$nnstreamer_android_api_lib" ]]; then
+if [[ $android_lib_build_res -eq 0 ]]; then
     today=$(date "+%Y-%m-%d")
-    android_lib_build_res=0
 
     # Prepare native libraries and header files for C-API
     unzip $nnstreamer_android_api_lib -d aar_extracted


### PR DESCRIPTION
This patch fixes build-nnstreamer-android scripts.
nnstreamer-release.aar file created even if ./gradlew build failed after some tasks.
So check exit code instead of aar file existance.

https://github.com/niley7464/api/actions/runs/8750553882
Tested with #502 (PR that should have failed Android Build Test action)