### PR TITLE
[Android] common path for external libs

### DIFF
--- a/java/android/nnstreamer/build.gradle
+++ b/java/android/nnstreamer/build.gradle
@@ -124,24 +124,9 @@ android {
     }
     sourceSets {
         main {
-            if (project.hasProperty('SNPE_EXT_LIBRARY_PATH')) {
-                jniLibs.srcDirs += project.properties['SNPE_EXT_LIBRARY_PATH']
-                println 'Set jniLibs.srcDirs includes libraries for SNPE'
-            }
-
-            if (project.hasProperty('QNN_EXT_LIBRARY_PATH')) {
-                jniLibs.srcDirs += project.properties['QNN_EXT_LIBRARY_PATH']
-                println 'Set jniLibs.srcDirs includes libraries for QNN'
-            }
-
-            if (project.hasProperty('NNFW_EXT_LIBRARY_PATH')) {
-                jniLibs.srcDirs += project.properties['NNFW_EXT_LIBRARY_PATH']
-                println 'Set jniLibs.srcDirs includes libraries for NNFW'
-            }
-
-            if (project.hasProperty('TFLITE_QNN_DELEGATE_EXT_LIBRARY_PATH')) {
-                jniLibs.srcDirs += project.properties['TFLITE_QNN_DELEGATE_EXT_LIBRARY_PATH']
-                println 'Set jniLibs.srcDirs includes libraries for TFLite QNN Delegate'
+            if (project.hasProperty('NNS_EXT_LIBRARY_PATH')) {
+                jniLibs.srcDirs += project.properties['NNS_EXT_LIBRARY_PATH']
+                println 'Set jniLibs.srcDirs for external libraries'
             }
         }
     }

--- a/java/android/nnstreamer/src/main/jni/Android-nnfw.mk
+++ b/java/android/nnstreamer/src/main/jni/Android-nnfw.mk
@@ -5,9 +5,9 @@
 # This mk file defines nnfw module with prebuilt shared library.
 # (nnfw core libraries, arm64-v8a only)
 #
-# You should check your `gradle.properties` to set the variable `NNFW_EXT_LIBRARY_PATH` properly.
+# You should check your `gradle.properties` to set the variable `NNS_EXT_LIBRARY_PATH` properly.
 # The variable should be assigned with path for external shared libs.
-# An example: "NNFW_EXT_LIBRARY_PATH=src/main/jni/nnfw/ext"
+# An example: "NNS_EXT_LIBRARY_PATH=src/main/jni/external/lib"
 #------------------------------------------------------
 LOCAL_PATH := $(call my-dir)
 
@@ -17,11 +17,10 @@ endif
 
 include $(NNSTREAMER_ROOT)/jni/nnstreamer.mk
 
-NNFW_DIR := $(LOCAL_PATH)/nnfw
-NNFW_INCLUDES := $(NNFW_DIR)/include $(NNFW_DIR)/include/nnfw
+NNFW_INCLUDES := $(EXT_INCLUDE_PATH)/nnfw
 
 ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
-NNFW_LIB_PATH := $(NNFW_DIR)/lib
+NNFW_LIB_PATH := $(EXT_LIB_PATH)
 else
 $(error Target arch ABI not supported: $(TARGET_ARCH_ABI))
 endif

--- a/java/android/nnstreamer/src/main/jni/Android-qnn.mk
+++ b/java/android/nnstreamer/src/main/jni/Android-qnn.mk
@@ -9,15 +9,13 @@ endif
 
 include $(NNSTREAMER_ROOT)/jni/nnstreamer.mk
 
-QNN_DIR := $(LOCAL_PATH)/qnn
-
 ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
-QNN_LIB_PATH := $(QNN_DIR)/lib
+QNN_LIB_PATH := $(EXT_LIB_PATH)
 else
 $(error Target arch ABI not supported: $(TARGET_ARCH_ABI))
 endif
 
-QNN_INCLUDES := $(QNN_DIR)/include/QNN
+QNN_INCLUDES := $(EXT_INCLUDE_PATH)/QNN
 
 #------------------------------------------------------
 # qnn-sdk (prebuilt shared library)

--- a/java/android/nnstreamer/src/main/jni/Android-snpe.mk
+++ b/java/android/nnstreamer/src/main/jni/Android-snpe.mk
@@ -5,9 +5,9 @@
 # (snpe-sdk, arm64-v8a only)
 # See Qualcomm Neural Processing SDK for AI (https://developer.qualcomm.com/software/qualcomm-neural-processing-sdk) for the details.
 #
-# You should check your `gradle.properties` to set the variable `SNPE_EXT_LIBRARY_PATH` properly.
+# You should check your `gradle.properties` to set the variable `NNS_EXT_LIBRARY_PATH` properly.
 # The variable should be assigned with path for external shared libs.
-# An example: "SNPE_EXT_LIBRARY_PATH=src/main/jni/snpe/lib/ext"
+# An example: "NNS_EXT_LIBRARY_PATH=src/main/jni/external/lib"
 #------------------------------------------------------
 LOCAL_PATH := $(call my-dir)
 
@@ -17,10 +17,8 @@ endif
 
 include $(NNSTREAMER_ROOT)/jni/nnstreamer.mk
 
-SNPE_DIR := $(LOCAL_PATH)/snpe
-
 ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
-SNPE_LIB_PATH := $(SNPE_DIR)/lib
+SNPE_LIB_PATH := $(EXT_LIB_PATH)
 else
 $(error Target arch ABI not supported: $(TARGET_ARCH_ABI))
 endif
@@ -29,14 +27,14 @@ SNPE_INCLUDES :=
 SNPE_FLAGS :=
 
 # Check the version of SNPE SDK (v1 or v2)
-ifeq ($(shell test -d $(SNPE_DIR)/include/zdl; echo $$?),0)
+ifeq ($(shell test -d $(EXT_INCLUDE_PATH)/zdl; echo $$?),0)
 SNPE_FLAGS += -DSNPE_VERSION_MAJOR=1
-SNPE_INCLUDES += $(SNPE_DIR)/include/zdl
-else ifeq ($(shell test -d $(SNPE_DIR)/include/SNPE; echo $$?),0)
+SNPE_INCLUDES += $(EXT_INCLUDE_PATH)/zdl
+else ifeq ($(shell test -d $(EXT_INCLUDE_PATH)/SNPE; echo $$?),0)
 SNPE_FLAGS += -DSNPE_VERSION_MAJOR=2
-SNPE_INCLUDES += $(SNPE_DIR)/include/SNPE
+SNPE_INCLUDES += $(EXT_INCLUDE_PATH)/SNPE
 else
-$(error SNPE SDK not found: $(SNPE_DIR))
+$(error Cannot find SNPE SDK)
 endif
 
 #------------------------------------------------------

--- a/java/android/nnstreamer/src/main/jni/Android-tensorflow-lite.mk
+++ b/java/android/nnstreamer/src/main/jni/Android-tensorflow-lite.mk
@@ -70,12 +70,9 @@ ifneq ($(TARGET_ARCH_ABI),arm64-v8a)
 $(error TensorFlow-Lite QNN delegate is available only for ABI arm64-v8a)
 endif
 
-QNN_DELEGATE_DIR := $(LOCAL_PATH)/tensorflow-lite-QNN-delegate
-QNN_DELEGATE_INCLUDE := $(QNN_DELEGATE_DIR)/include
-
 NNS_API_FLAGS += -DENABLE_TFLITE_QNN_DELEGATE=1
 TFLITE_FLAGS += -DTFLITE_QNN_DELEGATE_SUPPORTED=1
-TF_LITE_INCLUDES += $(QNN_DELEGATE_INCLUDE)
+TF_LITE_INCLUDES += $(EXT_INCLUDE_PATH)
 endif
 
 #------------------------------------------------------

--- a/java/android/nnstreamer/src/main/jni/Android.mk
+++ b/java/android/nnstreamer/src/main/jni/Android.mk
@@ -24,6 +24,10 @@ else
 $(error Target arch ABI not supported: $(TARGET_ARCH_ABI))
 endif
 
+# Path for external libraries
+EXT_INCLUDE_PATH := $(LOCAL_PATH)/external/include
+EXT_LIB_PATH := $(LOCAL_PATH)/external/lib/$(TARGET_ARCH_ABI)
+
 # Set ML API Version
 ML_API_VERSION  := 1.8.6
 ML_API_VERSION_MAJOR := $(word 1,$(subst ., ,${ML_API_VERSION}))


### PR DESCRIPTION
Set common path for external libraries on android build.
This PR will build android library including same external files - SNPE, QNN, and TF-lite QNN delegate.