### PR TITLE
[Debian/Build] Build ml-api on Ubuntu 26.04 (gcc fallback, C++17)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: ml-api
 Section: libs
 Priority: optional
 Maintainer: MyungJoo Ham <myungjoo.ham@samsung.com>
-Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
+Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4) | gcc,
  ninja-build, meson (>=0.50), debhelper (>=9),
  libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, gstreamer1.0-plugins-base,
  nnstreamer, nnstreamer-dev, nnstreamer-dev-internal, openjdk-11-jdk,

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@ project('ml-api', 'c', 'cpp',
     'werror=true',
     'warning_level=1',
     'c_std=gnu89',
-    'cpp_std=c++14'
+    'cpp_std=c++17'
   ]
 )
 


### PR DESCRIPTION
## Why

`ppa:nnstreamer/ppa` now publishes nnstreamer, nnstreamer-edge, ssat, tensorflow2-lite and edgetpu for Ubuntu 26.04 (resolute), but `ml-api` cannot follow: the Launchpad recipe `nnstreamer-ml-api-daily` stops at the build-dependency stage on 24.10 and later because every compiler alternative in `debian/control` (`gcc-9 | gcc-8 | ... | gcc-5`) has been dropped from the archive. Once past that, all four gtest binaries fail to compile on 26.04 because GoogleTest 1.17 refuses anything older than C++17.

## What

- `debian/control`: append the unversioned `gcc` as the last compiler alternative, the same fallback nnstreamer (#4895) and nnstreamer-edge (nnstreamer/nnstreamer-edge#256) already carry. 22.04 and 24.04 still resolve `gcc-9` first, so nothing changes there.
- `meson.build`: `cpp_std=c++14` -> `c++17`. The Android build already passes `-std=c++17` and nnstreamer has been on C++17 for years.

## How it was verified

Full packaging build in an `ubuntu:26.04` container with `ppa:nnstreamer/ppa` enabled, `mk-build-deps` from the modified control, then `dpkg-buildpackage -us -uc -b` (gcc 15.2.0, meson 1.10, openjdk 11 from the archive). Without the second commit the build stops with

```
/usr/include/gtest/internal/gtest-port.h:273:2: error: #error C++ versions less than C++17 are not supported.
```

in `unittest_capi_inference`, `unittest_capi_inference_single`, `unittest_capi_inference_latency` and `unittest_capi_datatype_consistency`. With both commits the build completes, `override_dh_auto_test` (`packaging/run_unittests.sh`) runs, and all eight `.deb`s are produced.

No functional change, so no new test case; the existing unit tests are what the C++17 change makes buildable again on 26.04.

Part of the 26.04 PPA work tracked in nnstreamer/nnstreamer#4902. After this merges, the Launchpad recipe needs Resolute added and a build requested (I can do that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
