### PR TITLE
[ml-service] Add staging header to prevent build error

### DIFF
--- a/c/include/meson.build
+++ b/c/include/meson.build
@@ -7,3 +7,6 @@ else
 endif
 
 nns_capi_service_headers = files('ml-api-service.h')
+if get_option('enable-tizen')
+  nns_capi_service_headers += files('ml-api-staging.h')
+endif

--- a/c/include/ml-api-staging.h
+++ b/c/include/ml-api-staging.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * NNStreamer API / Tizen Machine-Learning API Internal Header
+ * Copyright (C) 2024 Gichan Jang <gichan2.jang@samsung.com>
+ */
+/**
+ * @file    ml-api-staging.h
+ * @date    10 oct 2024
+ * @brief   Internal header for ML-API.
+ * @see     https://github.com/nnstreamer/nnstreamer
+ * @author  Gichan Jang <gichan2.jang@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#ifndef __ML_API_STAGING_H__
+#define __ML_API_STAGING_H__
+
+#include <ml-api-common.h>
+#include <ml-api-service.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * Temporarily use the API waiting for release.
+ */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* __ML_API_STAGING_H__ */

--- a/packaging/machine-learning-api.spec
+++ b/packaging/machine-learning-api.spec
@@ -295,6 +295,13 @@ Group:		Machine Learning/ML Framework
 Requires:	capi-machine-learning-service = %{version}-%{release}
 %description -n capi-machine-learning-service-devel-static
 Static library of Tizen Machine Learning Service API.
+
+%package -n capi-machine-learning-staging
+Summary:	Tizen staging headers for Tizen Machine Learning API
+Group:		Machine Learning/ML Framework
+Requires:	capi-machine-learning-service-devel = %{version}-%{release}
+%description -n capi-machine-learning-staging
+Tizen staging headers for Tizen Machine Learning API.
 %endif
 
 %if 0%{?unit_test}
@@ -538,6 +545,9 @@ install -m 0755 packaging/run-unittest.sh %{buildroot}%{_bindir}/tizen-unittests
 
 %files -n capi-machine-learning-service-devel-static
 %{_libdir}/libcapi-ml-service.a
+
+%files -n capi-machine-learning-staging
+%{_includedir}/nnstreamer/ml-api-staging.h
 %endif
 
 %if 0%{?unit_test}


### PR DESCRIPTION
Staging header will be added to Tizen 7.0.
Add empty staging header file to prevent build errors for users using the header file.