### PR TITLE
[ml-service] Get string member from json object

### DIFF
--- a/c/src/ml-api-service-agent-client.c
+++ b/c/src/ml-api-service-agent-client.c
@@ -62,10 +62,11 @@ _parse_app_info_and_update_path (ml_information_h ml_info)
         "Failed to get json object from the app_info. Skip it.");
   }
 
-  if (g_strcmp0 (json_object_get_string_member (jobj, "is_rpk"), "T") == 0) {
+  if (g_strcmp0 (_ml_service_get_json_string_member (jobj, "is_rpk"), "T") == 0) {
     gchar *ori_path, *new_path;
     g_autofree gchar *global_resource_path;
-    const gchar *res_type = json_object_get_string_member (jobj, "res_type");
+    const gchar *res_type =
+        _ml_service_get_json_string_member (jobj, "res_type");
 
     ret = ml_information_get (ml_info, "path", (void **) &ori_path);
     if (ret != ML_ERROR_NONE) {
@@ -226,7 +227,7 @@ _build_ml_info_from_json_cstr (const gchar * jcstring, void **handle)
     members = json_object_get_members (jobj);
     for (l = members; l != NULL; l = l->next) {
       const gchar *key = l->data;
-      const gchar *val = json_object_get_string_member (jobj, key);
+      const gchar *val = _ml_service_get_json_string_member (jobj, key);
 
       /* Prevent empty string case. */
       if (STR_IS_VALID (key) && STR_IS_VALID (val)) {

--- a/c/src/ml-api-service-extension.c
+++ b/c/src/ml-api-service-extension.c
@@ -458,8 +458,7 @@ _ml_extension_conf_parse_pipeline_node (ml_service_s * mls, JsonNode * node,
     else
       object = json_node_get_object (node);
 
-    if (json_object_has_member (object, "name"))
-      name = json_object_get_string_member (object, "name");
+    name = _ml_service_get_json_string_member (object, "name");
 
     node_info = _ml_extension_node_info_new (mls, name, type);
     if (!node_info) {

--- a/c/src/ml-api-service-offloading.c
+++ b/c/src/ml-api-service-offloading.c
@@ -854,7 +854,7 @@ _ml_service_offloading_convert_to_option (JsonObject * object,
       continue;
     }
 
-    val = json_object_get_string_member (object, key);
+    val = _ml_service_get_json_string_member (object, key);
 
     status = ml_option_set (tmp, key, g_strdup (val), g_free);
     if (status != ML_ERROR_NONE) {
@@ -1040,13 +1040,14 @@ ml_service_offloading_request (ml_service_h handle, const char *key,
         "Failed to get the json object from the json node.");
   }
 
-  service_str = json_object_get_string_member (service_obj, "service-type");
+  service_str =
+      _ml_service_get_json_string_member (service_obj, "service-type");
   if (!service_str) {
     _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
         "Failed to get service type from the json object.");
   }
 
-  service_key = json_object_get_string_member (service_obj, "service-key");
+  service_key = _ml_service_get_json_string_member (service_obj, "service-key");
   if (!service_key) {
     _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
         "Failed to get service key from the json object.");
@@ -1069,7 +1070,7 @@ ml_service_offloading_request (ml_service_h handle, const char *key,
     goto done;
   }
 
-  description = json_object_get_string_member (service_obj, "description");
+  description = _ml_service_get_json_string_member (service_obj, "description");
   if (description) {
     ret = nns_edge_data_set_info (data_h, "description", description);
     if (NNS_EDGE_ERROR_NONE != ret) {
@@ -1077,7 +1078,7 @@ ml_service_offloading_request (ml_service_h handle, const char *key,
     }
   }
 
-  name = json_object_get_string_member (service_obj, "name");
+  name = _ml_service_get_json_string_member (service_obj, "name");
   if (name) {
     ret = nns_edge_data_set_info (data_h, "name", name);
     if (NNS_EDGE_ERROR_NONE != ret) {
@@ -1085,7 +1086,7 @@ ml_service_offloading_request (ml_service_h handle, const char *key,
     }
   }
 
-  activate = json_object_get_string_member (service_obj, "activate");
+  activate = _ml_service_get_json_string_member (service_obj, "activate");
   if (activate) {
     ret = nns_edge_data_set_info (data_h, "activate", activate);
     if (NNS_EDGE_ERROR_NONE != ret) {

--- a/c/src/ml-api-service-private.h
+++ b/c/src/ml-api-service-private.h
@@ -119,6 +119,11 @@ int ml_service_pipeline_release_internal (ml_service_s *mls);
  */
 int ml_service_query_release_internal (ml_service_s *mls);
 
+/**
+ * @brief Internal function to get json string member.
+ */
+const gchar * _ml_service_get_json_string_member (JsonObject* object, const gchar* member_name);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/c/src/ml-api-service-training-offloading.c
+++ b/c/src/ml-api-service-training-offloading.c
@@ -249,7 +249,7 @@ _training_offloading_conf_parse_json (ml_service_s * mls, JsonObject * object)
   ret = _training_offloading_get_priv (mls, &training_s);
   g_return_val_if_fail (ret == ML_ERROR_NONE, ret);
 
-  val = json_object_get_string_member (object, "node-type");
+  val = _ml_service_get_json_string_member (object, "node-type");
 
   if (g_ascii_strcasecmp (val, "sender") == 0) {
     training_s->type = ML_TRAINING_OFFLOADING_TYPE_SENDER;
@@ -271,7 +271,7 @@ _training_offloading_conf_parse_json (ml_service_s * mls, JsonObject * object)
         ("The default time-limit(10 sec) is set because `time-limit` is not set.");
   }
 
-  val = json_object_get_string_member (training_obj, "sender-pipeline");
+  val = _ml_service_get_json_string_member (training_obj, "sender-pipeline");
   training_s->sender_pipe = g_strdup (val);
 
   if (!json_object_has_member (training_obj, "transfer-data")) {
@@ -295,7 +295,7 @@ _training_offloading_conf_parse_json (ml_service_s * mls, JsonObject * object)
           "The parameter, 'key' is invalid. It should be a valid string.");
     }
 
-    val = json_object_get_string_member (data_obj, key);
+    val = _ml_service_get_json_string_member (data_obj, key);
 
     if (STR_IS_VALID (val)) {
       transfer_data = g_strdup (val);
@@ -839,7 +839,7 @@ ml_service_training_offloading_start (ml_service_s * mls)
 
     if (json_object_has_member (pipe, "description")) {
       training_s->receiver_pipe =
-          g_strdup (json_object_get_string_member (pipe, "description"));
+          g_strdup (_ml_service_get_json_string_member (pipe, "description"));
     } else {
       _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
           "Failed to parse configuration file, cannot get the pipeline description.");

--- a/c/src/ml-api-service.c
+++ b/c/src/ml-api-service.c
@@ -389,7 +389,7 @@ ml_service_new (const char *config, ml_service_h * handle)
 
     for (iter = members; iter; iter = g_list_next (iter)) {
       const gchar *name = iter->data;
-      const gchar *value = json_object_get_string_member (info, name);
+      const gchar *value = _ml_service_get_json_string_member (info, name);
 
       status = _ml_service_set_information_internal (mls, name, value);
       if (status != ML_ERROR_NONE)
@@ -741,4 +741,30 @@ ml_service_destroy (ml_service_h handle)
   }
 
   return _ml_service_destroy_internal (mls);
+}
+
+/**
+ * @brief Internal function to get json string member.
+ */
+const gchar *
+_ml_service_get_json_string_member (JsonObject * object,
+    const gchar * member_name)
+{
+  const gchar *ret = NULL;
+
+  if (!object) {
+    _ml_error_report_return (ret,
+        "The parameter, object (JsonObject *), is NULL. It should be a valid JsonObject instance.");
+  }
+
+  if (!member_name) {
+    _ml_error_report_return (ret,
+        "The parameter, member_name (const gchar *), is NULL.");
+  }
+
+  if (json_object_has_member (object, member_name)) {
+    ret = json_object_get_string_member (object, member_name);
+  }
+
+  return ret;
 }


### PR DESCRIPTION
Changed to check the existence of the jsom member before getting the value.
This change reduces unnecessary error messages that occur when setting optional ml information.