### PR TITLE
[single] Add ML_NNFW_TYPE enum for QNN

### DIFF
--- a/c/include/ml-api-common.h
+++ b/c/include/ml-api-common.h
@@ -74,6 +74,7 @@ typedef enum {
   ML_NNFW_TYPE_ONNX_RUNTIME = 17,     /**< Open Neural Network Exchange (ONNX) Runtime (Since 9.0) */
   ML_NNFW_TYPE_NCNN = 18,             /**< Tencent ncnn (Since 9.0) */
   ML_NNFW_TYPE_TENSORRT = 19,         /**< NVidia Tensor-RT (Since 9.0) */
+  ML_NNFW_TYPE_QNN = 20,              /**< Qualcomm QNN (Qualcomm® AI Engine Direct) (Since 9.0) */
   ML_NNFW_TYPE_SNAP = 0x2001,         /**< SNAP (Samsung Neural Acceleration Platform), only for Android. (Since 6.0) */
 } ml_nnfw_type_e;
 

--- a/c/src/ml-api-inference-single.c
+++ b/c/src/ml-api-inference-single.c
@@ -111,6 +111,7 @@ static const char *ml_nnfw_subplugin_name[] = {
   [ML_NNFW_TYPE_ONNX_RUNTIME] = "onnxruntime",
   [ML_NNFW_TYPE_NCNN] = "ncnn",
   [ML_NNFW_TYPE_TENSORRT] = "tensorrt",
+  [ML_NNFW_TYPE_QNN] = "qnn",
   NULL
 };
 
@@ -1956,6 +1957,7 @@ _ml_validate_model_file (const char *const *model,
     case ML_NNFW_TYPE_ONNX_RUNTIME:
     case ML_NNFW_TYPE_NCNN:
     case ML_NNFW_TYPE_TENSORRT:
+    case ML_NNFW_TYPE_QNN:
       /**
        * We cannot check the file ext with NNFW.
        * NNFW itself will validate metadata and model file.


### PR DESCRIPTION
- Add enum for Qualcomm QNN (Qualcomm® AI Engine Direct)
- Its being prepared in Tizen and nnstreamer.