### PR TITLE
[service] Fix error value and log in ml_service_new

### DIFF
--- a/c/src/ml-api-service.c
+++ b/c/src/ml-api-service.c
@@ -339,8 +339,8 @@ ml_service_new (const char *config, ml_service_h * handle)
   }
 
   if (!json_parser_load_from_data (parser, json_string, -1, &err)) {
-    _ml_error_report_return (ML_ERROR_IO_ERROR,
-        "Failed to parse configuration file, cannot load json string (%s).",
+    _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
+        "Failed to parse configuration file. Parse error: %s",
         err ? err->message : "Unknown error");
   }
 


### PR DESCRIPTION
- Clearly state that the json parse error with INVALID_PARAM value