### PR TITLE
[android] Fix android tests handling tensor dimension

### DIFF
--- a/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestCommon.java
+++ b/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestCommon.java
@@ -34,7 +34,7 @@ public class APITestCommon {
     private static boolean mInitialized = false;
     private static String mRootDirectory = null;
 
-    private static String getRootDirectory() {
+    public static String getRootDirectory() {
         return mInitialized ? mRootDirectory : null;
     }
 

--- a/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestCommon.java
+++ b/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestCommon.java
@@ -3,9 +3,7 @@ package org.nnsuite.nnstreamer;
 import android.Manifest;
 import android.content.Context;
 import android.content.res.AssetManager;
-import android.os.Environment;
 import android.support.test.InstrumentationRegistry;
-import android.support.test.rule.GrantPermissionRule;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.Before;

--- a/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestCustomFilter.java
+++ b/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestCustomFilter.java
@@ -159,7 +159,7 @@ public class APITestCustomFilter {
     @Test
     public void testCustomFilters() {
         String desc = "appsrc name=srcx ! " +
-                "other/tensor,dimension=(string)10:1:1:1,type=(string)int32,framerate=(fraction)0/1 ! " +
+                "other/tensor,dimension=(string)10,type=(string)int32,framerate=(fraction)0/1 ! " +
                 "tensor_filter framework=custom-easy model=" + mCustomPassthrough.getName() + " ! " +
                 "tensor_filter framework=custom-easy model=" + mCustomConvert.getName() + " ! " +
                 "tensor_filter framework=custom-easy model=" + mCustomAdd.getName() + " ! " +

--- a/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestPipeline.java
+++ b/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestPipeline.java
@@ -1407,7 +1407,7 @@ public class APITestPipeline {
 
     @Test
     public void testAMCsrc() {
-        String root = Environment.getExternalStorageDirectory().getAbsolutePath();
+        String root = APITestCommon.getRootDirectory();
         String media = root + "/nnstreamer/test/test_video.mp4";
 
         String desc = "amcsrc location=" + media + " ! " +
@@ -2318,7 +2318,7 @@ public class APITestPipeline {
             return;
         }
 
-        String root = Environment.getExternalStorageDirectory().getAbsolutePath();
+        String root = APITestCommon.getRootDirectory();
         String png_path = root + "/nnstreamer/test/orange.png";
 
         String pipeline_desc = "appsrc name=srcx caps=image/png ! pngdec ! videoconvert ! videoscale ! video/x-raw,format=RGB,width=224,height=224,framerate=0/1 ! " +

--- a/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestPipeline.java
+++ b/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestPipeline.java
@@ -1,7 +1,5 @@
 package org.nnsuite.nnstreamer;
 
-import android.os.Environment;
-import android.support.test.rule.GrantPermissionRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.view.Surface;
 import android.view.SurfaceView;

--- a/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestPipeline.java
+++ b/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestPipeline.java
@@ -853,8 +853,7 @@ public class APITestPipeline {
                         mInvalidState = true;
                     }
 
-                    if (dimension[0] != 1 || dimension[1] != 500 ||
-                        dimension[2] != 1 || dimension[3] != 1) {
+                    if (dimension[0] != 1 || dimension[1] != 500) {
                         mInvalidState = true;
                     }
 

--- a/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestSingleShot.java
+++ b/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestSingleShot.java
@@ -1,7 +1,5 @@
 package org.nnsuite.nnstreamer;
 
-import android.os.Environment;
-import android.support.test.rule.GrantPermissionRule;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.Before;

--- a/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestSingleShot.java
+++ b/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestSingleShot.java
@@ -91,7 +91,7 @@ public class APITestSingleShot {
             /* output: uint8 1001:1 */
             assertEquals(1, info.getTensorsCount());
             assertEquals(NNStreamer.TensorType.UINT8, info.getTensorType(0));
-            assertArrayEquals(new int[]{1001,1,1,1}, info.getTensorDimension(0));
+            assertArrayEquals(new int[]{1001,1}, info.getTensorDimension(0));
 
             single.close();
         } catch (Exception e) {
@@ -149,7 +149,7 @@ public class APITestSingleShot {
             /* input: float32 with dimension 1 */
             assertEquals(1, info.getTensorsCount());
             assertEquals(NNStreamer.TensorType.FLOAT32, info.getTensorType(0));
-            assertArrayEquals(new int[]{1,1,1,1}, info.getTensorDimension(0));
+            assertArrayEquals(new int[]{1}, info.getTensorDimension(0));
 
             TensorsInfo newInfo = new TensorsInfo();
             newInfo.addTensorInfo(NNStreamer.TensorType.FLOAT32, new int[]{10});
@@ -160,13 +160,13 @@ public class APITestSingleShot {
             /* input: float32 with dimension 10 */
             assertEquals(1, info.getTensorsCount());
             assertEquals(NNStreamer.TensorType.FLOAT32, info.getTensorType(0));
-            assertArrayEquals(new int[]{10,1,1,1}, info.getTensorDimension(0));
+            assertArrayEquals(new int[]{10}, info.getTensorDimension(0));
 
             info = single.getOutputInfo();
             /* output: float32 with dimension 10 */
             assertEquals(1, info.getTensorsCount());
             assertEquals(NNStreamer.TensorType.FLOAT32, info.getTensorType(0));
-            assertArrayEquals(new int[]{10,1,1,1}, info.getTensorDimension(0));
+            assertArrayEquals(new int[]{10}, info.getTensorDimension(0));
 
             single.close();
         } catch (Exception e) {
@@ -658,7 +658,7 @@ public class APITestSingleShot {
             SingleShot single = new SingleShot(APITestCommon.getTFLiteImgModel());
 
             assertEquals("3:224:224:1", single.getValue("input"));
-            assertEquals("1001:1:1:1", single.getValue("output"));
+            assertEquals("1001:1", single.getValue("output"));
 
             single.close();
         } catch (Exception e) {

--- a/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestSingleShot.java
+++ b/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestSingleShot.java
@@ -367,7 +367,7 @@ public class APITestSingleShot {
 
     @Test
     public void testInvalidFile_n() {
-        String root = Environment.getExternalStorageDirectory().getAbsolutePath();
+        String root = APITestCommon.getRootDirectory();
         File model = new File(root + "/invalid_path/invalid.tflite");
 
         try {

--- a/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestTensorsInfo.java
+++ b/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestTensorsInfo.java
@@ -50,15 +50,15 @@ public class APITestTensorsInfo {
 
             assertEquals("name1", mInfo.getTensorName(0));
             assertEquals(NNStreamer.TensorType.INT8, mInfo.getTensorType(0));
-            assertArrayEquals(new int[]{1,1,1,1}, mInfo.getTensorDimension(0));
+            assertArrayEquals(new int[]{1}, mInfo.getTensorDimension(0));
 
             assertEquals("name2", mInfo.getTensorName(1));
             assertEquals(NNStreamer.TensorType.UINT8, mInfo.getTensorType(1));
-            assertArrayEquals(new int[]{2,2,1,1}, mInfo.getTensorDimension(1));
+            assertArrayEquals(new int[]{2,2}, mInfo.getTensorDimension(1));
 
             assertNull(mInfo.getTensorName(2));
             assertEquals(NNStreamer.TensorType.FLOAT32, mInfo.getTensorType(2));
-            assertArrayEquals(new int[]{3,3,3,1}, mInfo.getTensorDimension(2));
+            assertArrayEquals(new int[]{3,3,3}, mInfo.getTensorDimension(2));
 
             assertEquals(3, mInfo.getTensorsCount());
         } catch (Exception e) {
@@ -92,15 +92,15 @@ public class APITestTensorsInfo {
             /* check cloned info */
             assertEquals("name1", cloned.getTensorName(0));
             assertEquals(NNStreamer.TensorType.INT8, cloned.getTensorType(0));
-            assertArrayEquals(new int[]{1,1,1,1}, cloned.getTensorDimension(0));
+            assertArrayEquals(new int[]{1}, cloned.getTensorDimension(0));
 
             assertEquals("name2", cloned.getTensorName(1));
             assertEquals(NNStreamer.TensorType.UINT8, cloned.getTensorType(1));
-            assertArrayEquals(new int[]{2,2,1,1}, cloned.getTensorDimension(1));
+            assertArrayEquals(new int[]{2,2}, cloned.getTensorDimension(1));
 
             assertNull(cloned.getTensorName(2));
             assertEquals(NNStreamer.TensorType.FLOAT32, cloned.getTensorType(2));
-            assertArrayEquals(new int[]{3,3,3,1}, cloned.getTensorDimension(2));
+            assertArrayEquals(new int[]{3,3,3}, cloned.getTensorDimension(2));
 
             assertEquals(3, cloned.getTensorsCount());
         } catch (Exception e) {
@@ -170,9 +170,9 @@ public class APITestTensorsInfo {
             assertEquals(NNStreamer.TensorType.INT64, mInfo.getTensorType(2));
 
             mInfo.setTensorDimension(2, new int[]{2,3});
-            assertArrayEquals(new int[]{1,1,1,1}, mInfo.getTensorDimension(0));
-            assertArrayEquals(new int[]{2,2,1,1}, mInfo.getTensorDimension(1));
-            assertArrayEquals(new int[]{2,3,1,1}, mInfo.getTensorDimension(2));
+            assertArrayEquals(new int[]{1}, mInfo.getTensorDimension(0));
+            assertArrayEquals(new int[]{2,2}, mInfo.getTensorDimension(1));
+            assertArrayEquals(new int[]{2,3}, mInfo.getTensorDimension(2));
         } catch (Exception e) {
             fail();
         }

--- a/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestTensorsInfo.java
+++ b/java/android/nnstreamer/src/androidTest/java/org/nnsuite/nnstreamer/APITestTensorsInfo.java
@@ -193,7 +193,11 @@ public class APITestTensorsInfo {
     @Test
     public void testAddInvalidRank_n() {
         try {
-            mInfo.addTensorInfo(NNStreamer.TensorType.INT32, new int[]{2,2,2,2,2});
+            int[] invalid_rank_dim = new int[NNStreamer.TENSOR_RANK_LIMIT + 1];
+            for (int i = 0; i < invalid_rank_dim.length; i++) {
+                invalid_rank_dim[i] = i + 1;
+            }
+            mInfo.addTensorInfo(NNStreamer.TensorType.INT32, invalid_rank_dim);
             fail();
         } catch (Exception e) {
             /* expected */

--- a/java/android/nnstreamer/src/main/java/org/nnsuite/nnstreamer/TensorsInfo.java
+++ b/java/android/nnstreamer/src/main/java/org/nnsuite/nnstreamer/TensorsInfo.java
@@ -7,6 +7,7 @@
 package org.nnsuite.nnstreamer;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 
 /**
  * Provides interfaces to handle tensors information.
@@ -286,7 +287,15 @@ public final class TensorsInfo implements AutoCloseable, Cloneable {
         }
 
         public int[] getDimension() {
-            return this.dimension;
+            int rank = 0;
+            for (int i = 0; i < NNStreamer.TENSOR_RANK_LIMIT; i++) {
+                if (this.dimension[i] <= 0) {
+                    break;
+                }
+                rank++;
+            }
+
+            return Arrays.copyOf(this.dimension, rank);
         }
 
         public int getSize() {


### PR DESCRIPTION
- Fix test for max rank dimension
- Let `getDimension` returns rank-aware array
: `[3, 224, 224, 1]` rather than `[3, 224, 224, 1, 0, 0, ..., 0]`
- Use rank-aware dimension in android tests

- Use `getRootDirectory` instead of `getExternalStorageDirectory` for android tests.