### PR TITLE
JNI/Android: Update ndk build scripts to support TFLite x64

### DIFF
--- a/java/android/nnstreamer/src/main/jni/Android-tensorflow-lite.mk
+++ b/java/android/nnstreamer/src/main/jni/Android-tensorflow-lite.mk
@@ -83,6 +83,8 @@ ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
 TF_LITE_LIB_PATH := $(TF_LITE_DIR)/lib/armv7
 else ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
 TF_LITE_LIB_PATH := $(TF_LITE_DIR)/lib/arm64
+else ifeq ($(TARGET_ARCH_ABI),x86_64)
+TF_LITE_LIB_PATH := $(TF_LITE_DIR)/lib/x86_64
 else
 $(error Target arch ABI not supported: $(TARGET_ARCH_ABI))
 endif

--- a/java/android/nnstreamer/src/main/jni/Android.mk
+++ b/java/android/nnstreamer/src/main/jni/Android.mk
@@ -42,7 +42,7 @@ ENABLE_TENSOR_QUERY := true
 
 # tensorflow-lite (nnstreamer tf-lite subplugin)
 ifdef TFLITE_ROOT_ANDROID
-ifneq ($(filter $(TARGET_ARCH_ABI), armeabi-v7a arm64-v8a),)
+ifneq ($(filter $(TARGET_ARCH_ABI), armeabi-v7a arm64-v8a x86_64),)
 TFLITE_ROOT        := $(TFLITE_ROOT_ANDROID)
 endif
 endif


### PR DESCRIPTION
This patch updates the ndk build scripts related to TensorFlow Lite to support x86_64 architecture.

Signed-off-by: Wook Song <wook16.song@samsung.com>

