### PR TITLE
[Android] header for nns version

### DIFF
--- a/java/build-nnstreamer-android.sh
+++ b/java/build-nnstreamer-android.sh
@@ -898,7 +898,6 @@ fi
 rm -rf ${build_dir}
 
 popd
-cd ${nnstreamer_dir} && find -name nnstreamer_version.h -delete
 
 # exit with success/failure status
 exit ${android_lib_build_res}


### PR DESCRIPTION
Remove unnecessary line for deleting nnstreamer version header when building android library.