### PR TITLE
[android] Let test related files be copied to app's internal directory from assets.

### DIFF
--- a/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestPipeline.java
+++ b/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestPipeline.java
@@ -54,9 +54,6 @@ public class APITestPipeline {
         }
     };
 
-    @Rule
-    public GrantPermissionRule mPermissionRule = APITestCommon.grantPermissions();
-
     @Before
     public void setUp() {
         APITestCommon.initNNStreamer();

--- a/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestSingleShot.java
+++ b/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestSingleShot.java
@@ -19,9 +19,6 @@ import static org.junit.Assert.*;
  */
 @RunWith(AndroidJUnit4.class)
 public class APITestSingleShot {
-    @Rule
-    public GrantPermissionRule mPermissionRule = APITestCommon.grantPermissions();
-
     @Before
     public void setUp() {
         APITestCommon.initNNStreamer();

--- a/java/android/nnstreamer/src/main/assets/README.txt
+++ b/java/android/nnstreamer/src/main/assets/README.txt
@@ -1,0 +1,27 @@
+If you want to do unit tests, put the following files in this directory.
+
+$ tree .
+.
+└── nnstreamer
+    ├── pytorch_data
+    │   ├── mobilenetv2-quant_core-nnapi.pt
+    │   └── orange_float.raw
+    ├── snpe_data
+    │   ├── inception_v3_quantized.dlc
+    │   ├── orange_299x299_uint8.raw
+    │   └── plastic_cup.raw
+    └── test
+        ├── add
+        │   ├── add.tflite
+        │   └── metadata
+        │       └── MANIFEST
+        ├── imgclf
+        │   ├── labels.txt
+        │   ├── metadata
+        │   │   └── MANIFEST
+        │   ├── mobilenet_quant_v1_224.tflite
+        │   ├── mobilenet_v1_1.0_224_quant.tflite
+        │   ├── mobilenet_v1_1.0_224.tflite
+        │   ├── orange.png
+        │   └── orange.raw
+        └── orange.raw


### PR DESCRIPTION
- Recent Android do not allow to use `getExternalStorageDirectory`.
- Let's copy test related files to app's internal directory from assets. Required files are listed in the README.txt file