### PR TITLE
[Android] Support SNPE SDK v2

### DIFF
--- a/java/android/nnstreamer/build.gradle
+++ b/java/android/nnstreamer/build.gradle
@@ -113,8 +113,11 @@ android {
         }
     }
     packagingOptions {
-        // To do not show build warning messages
-        doNotStrip "*/arm64-v8a/*_skel.so"
+        jniLibs {
+            useLegacyPackaging = true
+            keepDebugSymbols += "**/*Skel.so"
+            keepDebugSymbols += "**/*skel.so"
+        }
     }
 }
 

--- a/java/android/nnstreamer/src/main/AndroidManifest.xml
+++ b/java/android/nnstreamer/src/main/AndroidManifest.xml
@@ -5,5 +5,6 @@
     <application
         android:largeHeap="true" >
         <uses-library android:name="libOpenCL.so" android:required="false" />
+        <uses-library android:name="libcdsprpc.so" android:required="false" />
     </application>
 </manifest>

--- a/java/android/nnstreamer/src/main/AndroidManifest.xml
+++ b/java/android/nnstreamer/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
     <uses-feature android:glEsVersion="0x00020000"/>
 
     <application
-        android:extractNativeLibs="true"
         android:largeHeap="true" >
         <uses-library android:name="libOpenCL.so" android:required="false" />
     </application>

--- a/java/android/nnstreamer/src/main/jni/Android-snpe.mk
+++ b/java/android/nnstreamer/src/main/jni/Android-snpe.mk
@@ -18,12 +18,24 @@ endif
 include $(NNSTREAMER_ROOT)/jni/nnstreamer.mk
 
 SNPE_DIR := $(LOCAL_PATH)/snpe
-SNPE_INCLUDES := $(SNPE_DIR)/include/zdl/
 
 ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
 SNPE_LIB_PATH := $(SNPE_DIR)/lib
 else
 $(error Target arch ABI not supported: $(TARGET_ARCH_ABI))
+endif
+
+SNPE_INCLUDES :=
+SNPE_FLAGS :=
+# Check the version of SNPE SDK (v1 or v2)
+ifeq ($(shell test -d $(SNPE_DIR)/include/zdl; echo $$?),0)
+SNPE_FLAGS += -DSNPE_VERSION_MAJOR=1
+SNPE_INCLUDES += $(SNPE_DIR)/include/zdl
+else ifeq ($(shell test -d $(SNPE_DIR)/include/SNPE; echo $$?),0)
+SNPE_FLAGS += -DSNPE_VERSION_MAJOR=2
+SNPE_INCLUDES += $(SNPE_DIR)/include/SNPE
+else
+$(error SNPE SDK not found: $(SNPE_DIR))
 endif
 
 #------------------------------------------------------
@@ -38,7 +50,7 @@ include $(CLEAR_VARS)
 
 LOCAL_MODULE := snpe-subplugin
 LOCAL_SRC_FILES := $(NNSTREAMER_FILTER_SNPE_SRCS)
-LOCAL_CXXFLAGS := -O3 -fPIC -frtti -fexceptions $(NNS_API_FLAGS)
+LOCAL_CXXFLAGS := -O3 -fPIC -frtti -fexceptions $(NNS_API_FLAGS) $(SNPE_FLAGS)
 LOCAL_C_INCLUDES := $(SNPE_INCLUDES) $(NNSTREAMER_INCLUDES) $(GST_HEADERS_COMMON)
 LOCAL_STATIC_LIBRARIES := nnstreamer
 LOCAL_SHARED_LIBRARIES := $(SNPE_PREBUILT_LIBS)

--- a/java/build-nnstreamer-android.sh
+++ b/java/build-nnstreamer-android.sh
@@ -554,12 +554,14 @@ if [[ $enable_snpe == "yes" ]]; then
 
     mkdir -p nnstreamer/src/main/jni/snpe/lib/ext/arm64-v8a
     cp -r $SNPE_DIRECTORY/include nnstreamer/src/main/jni/snpe
-    cp $SNPE_DIRECTORY/lib/aarch64-android-clang6.0/libSNPE.so nnstreamer/src/main/jni/snpe/lib
 
     # Copy external so files for SNPE
-    cp $SNPE_DIRECTORY/lib/aarch64-android-clang6.0/lib*dsp*.so nnstreamer/src/main/jni/snpe/lib/ext/arm64-v8a
-    cp $SNPE_DIRECTORY/lib/aarch64-android-clang6.0/libhta.so nnstreamer/src/main/jni/snpe/lib/ext/arm64-v8a
-    cp $SNPE_DIRECTORY/lib/dsp/libsnpe*.so nnstreamer/src/main/jni/snpe/lib/ext/arm64-v8a
+    cp $SNPE_DIRECTORY/lib/aarch64-android*/*.so nnstreamer/src/main/jni/snpe/lib/ext/arm64-v8a
+    cp $SNPE_DIRECTORY/lib/dsp/*.so nnstreamer/src/main/jni/snpe/lib/ext/arm64-v8a
+    cp $SNPE_DIRECTORY/lib/hexagon-v*/unsigned/*.* nnstreamer/src/main/jni/snpe/lib/ext/arm64-v8a
+
+    rm nnstreamer/src/main/jni/snpe/lib/ext/arm64-v8a/libc++_shared.so
+    mv nnstreamer/src/main/jni/snpe/lib/ext/arm64-v8a/libSNPE.so nnstreamer/src/main/jni/snpe/lib
 fi
 
 # Update PyTorch option


### PR DESCRIPTION
Add SNPE SDK v2 support:
- Let `build-nnstreamer-android.sh` copy proper files from SNPE SDK
- Let ndk build with tensor_filter_snpe.cc or ..._v1.cc with proper headers and flags
- Link `libcdsprpc.so`
REF: https://source.android.com/docs/core/permissions/namespaces_libraries#specify-native-library-dependencies

Proper android app settings:
- Recent AGP requires `useLegacyPackaging = true` in build.gradle
REF: https://developer.android.com/build/releases/past-releases/agp-4-2-0-release-notes#compress-native-libs-dsl