### PR TITLE
[Tizen] Remove i586 build test

### DIFF
--- a/.github/workflows/daily-build-gbs.yml
+++ b/.github/workflows/daily-build-gbs.yml
@@ -12,7 +12,6 @@ jobs:
   build:
     outputs:
       x86_64: ${{ steps.gbs-result.outputs.x86_64 }}
-      i586: ${{ steps.gbs-result.outputs.i586 }}
       armv7l: ${{ steps.gbs-result.outputs.armv7l }}
       aarch64: ${{ steps.gbs-result.outputs.aarch64 }}
     strategy:
@@ -21,8 +20,6 @@ jobs:
         include:
           - gbs_build_arch: "x86_64"
             gbs_build_option: "--define \"unit_test 1\" --define \"testcoverage 1\""
-          - gbs_build_arch: "i586"
-            gbs_build_option: "--define \"unit_test 1\""
           - gbs_build_arch: "armv7l"
             gbs_build_option: "--define \"unit_test 1\""
           - gbs_build_arch: "aarch64"

--- a/.github/workflows/gbs_build.yml
+++ b/.github/workflows/gbs_build.yml
@@ -15,8 +15,6 @@ jobs:
         include:
           - gbs_build_arch: "x86_64"
             gbs_build_option: "--define \"unit_test 1\""
-          - gbs_build_arch: "i586"
-            gbs_build_option: "--define \"unit_test 1\""
           - gbs_build_arch: "armv7l"
             gbs_build_option: "--define \"unit_test 0\""
           - gbs_build_arch: "aarch64"


### PR DESCRIPTION
From Tizen 10, i586 is removed.
Let's remove the i586 build.