### PR TITLE
[Android] invalid param

### DIFF
--- a/java/android/nnstreamer/src/main/jni/nnstreamer-native-singleshot.c
+++ b/java/android/nnstreamer/src/main/jni/nnstreamer-native-singleshot.c
@@ -353,7 +353,7 @@ nns_native_single_set_prop (JNIEnv * env, jobject thiz, jlong handle,
   }
 
   (*env)->ReleaseStringUTFChars (env, name, prop_name);
-  (*env)->ReleaseStringUTFChars (env, name, prop_value);
+  (*env)->ReleaseStringUTFChars (env, value, prop_value);
   return ret;
 }
 


### PR DESCRIPTION
Fix invalid param when releasing converted string in native function.
