### PR TITLE
[android] Let it build and use orc from nnstreamer

### DIFF
--- a/java/android/nnstreamer/src/main/jni/Android-nnstreamer.mk
+++ b/java/android/nnstreamer/src/main/jni/Android-nnstreamer.mk
@@ -39,6 +39,21 @@ NNSTREAMER_SRC_FILES += \
     $(NNSTREAMER_DECODER_IS_SRCS) \
     $(NNSTREAMER_JOIN_SRCS)
 
+ifeq ($(shell which orcc),)
+$(info No 'orcc' in your PATH, install it to enable orc.)
+else
+$(info Compile ORC code)
+$(shell mkdir -p $(LOCAL_PATH)/orc)
+$(shell orcc --header -o $(LOCAL_PATH)/orc/nnstreamer-orc.h $(NNSTREAMER_ORC_SRC))
+$(shell orcc --implementation -o $(LOCAL_PATH)/orc/nnstreamer-orc.c $(NNSTREAMER_ORC_SRC))
+
+NNSTREAMER_SRC_FILES     += $(LOCAL_PATH)/orc/nnstreamer-orc.c
+NNSTREAMER_CAPI_INCLUDES += $(LOCAL_PATH)/orc
+NNSTREAMER_CAPI_INCLUDES += $(GSTREAMER_ROOT)/include/orc-0.4
+
+NNS_API_FLAGS += -DHAVE_ORC=1
+endif
+
 ifeq ($(ENABLE_TENSOR_QUERY), true)
 ifndef NNSTREAMER_EDGE_ROOT
 $(error NNSTREAMER_EDGE_ROOT is not defined!)

--- a/java/android/nnstreamer/src/main/jni/Android.mk
+++ b/java/android/nnstreamer/src/main/jni/Android.mk
@@ -225,7 +225,7 @@ GST_BLOCKED_PLUGINS      := \
         rsaudiofx rsvideofx
 
 GSTREAMER_PLUGINS        := $(filter-out $(GST_BLOCKED_PLUGINS), $(GST_REQUIRED_PLUGINS))
-GSTREAMER_EXTRA_DEPS     := $(GST_REQUIRED_DEPS) glib-2.0 gio-2.0 gmodule-2.0
+GSTREAMER_EXTRA_DEPS     := $(GST_REQUIRED_DEPS) glib-2.0 gio-2.0 gmodule-2.0 orc-0.4
 GSTREAMER_EXTRA_LIBS     := $(GST_REQUIRED_LIBS) -liconv
 
 ifeq ($(NNSTREAMER_API_OPTION),all)


### PR DESCRIPTION
- Let android utilizes nnstreamer's orc code (tensor_transform).
- Requires https://github.com/nnstreamer/nnstreamer/pull/4651 to be merged.

