### PR TITLE
[After #607][api/single] Support executorch-llama

### DIFF
--- a/c/include/ml-api-common.h
+++ b/c/include/ml-api-common.h
@@ -75,6 +75,7 @@ typedef enum {
   ML_NNFW_TYPE_NCNN = 18,             /**< Tencent ncnn (Since 9.0) */
   ML_NNFW_TYPE_TENSORRT = 19,         /**< NVidia Tensor-RT (Since 9.0) */
   ML_NNFW_TYPE_QNN = 20,              /**< Qualcomm QNN (Qualcomm® AI Engine Direct) (Since 9.0) */
+  ML_NNFW_TYPE_EXECUTORCH_LLAMA = 21, /**< ExecuTorch Llama runner */
   ML_NNFW_TYPE_SNAP = 0x2001,         /**< SNAP (Samsung Neural Acceleration Platform), only for Android. (Since 6.0) */
 } ml_nnfw_type_e;
 

--- a/c/src/ml-api-inference-single.c
+++ b/c/src/ml-api-inference-single.c
@@ -112,6 +112,7 @@ static const char *ml_nnfw_subplugin_name[] = {
   [ML_NNFW_TYPE_NCNN] = "ncnn",
   [ML_NNFW_TYPE_TENSORRT] = "tensorrt",
   [ML_NNFW_TYPE_QNN] = "qnn",
+  [ML_NNFW_TYPE_EXECUTORCH_LLAMA] = "executorch-llama",
   NULL
 };
 
@@ -1985,6 +1986,7 @@ _ml_validate_model_file (const char *const *model,
     case ML_NNFW_TYPE_ONNX_RUNTIME:
     case ML_NNFW_TYPE_NCNN:
     case ML_NNFW_TYPE_TENSORRT:
+    case ML_NNFW_TYPE_EXECUTORCH_LLAMA:
     case ML_NNFW_TYPE_QNN:
       /**
        * We cannot check the file ext with NNFW.

--- a/c/src/ml-api-inference-single.c
+++ b/c/src/ml-api-inference-single.c
@@ -137,6 +137,7 @@ typedef struct
   gboolean invoking;                  /**< invoke running flag */
   ml_tensors_data_h in_tensors;       /**< input tensor wrapper for processing */
   ml_tensors_data_h out_tensors;      /**< output tensor wrapper for processing */
+  gboolean is_flexible;               /**< true if tensor filter handles flexible input/output */
 
   GList *destroy_data_list;         /**< data to be freed by filter */
 } ml_single;
@@ -778,6 +779,11 @@ ml_single_set_info_in_handle (ml_single_h single, gboolean is_input,
     ml_tensors_info_h info = NULL;
 
     ml_single_get_gst_info (single_h, is_input, &gst_info);
+    if (single_h->is_flexible) {
+      gst_info.format = _NNS_TENSOR_FORMAT_FLEXIBLE;
+      gst_info.num_tensors = 1U;        /* TODO: Consider multiple input tensors filter */
+    }
+
     _ml_tensors_info_create_from_gst (&info, &gst_info);
 
     gst_tensors_info_free (&gst_info);
@@ -846,6 +852,7 @@ ml_single_create_handle (ml_nnfw_type_e nnfw)
   single_h->output = NULL;
   single_h->destroy_data_list = NULL;
   single_h->invoking = FALSE;
+  single_h->is_flexible = FALSE;
 
   gst_tensors_info_init (&single_h->in_info);
   gst_tensors_info_init (&single_h->out_info);
@@ -945,6 +952,7 @@ ml_single_open_custom (ml_single_h * single, ml_single_preset * info)
   gchar **list_models;
   guint i, num_models;
   char *hw_name;
+  gboolean invoke_dynamic = FALSE;
 
   check_feature_state (ML_FEATURE_INFERENCE);
 
@@ -1081,6 +1089,21 @@ ml_single_open_custom (ml_single_h * single, ml_single_preset * info)
         fw_name);
     status = ML_ERROR_STREAMS_PIPE;
     goto error;
+  }
+
+  /* handle flexible single */
+  /**
+   * Set invoke_dynamic as TRUE if the given nnfw do invoke_dynamic
+   *
+   * if (info->nnfw == ML_NNFW_TYPE_EXECUTORCH_LLAMA || info->nnfw == ML_NNFW_TYPE_LLAMACPP) {
+   *   invoke_dynamic = TRUE;
+   * }
+   *
+   */
+
+  if (invoke_dynamic) {
+    single_h->is_flexible = TRUE;
+    g_object_set (filter_obj, "invoke-dynamic", TRUE, NULL);
   }
 
   if (nnfw == ML_NNFW_TYPE_NNTR_INF) {
@@ -1317,6 +1340,11 @@ _ml_single_invoke_validate_data (ml_single_h single,
       _ml_error_report_return (ML_ERROR_INVALID_PARAMETER,
           "The %d-th input tensor is not valid. There is no valid dimension metadata for this tensor.",
           i);
+
+    if (single_h->is_flexible) {
+      /* Skip data size check for flexible */
+      continue;
+    }
 
     raw_size = _model->tensors[i].size;
     if (G_UNLIKELY (_data->tensors[i].size != raw_size))

--- a/c/src/ml-api-inference-single.c
+++ b/c/src/ml-api-inference-single.c
@@ -1093,14 +1093,9 @@ ml_single_open_custom (ml_single_h * single, ml_single_preset * info)
   }
 
   /* handle flexible single */
-  /**
-   * Set invoke_dynamic as TRUE if the given nnfw do invoke_dynamic
-   *
-   * if (info->nnfw == ML_NNFW_TYPE_EXECUTORCH_LLAMA || info->nnfw == ML_NNFW_TYPE_LLAMACPP) {
-   *   invoke_dynamic = TRUE;
-   * }
-   *
-   */
+  if (info->nnfw == ML_NNFW_TYPE_EXECUTORCH_LLAMA) {
+    invoke_dynamic = TRUE;
+  }
 
   if (invoke_dynamic) {
     single_h->is_flexible = TRUE;


### PR DESCRIPTION
- Let single API handle flexible filter (executorch-llama)
- Add a enum for new nnfw `EXECUTORCH_LLAMA`
- Add a simple disabled test to show how to use executorch-llama with single api