### PR TITLE
JNI/Android: Add .mk files for ndk-build support of llama2.c

### DIFF
--- a/java/android/nnstreamer/src/main/jni/Android-llama2c-prebuilt.mk
+++ b/java/android/nnstreamer/src/main/jni/Android-llama2c-prebuilt.mk
@@ -1,0 +1,30 @@
+#------------------------------------------------------
+# Llama2.c: Inference Llama 2 in one file of pure C
+#   https://github.com/karpathy/llama2.c (original upstream repository)
+#   https://github.com/nnsuite/llama2.c (NNSuite forked repository)
+#
+# This mk file defines a prebuilt shared library for the llama2.c module.
+#------------------------------------------------------
+LOCAL_PATH := $(call my-dir)
+
+ifndef LLAMA2C_DIR
+$(error LLAMA2C_DIR is not defined!)
+endif
+
+LLAMA2C_LIB_PATH := $(LLAMA2C_DIR)/lib
+
+#------------------------------------------------------
+# The prebuilt shared library for llama2.c
+#------------------------------------------------------
+LLAMA2C_PREBUILT_LIBS :=
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := llama2c
+LOCAL_SRC_FILES := \
+    $(LLAMA2C_DIR)/api.c \
+    $(LLAMA2C_DIR)/sampler.c \
+    $(LLAMA2C_DIR)/tokenizer.c \
+    $(LLAMA2C_DIR)/transformer.c \
+    $(LLAMA2C_DIR)/util.c
+include $(BUILD_SHARED_LIBRARY)
+LLAMA2C_PREBUILT_LIBS += llama2c

--- a/java/android/nnstreamer/src/main/jni/Android-llama2c.mk
+++ b/java/android/nnstreamer/src/main/jni/Android-llama2c.mk
@@ -1,0 +1,23 @@
+LOCAL_PATH := $(call my-dir)
+
+LLAMA2C_DIR := $(LOCAL_PATH)/llama2.c
+LLAMA2C_INCLUDES := $(LLAMA2C_DIR)/include
+LLAMA2C_LIB_PATH := $(LLAMA2C_DIR)/lib
+
+#------------------------------------------------------
+# Import LLAMA2C_PREBUILT_LIBS
+#------------------------------------------------------
+include $(LOCAL_PATH)/Android-llama2c-prebuilt.mk
+
+#------------------------------------------------------
+# tensor-filter sub-plugin for llama2.c
+#------------------------------------------------------
+include $(CLEAR_VARS)
+LOCAL_MODULE := llama2c-subplugin
+LOCAL_SRC_FILES := $(NNSTREAMER_FILTER_LLAMA2C_SRCS)
+LOCAL_CXXFLAGS := -O3 -fPIC -frtti -fexceptions $(NNS_API_FLAGS)
+LOCAL_C_INCLUDES := $(LLAMA2C_INCLUDES) $(NNSTREAMER_INCLUDES) $(GST_HEADERS_COMMON)
+LOCAL_STATIC_LIBRARIES := nnstreamer
+LOCAL_SHARED_LIBRARIES := $(LLAMA2C_PREBUILT_LIBS)
+
+include $(BUILD_STATIC_LIBRARY)

--- a/java/android/nnstreamer/src/main/jni/Android.mk
+++ b/java/android/nnstreamer/src/main/jni/Android.mk
@@ -97,6 +97,8 @@ $(error DO NOT enable SNAP and SNPE both. The app would fail to use DSP or NPU r
 endif
 endif
 
+ENABLE_LLAMA2C := false
+
 NNS_API_FLAGS := -DVERSION=\"$(ML_API_VERSION)\" -DVERSION_MAJOR=$(ML_API_VERSION_MAJOR) -DVERSION_MINOR=$(ML_API_VERSION_MINOR) -DVERSION_MICRO=$(ML_API_VERSION_MICRO)
 NNS_SUBPLUGINS :=
 
@@ -159,6 +161,13 @@ NNS_API_FLAGS += -DENABLE_MXNET=1
 NNS_SUBPLUGINS += mxnet-subplugin
 
 include $(LOCAL_PATH)/Android-mxnet.mk
+endif
+
+ifeq ($(ENABLE_LLAMA2C), true)
+NNS_API_FLAGS += -DENABLE_LLAMA2C=1
+NNS_SUBPLUGINS += llama2c-subplugin
+
+include $(LOCAL_PATH)/Android-llama2c.mk
 endif
 
 ifneq ($(NNSTREAMER_API_OPTION),single)


### PR DESCRIPTION
This patch adds the .mk scripts to enable ndk-build support for llama2.c.

Signed-off-by: Wook Song <wook16.song@samsung.com>
