### PR TITLE
[Action] Change how to detect code change

### DIFF
--- a/.github/actions/gitpush/action.yml
+++ b/.github/actions/gitpush/action.yml
@@ -25,8 +25,7 @@ runs:
         pushd nnstreamer.github.io
         mkdir -p ${{ inputs.dest }}
         cp -r ${{ inputs.source }} ${{ inputs.dest }}
-        git diff -s --exit-code
-        if [ $? -ne 0 ]; then
+        if git diff --shortstat | grep -q changed; then
           git config user.email "nnsuite@samsung.com"
           git config user.name "nnsuite"
           git add *


### PR DESCRIPTION
The method of getting the diff of git is failing now.
Changed to check code diff by filtering the result.

Failed job: https://github.com/nnstreamer/api/actions/runs/12400628640/job/34618240664
After this patch: https://github.com/gichan-jang/api/actions/runs/12409355776/job/34642806472


* I'm sorry that I didn't check the behavior of the daily build accurately in the last patch.