### PR TITLE
[Service] fix use-after-free on training offloading destroy

### DIFF
--- a/c/src/ml-api-service-training-offloading.c
+++ b/c/src/ml-api-service-training-offloading.c
@@ -911,18 +911,21 @@ _ml_service_training_offloading_destroy (ml_service_s * mls)
     training_s->transfer_data_table = NULL;
   }
 
-  if (training_s->node_table) {
-    g_hash_table_destroy (training_s->node_table);
-    training_s->node_table = NULL;
-  }
-
+  /* Stop the pipeline before releasing the node info the sink callback uses. */
   if (training_s->pipeline_h) {
+    ml_pipeline_stop (training_s->pipeline_h);
+
     ret = ml_pipeline_destroy (training_s->pipeline_h);
     if (ret != ML_ERROR_NONE) {
       _ml_error_report ("Failed to destroy ml pipeline, clear handle anyway.");
     }
 
     training_s->pipeline_h = NULL;
+  }
+
+  if (training_s->node_table) {
+    g_hash_table_destroy (training_s->node_table);
+    training_s->node_table = NULL;
   }
 
   g_clear_pointer (&training_s->path, g_free);

--- a/c/src/ml-api-service-training-offloading.c
+++ b/c/src/ml-api-service-training-offloading.c
@@ -913,7 +913,9 @@ _ml_service_training_offloading_destroy (ml_service_s * mls)
 
   /* Stop the pipeline before releasing the node info the sink callback uses. */
   if (training_s->pipeline_h) {
-    ml_pipeline_stop (training_s->pipeline_h);
+    if (ml_pipeline_stop (training_s->pipeline_h) != ML_ERROR_NONE) {
+      _ml_error_report ("Failed to stop ml pipeline, destroy it anyway.");
+    }
 
     ret = ml_pipeline_destroy (training_s->pipeline_h);
     if (ret != ML_ERROR_NONE) {

--- a/tests/capi/unittest_capi_service_training_offloading.cc
+++ b/tests/capi/unittest_capi_service_training_offloading.cc
@@ -9,6 +9,9 @@
 
 #include <gtest/gtest.h>
 #include <glib/gstdio.h>
+#ifdef __GLIBC__
+#include <malloc.h>
+#endif
 #include <ml-api-inference-pipeline-internal.h>
 #include <ml-api-internal.h>
 #include <ml-api-service-private.h>
@@ -348,6 +351,16 @@ static const gchar *receiver_pipe_json
 #define SINK_CB_HOLD_TIME (300000)
 
 /**
+ * @brief Handshake between the sink callback and the thread tearing the
+ * service down.
+ */
+typedef struct {
+  GMutex lock;
+  GCond cond;
+  gboolean entered;
+} sink_hold_s;
+
+/**
  * @brief Callback holding the streaming thread while the service is destroyed.
  *
  * The 'name' of the event data is the name of the node info owned by the
@@ -358,13 +371,17 @@ static const gchar *receiver_pipe_json
 static void
 _hold_new_data_cb (ml_service_event_e event, ml_information_h event_data, void *user_data)
 {
-  gint *received = (gint *) user_data;
+  sink_hold_s *hold = (sink_hold_s *) user_data;
   char *node_name = NULL;
 
   if (event != ML_SERVICE_EVENT_NEW_DATA)
     return;
 
-  g_atomic_int_inc (received);
+  g_mutex_lock (&hold->lock);
+  hold->entered = TRUE;
+  g_cond_broadcast (&hold->cond);
+  g_mutex_unlock (&hold->lock);
+
   g_usleep (SINK_CB_HOLD_TIME);
 
   EXPECT_EQ (ml_information_get (event_data, "name", (void **) &node_name), ML_ERROR_NONE);
@@ -372,21 +389,22 @@ _hold_new_data_cb (ml_service_event_e event, ml_information_h event_data, void *
 }
 
 /**
- * @brief Bring a receiver service up to the point where its pipeline is
- * playing and the sink callback is firing.
+ * @brief Bring a receiver service up to the point where the sink callback has
+ * entered and is holding the streaming thread.
  */
 static void
-_start_receiver_pipeline (ml_service_h receiver_h, const gchar *path, gint *received)
+_start_receiver_pipeline (ml_service_h receiver_h, const gchar *path, sink_hold_s *hold)
 {
   ml_service_s *mls = (ml_service_s *) receiver_h;
   nns_edge_data_h data_h = NULL;
-  gint loop;
+  gint64 deadline;
+  gboolean entered;
   int status;
 
   status = _ml_service_training_offloading_set_path (mls, path);
   ASSERT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_service_set_event_cb (receiver_h, _hold_new_data_cb, received);
+  status = ml_service_set_event_cb (receiver_h, _hold_new_data_cb, hold);
   ASSERT_EQ (status, ML_ERROR_NONE);
 
   ASSERT_EQ (nns_edge_data_create (&data_h), NNS_EDGE_ERROR_NONE);
@@ -398,10 +416,17 @@ _start_receiver_pipeline (ml_service_h receiver_h, const gchar *path, gint *rece
   status = _ml_service_training_offloading_start (mls);
   ASSERT_EQ (status, ML_ERROR_NONE);
 
-  for (loop = 0; loop < 500 && g_atomic_int_get (received) == 0; loop++)
-    g_usleep (10000);
+  deadline = g_get_monotonic_time () + 10 * G_TIME_SPAN_SECOND;
 
-  ASSERT_GT (g_atomic_int_get (received), 0);
+  g_mutex_lock (&hold->lock);
+  while (!hold->entered) {
+    if (!g_cond_wait_until (&hold->cond, &hold->lock, deadline))
+      break;
+  }
+  entered = hold->entered;
+  g_mutex_unlock (&hold->lock);
+
+  ASSERT_TRUE (entered);
 }
 
 /**
@@ -411,7 +436,7 @@ _start_receiver_pipeline (ml_service_h receiver_h, const gchar *path, gint *rece
 TEST_F (MLServiceTrainingOffloading, destroyWhileRunning_p)
 {
   int status;
-  gint received = 0;
+  sink_hold_s hold = {};
   ml_service_h receiver_h = NULL;
   g_autofree gchar *path = g_dir_make_tmp ("ml-training-offloading-XXXXXX", NULL);
 
@@ -421,14 +446,36 @@ TEST_F (MLServiceTrainingOffloading, destroyWhileRunning_p)
   g_autofree gchar *receiver_config
       = prepare_test_config ("training_offloading_receiver.conf", avail_port);
 
+  g_mutex_init (&hold.lock);
+  g_cond_init (&hold.cond);
+
   status = ml_service_new (receiver_config, &receiver_h);
   ASSERT_EQ (status, ML_ERROR_NONE);
 
-  _start_receiver_pipeline (receiver_h, path, &received);
+  _start_receiver_pipeline (receiver_h, path, &hold);
+
+#ifdef __GLIBC__
+  /**
+   * Scrub memory as it is released, so that a node name read after the node
+   * table is gone is caught rather than read back intact. glibc skips this for
+   * a chunk that fits the tcache, which the node name normally does; there the
+   * detection instead comes from tcache_put() writing its own link fields over
+   * the first 16 bytes of the chunk. Neither is a property of the code under
+   * test, so a sanitizer build remains the only airtight net for this.
+   */
+  mallopt (M_PERTURB, 0xAA);
+#endif
 
   /* Destroy without stopping first. */
   status = ml_service_destroy (receiver_h);
   EXPECT_EQ (ML_ERROR_NONE, status);
+
+#ifdef __GLIBC__
+  mallopt (M_PERTURB, 0);
+#endif
+
+  g_mutex_clear (&hold.lock);
+  g_cond_clear (&hold.cond);
 
   EXPECT_EQ (g_remove (receiver_config), 0);
   EXPECT_EQ (g_rmdir (path), 0);
@@ -440,7 +487,7 @@ TEST_F (MLServiceTrainingOffloading, destroyWhileRunning_p)
 TEST_F (MLServiceTrainingOffloading, destroyAfterStop_p)
 {
   int status;
-  gint received = 0;
+  sink_hold_s hold = {};
   ml_service_h receiver_h = NULL;
   g_autofree gchar *path = g_dir_make_tmp ("ml-training-offloading-XXXXXX", NULL);
 
@@ -450,16 +497,22 @@ TEST_F (MLServiceTrainingOffloading, destroyAfterStop_p)
   g_autofree gchar *receiver_config
       = prepare_test_config ("training_offloading_receiver.conf", avail_port);
 
+  g_mutex_init (&hold.lock);
+  g_cond_init (&hold.cond);
+
   status = ml_service_new (receiver_config, &receiver_h);
   ASSERT_EQ (status, ML_ERROR_NONE);
 
-  _start_receiver_pipeline (receiver_h, path, &received);
+  _start_receiver_pipeline (receiver_h, path, &hold);
 
   status = ml_service_stop (receiver_h);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
   status = ml_service_destroy (receiver_h);
   EXPECT_EQ (ML_ERROR_NONE, status);
+
+  g_mutex_clear (&hold.lock);
+  g_cond_clear (&hold.cond);
 
   EXPECT_EQ (g_remove (receiver_config), 0);
   EXPECT_EQ (g_rmdir (path), 0);
@@ -512,7 +565,7 @@ TEST_F (MLServiceTrainingOffloading, destroyInvalidParam2_n)
   status = _ml_service_training_offloading_destroy (mls);
   EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
 
-  status = _ml_service_offloading_release_internal (mls);
+  status = _ml_service_destroy_internal (mls);
   EXPECT_EQ (ML_ERROR_NONE, status);
 
   EXPECT_EQ (g_remove (receiver_config), 0);

--- a/tests/capi/unittest_capi_service_training_offloading.cc
+++ b/tests/capi/unittest_capi_service_training_offloading.cc
@@ -8,10 +8,12 @@
  */
 
 #include <gtest/gtest.h>
+#include <glib/gstdio.h>
 #include <ml-api-inference-pipeline-internal.h>
 #include <ml-api-internal.h>
 #include <ml-api-service-private.h>
 #include <ml-api-service.h>
+#include <nnstreamer-edge.h>
 
 #include "ml-api-service-offloading.h"
 #include "ml-api-service-training-offloading.h"
@@ -333,6 +335,137 @@ TEST_F (MLServiceTrainingOffloading, create_p)
 }
 
 /**
+ * @brief Pipeline the receiver would normally get from the remote sender.
+ * It is self-contained on purpose: the teardown order, not the training
+ * framework, is under test here.
+ */
+static const gchar *receiver_pipe_json
+    = R"JSON({"pipeline":{"description":"videotestsrc is-live=true ! videoconvert ! video/x-raw,format=RGB,width=16,height=16,framerate=30/1 ! tensor_converter ! tensor_sink name=training_result async=false","output_node":[{"name":"training_result"}]}})JSON";
+
+/**
+ * @brief Time the sink callback stays in the pipeline, in microseconds.
+ */
+#define SINK_CB_HOLD_TIME (300000)
+
+/**
+ * @brief Callback holding the streaming thread while the service is destroyed.
+ *
+ * The 'name' of the event data is the name of the node info owned by the
+ * training offloading handle, handed over without a copy. Holding the callback
+ * makes the teardown overlap with it, so reading the name afterwards fails if
+ * the node info was released while the pipeline was still running.
+ */
+static void
+_hold_new_data_cb (ml_service_event_e event, ml_information_h event_data, void *user_data)
+{
+  gint *received = (gint *) user_data;
+  char *node_name = NULL;
+
+  if (event != ML_SERVICE_EVENT_NEW_DATA)
+    return;
+
+  g_atomic_int_inc (received);
+  g_usleep (SINK_CB_HOLD_TIME);
+
+  EXPECT_EQ (ml_information_get (event_data, "name", (void **) &node_name), ML_ERROR_NONE);
+  EXPECT_STREQ (node_name, "training_result");
+}
+
+/**
+ * @brief Bring a receiver service up to the point where its pipeline is
+ * playing and the sink callback is firing.
+ */
+static void
+_start_receiver_pipeline (ml_service_h receiver_h, const gchar *path, gint *received)
+{
+  ml_service_s *mls = (ml_service_s *) receiver_h;
+  nns_edge_data_h data_h = NULL;
+  gint loop;
+  int status;
+
+  status = _ml_service_training_offloading_set_path (mls, path);
+  ASSERT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_service_set_event_cb (receiver_h, _hold_new_data_cb, received);
+  ASSERT_EQ (status, ML_ERROR_NONE);
+
+  ASSERT_EQ (nns_edge_data_create (&data_h), NNS_EDGE_ERROR_NONE);
+  status = _ml_service_training_offloading_process_received_data (mls, data_h,
+      path, receiver_pipe_json, ML_SERVICE_OFFLOADING_TYPE_PIPELINE_RAW);
+  nns_edge_data_destroy (data_h);
+  ASSERT_EQ (status, ML_ERROR_NONE);
+
+  status = _ml_service_training_offloading_start (mls);
+  ASSERT_EQ (status, ML_ERROR_NONE);
+
+  for (loop = 0; loop < 500 && g_atomic_int_get (received) == 0; loop++)
+    g_usleep (10000);
+
+  ASSERT_GT (g_atomic_int_get (received), 0);
+}
+
+/**
+ * @brief Destroying a running service must not release the node info the sink
+ * callback is still using.
+ */
+TEST_F (MLServiceTrainingOffloading, destroyWhileRunning_p)
+{
+  int status;
+  gint received = 0;
+  ml_service_h receiver_h = NULL;
+  g_autofree gchar *path = g_dir_make_tmp ("ml-training-offloading-XXXXXX", NULL);
+
+  ASSERT_NE (nullptr, path);
+
+  guint avail_port = get_available_port ();
+  g_autofree gchar *receiver_config
+      = prepare_test_config ("training_offloading_receiver.conf", avail_port);
+
+  status = ml_service_new (receiver_config, &receiver_h);
+  ASSERT_EQ (status, ML_ERROR_NONE);
+
+  _start_receiver_pipeline (receiver_h, path, &received);
+
+  /* Destroy without stopping first. */
+  status = ml_service_destroy (receiver_h);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  EXPECT_EQ (g_remove (receiver_config), 0);
+  EXPECT_EQ (g_rmdir (path), 0);
+}
+
+/**
+ * @brief Stopping the service before destroying it keeps working.
+ */
+TEST_F (MLServiceTrainingOffloading, destroyAfterStop_p)
+{
+  int status;
+  gint received = 0;
+  ml_service_h receiver_h = NULL;
+  g_autofree gchar *path = g_dir_make_tmp ("ml-training-offloading-XXXXXX", NULL);
+
+  ASSERT_NE (nullptr, path);
+
+  guint avail_port = get_available_port ();
+  g_autofree gchar *receiver_config
+      = prepare_test_config ("training_offloading_receiver.conf", avail_port);
+
+  status = ml_service_new (receiver_config, &receiver_h);
+  ASSERT_EQ (status, ML_ERROR_NONE);
+
+  _start_receiver_pipeline (receiver_h, path, &received);
+
+  status = ml_service_stop (receiver_h);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  status = ml_service_destroy (receiver_h);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  EXPECT_EQ (g_remove (receiver_config), 0);
+  EXPECT_EQ (g_rmdir (path), 0);
+}
+
+/**
  * @brief Test _ml_service_training_offloading_destroy.
  */
 TEST_F (MLServiceTrainingOffloading, destroyInvalidParam1_n)
@@ -341,6 +474,48 @@ TEST_F (MLServiceTrainingOffloading, destroyInvalidParam1_n)
 
   status = _ml_service_training_offloading_destroy (NULL);
   EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+}
+
+/**
+ * @brief Test _ml_service_training_offloading_destroy with a service that is
+ * not in training mode.
+ */
+TEST_F (MLServiceTrainingOffloading, destroyInvalidParam2_n)
+{
+  int status;
+  ml_service_s *mls;
+
+  g_autoptr (JsonParser) parser = NULL;
+  g_autofree gchar *json_string = NULL;
+  JsonNode *root;
+  JsonObject *object;
+
+  guint avail_port = get_available_port ();
+  g_autofree gchar *receiver_config
+      = prepare_test_config ("service_offloading_receiver.conf", avail_port);
+
+  ASSERT_TRUE (g_file_get_contents (receiver_config, &json_string, NULL, NULL));
+  parser = json_parser_new ();
+  ASSERT_TRUE (json_parser_load_from_data (parser, json_string, -1, NULL));
+  root = json_parser_get_root (parser);
+  ASSERT_NE (nullptr, root);
+  object = json_node_get_object (root);
+  ASSERT_NE (nullptr, object);
+
+  mls = _ml_service_create_internal (ML_SERVICE_TYPE_OFFLOADING);
+  ASSERT_NE (nullptr, mls);
+
+  /* The configuration has no 'training' member, so the mode stays NONE. */
+  status = _ml_service_offloading_create (mls, object);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  status = _ml_service_training_offloading_destroy (mls);
+  EXPECT_EQ (ML_ERROR_INVALID_PARAMETER, status);
+
+  status = _ml_service_offloading_release_internal (mls);
+  EXPECT_EQ (ML_ERROR_NONE, status);
+
+  EXPECT_EQ (g_remove (receiver_config), 0);
 }
 
 /**


### PR DESCRIPTION
Addresses item **H3** of #690.

## The defect

`_ml_service_training_offloading_destroy()` tore the handle down in this order:

1. `g_hash_table_destroy (training_s->node_table)` — frees every `ml_service_node_info_s`
2. `ml_pipeline_destroy (training_s->pipeline_h)`

and never called `ml_pipeline_stop()`.

Each output node in the received pipeline is registered with
`ml_pipeline_sink_register (..., _ml_service_pipeline_sink_cb, node_info, ...)`,
and that callback dereferences `node_info->mls` and `node_info->name`. It also
passes `node_info->name` into the event data through `_ml_info_set_value()`,
which stores the pointer without copying it, so a callback that is still running
when the node table goes away reads freed memory.

`ml_service_stop()` is not mandatory before `ml_service_destroy()`, so a receiver
that is still PLAYING when the application destroys it can have a buffer reach
the sink after step 1 and run the callback on a freed `node_info`.

## The fix

Release the pipeline before the node table, mirroring
`_ml_service_extension_destroy()`:

- `ml_pipeline_stop()` takes the pipeline out of PLAYING.
- `ml_pipeline_destroy()` brings it to `GST_STATE_NULL`. It blocks on the
  element lock that `cb_sink_event()` holds for the whole user callback, and
  joins the streaming threads, so no sink callback can be in flight once it
  returns.
- only then is `node_table` destroyed.

Stopping first also narrows the separate window in which `ml_pipeline_destroy()`
frees its named nodes while the pipeline is still running.

## Tests

`destroyWhileRunning_p` drives a receiver to PLAYING and destroys it **without**
stopping — the exact reproduction from the issue. The pipeline is injected the
way the remote sender would send it, but is self-contained (`videotestsrc` into
`tensor_sink`) so the test covers the teardown order rather than nntrainer.

The sink callback signals a condition variable on entry and then holds the
streaming thread for 300 ms; the test waits for that signal before destroying,
so the destroy always overlaps the callback rather than usually overlapping it.
After the hold, the callback reads the node name back out of the event data.
With the old order the node table is freed while the callback is still parked,
so that read lands on released memory.

What makes that read fail is allocator behaviour, and it is worth being precise
about which. `M_PERTURB` is enabled for the duration of the destroy call — and
cleared right after, to keep it off the rest of the suite — but glibc returns
from `tcache_put()` before `free_perturb()` runs, and the node name is tcache
sized, so for that chunk `M_PERTURB` is inert. The clobber the assertion
actually sees is `tcache_put()` writing its own link fields over the first 16
bytes of the freed chunk, which is reliable on glibc but is still not a property
of the code under test. `M_PERTURB` stays as a second net for the paths where
the chunk does not go to the tcache. A sanitizer or valgrind job would be the
only airtight net here; that is repository-wide CI work and belongs in its own
issue.

`destroyAfterStop_p` keeps the documented stop-then-destroy order working now
that destroy stops the pipeline itself, and `destroyInvalidParam2_n` covers the
guard that rejects a service which is not in training mode.

## Deliberately left out

- **`_training_offloading_send_trained_model()` still runs before the stop.**
  Moving the stop above it would not make the transfer deterministic:
  `ml_pipeline_stop()` only pauses, it does not make `tensor_trainer` finalize
  the model file, so an earlier stop could ship a different model rather than a
  more complete one. That is a behaviour decision for the training offloading
  protocol, not part of this use-after-free.
- **`g_cond_clear` / `g_mutex_clear` before `g_thread_join` in the same
  function.** Real UB, and tracked separately as item **M6** of #690, which also
  covers the `is_received` reset and the spurious-wakeup predicate in
  `_training_offloading_check_received_data()`. Fixing only the teardown half
  here would leave that item ambiguous.

## Not verified locally

These tests need nnstreamer, nnstreamer-edge, mlops-agent and nntrainer, which
are not installed on the machine this was written on, so they have not been run
locally — only the GBS CI job with `unit_test 1` exercises
`unittest_capi_service_training_offloading`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
