### PR TITLE
[android] Build qnn subplugin

### DIFF
--- a/java/android/nnstreamer/build.gradle
+++ b/java/android/nnstreamer/build.gradle
@@ -107,6 +107,11 @@ android {
                 println 'Set jniLibs.srcDirs includes libraries for SNPE'
             }
 
+            if (project.hasProperty('QNN_EXT_LIBRARY_PATH')) {
+                jniLibs.srcDirs += project.properties['QNN_EXT_LIBRARY_PATH']
+                println 'Set jniLibs.srcDirs includes libraries for QNN'
+            }
+
             if (project.hasProperty('NNFW_EXT_LIBRARY_PATH')) {
                 jniLibs.srcDirs += project.properties['NNFW_EXT_LIBRARY_PATH']
                 println 'Set jniLibs.srcDirs includes libraries for NNFW'

--- a/java/android/nnstreamer/src/main/java/org/nnsuite/nnstreamer/NNStreamer.java
+++ b/java/android/nnstreamer/src/main/java/org/nnsuite/nnstreamer/NNStreamer.java
@@ -86,6 +86,11 @@ public final class NNStreamer {
          */
         MXNET,
         /**
+         * <a href="https://www.qualcomm.com/developer/software/qualcomm-ai-engine-direct-sdk">QNN</a>
+         * provides lower-level, unified APIs for Qualcomm AI development.
+         */
+        QNN,
+        /**
          * Unknown framework (usually error)
          */
         UNKNOWN

--- a/java/android/nnstreamer/src/main/jni/Android-qnn.mk
+++ b/java/android/nnstreamer/src/main/jni/Android-qnn.mk
@@ -1,0 +1,63 @@
+#------------------------------------------------------
+# QNN
+#------------------------------------------------------
+LOCAL_PATH := $(call my-dir)
+
+ifndef NNSTREAMER_ROOT
+$(error NNSTREAMER_ROOT is not defined!)
+endif
+
+include $(NNSTREAMER_ROOT)/jni/nnstreamer.mk
+
+QNN_DIR := $(LOCAL_PATH)/qnn
+
+ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
+QNN_LIB_PATH := $(QNN_DIR)/lib
+else
+$(error Target arch ABI not supported: $(TARGET_ARCH_ABI))
+endif
+
+QNN_INCLUDES := $(QNN_DIR)/include/QNN
+
+#------------------------------------------------------
+# qnn-sdk (prebuilt shared library)
+#------------------------------------------------------
+QNN_PREBUILT_LIBS :=
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libQnnCpu
+LOCAL_SRC_FILES := $(QNN_LIB_PATH)/libQnnCpu.so
+include $(PREBUILT_SHARED_LIBRARY)
+QNN_PREBUILT_LIBS += libQnnCpu
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libQnnGpu
+LOCAL_SRC_FILES := $(QNN_LIB_PATH)/libQnnGpu.so
+include $(PREBUILT_SHARED_LIBRARY)
+QNN_PREBUILT_LIBS += libQnnGpu
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libQnnDsp
+LOCAL_SRC_FILES := $(QNN_LIB_PATH)/libQnnDsp.so
+include $(PREBUILT_SHARED_LIBRARY)
+QNN_PREBUILT_LIBS += libQnnDsp
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libQnnHtp
+LOCAL_SRC_FILES := $(QNN_LIB_PATH)/libQnnHtp.so
+include $(PREBUILT_SHARED_LIBRARY)
+QNN_PREBUILT_LIBS += libQnnHtp
+
+#------------------------------------------------------
+# tensor-filter sub-plugin for qnn
+#------------------------------------------------------
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := qnn-subplugin
+LOCAL_SRC_FILES := $(NNSTREAMER_FILTER_QNN_SRCS)
+LOCAL_CXXFLAGS := -O3 -fPIC -frtti -fexceptions $(NNS_API_FLAGS)
+LOCAL_C_INCLUDES := $(QNN_INCLUDES) $(NNSTREAMER_INCLUDES) $(GST_HEADERS_COMMON)
+LOCAL_STATIC_LIBRARIES := nnstreamer
+LOCAL_SHARED_LIBRARIES := $(QNN_PREBUILT_LIBS)
+
+include $(BUILD_STATIC_LIBRARY)

--- a/java/android/nnstreamer/src/main/jni/Android.mk
+++ b/java/android/nnstreamer/src/main/jni/Android.mk
@@ -76,6 +76,9 @@ _ENABLE_SNPE := false
 endif #endif ($(filter $(TARGET_ARCH_ABI), arm64-v8a,)
 endif #endif ($(ENABLE_SNPE),true)
 
+# QNN
+ENABLE_QNN := false
+
 # PyTorch
 ENABLE_PYTORCH := false
 
@@ -135,6 +138,13 @@ NNS_API_FLAGS += -DENABLE_SNPE=1
 NNS_SUBPLUGINS += snpe-subplugin
 
 include $(LOCAL_PATH)/Android-snpe.mk
+endif
+
+ifeq ($(ENABLE_QNN),true)
+NNS_API_FLAGS += -DENABLE_QNN=1
+NNS_SUBPLUGINS += qnn-subplugin
+
+include $(LOCAL_PATH)/Android-qnn.mk
 endif
 
 ifeq ($(ENABLE_PYTORCH),true)

--- a/java/android/nnstreamer/src/main/jni/nnstreamer-native-api.c
+++ b/java/android/nnstreamer/src/main/jni/nnstreamer-native-api.c
@@ -155,6 +155,9 @@ extern void init_filter_nnfw (void);
 #if defined (ENABLE_SNPE)
 extern void init_filter_snpe (void);
 #endif
+#if defined (ENABLE_QNN)
+extern void init_filter_qnn (void);
+#endif
 #if defined (ENABLE_PYTORCH)
 extern void init_filter_torch (void);
 #endif
@@ -844,6 +847,9 @@ nns_get_nnfw_type (jint fw_type, ml_nnfw_type_e * nnfw)
     case 5: /* NNFWType.MXNET */
       *nnfw = ML_NNFW_TYPE_MXNET;
       break;
+    case 6: /* NNFWType.QNN */
+      *nnfw = ML_NNFW_TYPE_QNN;
+      break;
     default: /* Unknown */
       _ml_logw ("Unknown NNFW type (%d).", fw_type);
       return FALSE;
@@ -918,7 +924,7 @@ nnstreamer_native_initialize (JNIEnv * env, jobject context)
 #endif /* ENABLE_FLATBUF */
 #endif
 
-#if defined (ENABLE_SNPE) || defined (ENABLE_TFLITE_QNN_DELEGATE)
+#if defined (ENABLE_QNN) || defined (ENABLE_SNPE) || defined (ENABLE_TFLITE_QNN_DELEGATE)
     /* some filters require additional tasks */
     if (!_qc_android_set_env (env, context)) {
       _ml_logw ("Failed to set environment variables for QC Android. Some features may not work properly.");
@@ -941,6 +947,9 @@ nnstreamer_native_initialize (JNIEnv * env, jobject context)
 #endif
 #if defined (ENABLE_SNPE)
     init_filter_snpe ();
+#endif
+#if defined (ENABLE_QNN)
+    init_filter_qnn ();
 #endif
 #if defined (ENABLE_PYTORCH)
     init_filter_torch ();


### PR DESCRIPTION
- Add ndk-build/makefile to build qnn subplugin.
- Add Java enum type for qnn and fIx script to build qnn subplugin.

This requires https://github.com/nnstreamer/nnstreamer/pull/4566.