### PR TITLE
[Android] Use c++17 for ndk-build

### DIFF
--- a/java/android/nnstreamer/src/main/jni/Application.mk
+++ b/java/android/nnstreamer/src/main/jni/Application.mk
@@ -1,3 +1,4 @@
 # Set target ABI in build.gradle (externalNativeBuild - abiFilters)
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
+APP_CPPFLAGS := -std=c++17
 APP_STL := c++_shared


### PR DESCRIPTION
This patch changes the c++ version to 17 in the jni files. meson.build also uses cpp_std=c++17.
https://github.com/nnstreamer/nnstreamer/issues/4493