### PR TITLE
[Spec] Disable some features for movable project

### DIFF
--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -54,6 +54,8 @@
 # Disable a few features for movable device
 %if 0%{?mv_prj}
 %define		nntrainer_support 0
+%define		nnfw_support 0
+%define		onnxruntime_support 0
 %endif
 
 # If it is tizen, we can export Tizen API packages.


### PR DESCRIPTION
This patch disables the nnfw and onnxruntime features for the movable project.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped
