### PR TITLE
[Service] Fix a typo in a Doxygen brief

### DIFF
--- a/c/src/ml-api-service-offloading.c
+++ b/c/src/ml-api-service-offloading.c
@@ -303,7 +303,7 @@ _mlrs_get_model_dir_path (_ml_service_offloading_s * offloading_s,
 }
 
 /**
- * @brief Get data from gievn uri
+ * @brief Get data from given uri
  */
 static gboolean
 _mlrs_get_data_from_uri (gchar * uri, GByteArray * array)


### PR DESCRIPTION
One-word fix: `gievn` to `given` in the `@brief` of the offloading URI helper in `c/src/ml-api-service-offloading.c`.

The `Spell Check with Typos` job reports it on every PR that runs, including ones that do not touch the file (seen on #688), so this clears the job for everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
