### PR TITLE
[C-Api] validate the flexible tensor header in the sink callback

### DIFF
--- a/c/src/ml-api-inference-pipeline.c
+++ b/c/src/ml-api-inference-pipeline.c
@@ -361,8 +361,26 @@ cb_sink_event (GstElement * e, GstBuffer * b, gpointer user_data)
 
     /* handle header for flex tensor */
     for (i = 0; i < num_tensors; i++) {
-      gst_tensor_meta_info_parse_header (&meta, map[i].data);
+      /* the parser fills the whole meta before it validates any of it */
+      if (map[i].size < sizeof (GstTensorMetaInfo) ||
+          !gst_tensor_meta_info_parse_header (&meta, map[i].data)) {
+        _ml_loge (_ml_detail
+            ("The sink event of [%s] cannot be handled because the flexible tensor header is invalid (tensor %u, memory %"
+                G_GSIZE_FORMAT " bytes).", elem->name, i, map[i].size));
+
+        goto error;
+      }
+
       hsize = gst_tensor_meta_info_get_header_size (&meta);
+
+      if (hsize == 0 || map[i].size < hsize) {
+        _ml_loge (_ml_detail
+            ("The sink event of [%s] cannot be handled because the flexible tensor header does not fit the memory (tensor %u, header %"
+                G_GSIZE_FORMAT " bytes, memory %" G_GSIZE_FORMAT " bytes).",
+                elem->name, i, hsize, map[i].size));
+
+        goto error;
+      }
 
       gst_tensor_meta_info_convert (&meta,
           gst_tensors_info_get_nth_info (&gst_info, i));

--- a/tests/capi/unittest_capi_inference.cc
+++ b/tests/capi/unittest_capi_inference.cc
@@ -8207,6 +8207,269 @@ TEST (nnstreamer_capi_flex, src_multi)
 }
 
 /**
+ * @brief Result of a flexible tensor sink callback.
+ */
+typedef struct {
+  guint received;
+  size_t size;
+} TestFlexSinkResult;
+
+/**
+ * @brief Callback to record what a flexible tensor sink handed over.
+ */
+static void
+test_sink_callback_flex_size (
+    const ml_tensors_data_h data, const ml_tensors_info_h info, void *user_data)
+{
+  TestFlexSinkResult *result = (TestFlexSinkResult *) user_data;
+  void *raw = NULL;
+  size_t size = 0;
+
+  G_LOCK (callback_lock);
+  if (ml_tensors_data_get_tensor_data (data, 0, &raw, &size) == ML_ERROR_NONE)
+    result->size = size;
+  result->received = result->received + 1;
+  G_UNLOCK (callback_lock);
+}
+
+/**
+ * @brief Fill a tensor meta that describes a valid flexible tensor.
+ */
+static void
+init_flex_meta (GstTensorMetaInfo *meta)
+{
+  gst_tensor_meta_info_init (meta);
+  meta->type = _NNS_INT32;
+  meta->dimension[0] = 4U;
+}
+
+/**
+ * @brief Write a flexible tensor header, cut down to the given size, into a new temp dir.
+ * @param meta The header to write, NULL to leave the file zeroed.
+ * @param size The file size in bytes. The header is truncated or zero-padded to it.
+ * @param dir Set to the directory holding the file, NULL on failure.
+ * @return The file path, NULL on failure. Release both with remove_flex_header_file ().
+ */
+static gchar *
+create_flex_header_file (GstTensorMetaInfo *meta, gsize size, gchar **dir)
+{
+  GstTensorMetaInfo _meta;
+  gchar *path = NULL;
+  gchar *tmpdir;
+  guint8 *content;
+  gsize hsize;
+
+  *dir = NULL;
+
+  if (size == 0)
+    return NULL;
+
+  tmpdir = g_build_path (G_DIR_SEPARATOR_S, g_get_tmp_dir (), "nns-flex-XXXXXX", NULL);
+  if (!g_mkdtemp (tmpdir)) {
+    g_free (tmpdir);
+    return NULL;
+  }
+
+  gst_tensor_meta_info_init (&_meta);
+  hsize = gst_tensor_meta_info_get_header_size (&_meta);
+  content = (guint8 *) g_malloc0 (MAX (size, hsize));
+
+  if (!meta || gst_tensor_meta_info_update_header (meta, content)) {
+    path = g_build_path (G_DIR_SEPARATOR_S, tmpdir, "flex-header", NULL);
+    if (!g_file_set_contents (path, (const gchar *) content, size, NULL))
+      g_clear_pointer (&path, g_free);
+  }
+
+  g_free (content);
+
+  if (path) {
+    *dir = tmpdir;
+  } else {
+    g_remove (tmpdir);
+    g_free (tmpdir);
+  }
+
+  return path;
+}
+
+/**
+ * @brief Remove a file created by create_flex_header_file () and its directory.
+ */
+static void
+remove_flex_header_file (gchar *file, gchar *dir)
+{
+  g_remove (file);
+  g_remove (dir);
+  g_free (file);
+  g_free (dir);
+}
+
+/**
+ * @brief Push a file into a flexible tensor sink and report what the sink gave back.
+ */
+static void
+run_flex_header_pipeline (const gchar *sink, const gchar *file, guint expected,
+    TestFlexSinkResult *result)
+{
+  ml_pipeline_h handle;
+  ml_pipeline_sink_h sinkhandle;
+  gchar *pipeline;
+  int status;
+
+  pipeline = g_strdup_printf ("filesrc location=\"%s\" ! "
+                              "other/tensors,format=flexible,framerate=(fraction)10/1 ! "
+                              "%s name=sinkx sync=false",
+      file, sink);
+
+  status = ml_pipeline_construct (pipeline, NULL, NULL, &handle);
+  g_free (pipeline);
+  ASSERT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_sink_register (
+      handle, "sinkx", test_sink_callback_flex_size, result, &sinkhandle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_pipeline_start (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  /* the buffer is pushed once the source is running, so wait for that first */
+  status = waitPipelineStateChange (handle, ML_PIPELINE_STATE_PLAYING, 2000);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  if (expected > 0)
+    wait_pipeline_process_buffers (result->received, expected);
+  g_usleep (300000);
+
+  status = ml_pipeline_destroy (handle);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Test NNStreamer pipeline for a flexible tensor smaller than the parsed meta.
+ */
+TEST (nnstreamer_capi_flex, sink_short_header_n)
+{
+  GstTensorMetaInfo meta;
+  TestFlexSinkResult result = { 0U, 0 };
+  gchar *dir, *file;
+
+  init_flex_meta (&meta);
+  file = create_flex_header_file (&meta, 16, &dir);
+  ASSERT_TRUE (file != NULL);
+
+  run_flex_header_pipeline ("tensor_sink", file, 0, &result);
+  EXPECT_EQ (result.received, 0U);
+
+  remove_flex_header_file (file, dir);
+}
+
+/**
+ * @brief Test NNStreamer pipeline for a flexible tensor without a valid meta.
+ */
+TEST (nnstreamer_capi_flex, sink_invalid_magic_n)
+{
+  GstTensorMetaInfo meta;
+  TestFlexSinkResult result = { 0U, 0 };
+  gchar *dir, *file;
+
+  /* long enough for the parser, zeroed so that it rejects the meta */
+  gst_tensor_meta_info_init (&meta);
+  file = create_flex_header_file (NULL, gst_tensor_meta_info_get_header_size (&meta), &dir);
+  ASSERT_TRUE (file != NULL);
+
+  run_flex_header_pipeline ("tensor_sink", file, 0, &result);
+  EXPECT_EQ (result.received, 0U);
+
+  remove_flex_header_file (file, dir);
+}
+
+/**
+ * @brief Test NNStreamer pipeline for a flexible tensor of an unsupported meta version.
+ */
+TEST (nnstreamer_capi_flex, sink_unsupported_version_n)
+{
+  GstTensorMetaInfo meta;
+  TestFlexSinkResult result = { 0U, 0 };
+  gchar *dir, *file;
+  gsize hsize;
+
+  init_flex_meta (&meta);
+  hsize = gst_tensor_meta_info_get_header_size (&meta);
+
+  /* keep the version tag the meta is validated against, drop the version number */
+  meta.version &= 0xFF000000U;
+  file = create_flex_header_file (&meta, hsize, &dir);
+  ASSERT_TRUE (file != NULL);
+
+  run_flex_header_pipeline ("tensor_sink", file, 0, &result);
+  EXPECT_EQ (result.received, 0U);
+
+  remove_flex_header_file (file, dir);
+}
+
+/**
+ * @brief Test NNStreamer pipeline for a flexible tensor holding a truncated header.
+ */
+TEST (nnstreamer_capi_flex, sink_truncated_header_n)
+{
+  GstTensorMetaInfo meta;
+  TestFlexSinkResult result = { 0U, 0 };
+  gchar *dir, *file;
+
+  /* the whole meta is there, the 128 byte header it declares is not */
+  init_flex_meta (&meta);
+  file = create_flex_header_file (&meta, 96, &dir);
+  ASSERT_TRUE (file != NULL);
+
+  run_flex_header_pipeline ("tensor_sink", file, 0, &result);
+  EXPECT_EQ (result.received, 0U);
+
+  remove_flex_header_file (file, dir);
+}
+
+/**
+ * @brief Test NNStreamer pipeline for a truncated flexible tensor reaching an appsink.
+ */
+TEST (nnstreamer_capi_flex, sink_truncated_header_appsink_n)
+{
+  GstTensorMetaInfo meta;
+  TestFlexSinkResult result = { 0U, 0 };
+  gchar *dir, *file;
+
+  init_flex_meta (&meta);
+  file = create_flex_header_file (&meta, 96, &dir);
+  ASSERT_TRUE (file != NULL);
+
+  run_flex_header_pipeline ("appsink", file, 0, &result);
+  EXPECT_EQ (result.received, 0U);
+
+  remove_flex_header_file (file, dir);
+}
+
+/**
+ * @brief Test NNStreamer pipeline for a flexible tensor that carries a header and no data.
+ * @note This pins the header boundary only. Whether the payload matches the dimension
+ *       the header declares is not checked by the sink callback.
+ */
+TEST (nnstreamer_capi_flex, sink_header_only)
+{
+  GstTensorMetaInfo meta;
+  TestFlexSinkResult result = { 0U, 1 };
+  gchar *dir, *file;
+
+  init_flex_meta (&meta);
+  file = create_flex_header_file (
+      &meta, gst_tensor_meta_info_get_header_size (&meta), &dir);
+  ASSERT_TRUE (file != NULL);
+
+  run_flex_header_pipeline ("tensor_sink", file, 1, &result);
+  EXPECT_EQ (result.received, 1U);
+  EXPECT_EQ (result.size, 0U);
+
+  remove_flex_header_file (file, dir);
+}
+
+/**
  * @brief Callback for check output of tflite model with 32 in/out tensors.
  */
 static void


### PR DESCRIPTION
Addresses item **M9** of #690.

## The defect

`cb_sink_event()` (`c/src/ml-api-inference-pipeline.c`) handled a flexible tensor like this:

```c
gst_tensor_meta_info_parse_header (&meta, map[i].data);
hsize = gst_tensor_meta_info_get_header_size (&meta);
...
_data->tensors[i].data = map[i].data + hsize;
_data->tensors[i].size = map[i].size - hsize;
```

`map[i]` is the mapped GstMemory that arrived at the sink, so `map[i].size` is whatever the upstream element produced. Nothing in those four lines is checked.

**The parser reads before it validates.** `gst_tensor_meta_info_parse_header()` fills the whole `GstTensorMetaInfo` — 88 bytes, `val[0]` through `val[21]` — out of the pointer it is given, and only then calls `gst_tensor_meta_info_validate()`. A memory shorter than the struct is read past its end.

**The return value is dropped.** `hsize` is used whether or not the meta was accepted.

**The subtraction wraps.** `map[i].size - hsize` is `gsize` arithmetic. When the memory is shorter than the header it declares, the callback receives a pointer past the end of the mapped region together with a size near 2^64.

Measured on `main` (`8952123`), a 96-byte buffer carrying a complete, valid meta reaches the application callback with

```
PROBE size=18446744073709551584      /* 96 - 128 */
```

Note on tooling: the over-read is not something a sanitizer catches here. `filesrc` allocates its blocksize and resizes the buffer down, so the 88-byte read stays inside a much larger live allocation; an ASAN build of `main` reports nothing and fails only on the assertion. The wrapped size is the part that is reliably observable, and that is what the tests assert.

## The fix

The guarded form of the same operation, the way `gst_tensor_meta_info_parse_memory()` does it in nnstreamer:

1. The memory must be at least `sizeof (GstTensorMetaInfo)` before the parser touches it. That is exactly the window the parser fills — the parser reads the struct through a `uint32_t *` view of itself — so the bound is structural and does not depend on how meta versions are numbered.
2. The parse result decides whether the meta is used at all.
3. The header size the parsed meta reports must be non-zero **and** must fit the memory.

Step 3's zero check matters on its own. `GST_TENSOR_META_VERSION_VALID` only tests the `0xDE` tag while `GST_TENSOR_META_IS_V1` needs the version bits, so a meta can validate and still have no header size. Treating that as a zero-length header would hand the header bytes to the application as payload, described by an info the sender chose.

A rejected buffer takes the existing `error:` path: the memories are unmapped and unreffed, the data handle is destroyed, and no sink callback runs. The sink pad caps are deliberately left alone — unlike the tensor-count and size mismatches in the static branch, a malformed buffer is not a reason to renegotiate.

## Tests

Six cases in `nnstreamer_capi_flex`, all driving a real pipeline through the public C API:

| test | buffer | clause reached |
| --- | --- | --- |
| `sink_short_header_n` | 16 B | `size < sizeof (GstTensorMetaInfo)` |
| `sink_invalid_magic_n` | 128 B, zeroed | `parse_header` returns FALSE |
| `sink_unsupported_version_n` | 128 B, valid meta with the version number cleared | `hsize == 0` |
| `sink_truncated_header_n` | 96 B, complete meta | `hsize` 128 > 96 |
| `sink_truncated_header_appsink_n` | 96 B, complete meta | same, through the `appsink` entry point |
| `sink_header_only` | exactly 128 B | accepted — callback once, tensor size 0 |

Which guard each case reaches was confirmed from the `_ml_loge` it triggers; the two guards log different messages, and within a guard the clause follows from the buffer size (16 < 88 against 128 ≥ 88 for the first, `hsize` 128 over a 96-byte memory against `hsize` 0 for the second).

One honest limit on that table: the first row is *reached* but not *pinned*. Deleting the `size < sizeof (GstTensorMetaInfo)` clause would let the 16-byte case fall through to the second guard, which still rejects it, so the suite would stay green. What that clause prevents — the parser reading past the memory — is not observable here for the reason given above: `filesrc` over-allocates, so the read stays inside a live allocation and no sanitizer fires. The clause is kept because the read is out of bounds of the *buffer*, which is what the sink is contractually given.

Headers are built with nnstreamer's own `gst_tensor_meta_info_update_header()` and truncated, so the tests follow the header layout rather than hardcoding it, and the unsupported version is produced by masking the real version tag rather than by writing a literal. They are fed in through `filesrc` with the flexible caps forced in front of the sink.

**On `main` all five negative cases fail** (`result.received` is 1, expected 0); with this change all six pass. `sink_header_only` passes before and after, so an over-strict guard would be caught too.

`sink_truncated_header_appsink_n` covers the second way into `cb_sink_event` — `cb_appsink_new_sample()` — which is what the ml-service extension, the training-offloading receiver and the Android JNI sink all end up using.

## Verification

Built against nnstreamer 2.7.0 on Ubuntu 22.04, `-Denable-ml-service=false`:

```
unittest_capi_inference               242 tests   PASSED
unittest_capi_inference_single         48 tests   PASSED
unittest_capi_datatype_consistency      4 tests   PASSED
```

`clang-format` reports no diff on the test file, and GNU `indent` with the CI options reports no diff inside the changed function.

**Gating:** `unittest_capi_inference` runs on a PR through `Tizen GBS build on Ubuntu (x86_64, --define "unit_test 1")` only — `pdebuild` declares `on: pull_request` but has not actually been triggered by one since 2026-08-09. A regression in these cases blocks the merge through that job.

## Review rounds

Four review passes, each by a fresh agent, and one approving review: [round 1](https://github.com/nnstreamer/api/pull/694#issuecomment-5594430151), [round 2](https://github.com/nnstreamer/api/pull/694#issuecomment-5594544650), [round 3](https://github.com/nnstreamer/api/pull/694#issuecomment-5594659209), [round 4](https://github.com/nnstreamer/api/pull/694#issuecomment-5594758072). Everything actionable is in the branch.

Round 2's two substantive findings drove the restructuring above:

- **The `parse_header` return value had no coverage.** Every negative test was short-circuiting on the size check, so deleting that clause would have left the suite green. `sink_invalid_magic_n` closes it, and moving the pre-parse bound from the header size (128) to `sizeof (GstTensorMetaInfo)` (88) means the 96-byte cases now exercise the second guard instead of the first.
- **A validated meta can report `hsize == 0`.** Round 1's reply had reasoned that zero was benign; it is not, and it is the same input class this PR exists to reject. Guarded, and `sink_unsupported_version_n` covers it.

Round 2 also corrected round 1's `cur_hsize` finding — the real hazard was the zero case, not a future larger header. `sizeof (GstTensorMetaInfo)` removes the version coupling that started that thread.

While covering the version case, `sink_unsupported_version_n` was found to be passing vacuously: it sized the file from the meta it had just mutated, so the header size came back 0 and `filesrc` pushed nothing. Fixed by taking the size before the mutation, and `create_flex_header_file()` now refuses a zero-length file so the same mistake cannot pass silently again.

Round 3 found no blocking issue. It verified `sizeof (GstTensorMetaInfo)` is 88 on every target this repo builds for — all members are `uint32_t`, including the anonymous union's, so there is no padding — and that it matches the parser's read window exactly. Its remaining points were the two body inaccuracies corrected above, plus the temp-directory boilerplate, which is now factored into `create_flex_header_file ()` and `remove_flex_header_file ()` (−17 lines net in the test file).

Round 4 re-checked the test refactoring against the head it replaced: the inputs that select each arm are unchanged byte for byte, including the ordering in `sink_unsupported_version_n` that the round-2 vacuous pass turned on, and the helper now cleans up its own directory when it fails, which removes a leak the earlier tests had on an assertion failure. No blocking issue.

Round 3 also independently confirmed what is noted under Verification below: `pdebuild` has not been triggered by a pull request since 2026-08-09 despite its `on: pull_request`, so the GBS x86_64 job is the only PR check that runs `unittest_capi_inference`. That dormancy is an infrastructure matter for its own issue, not something to fix here.

After the four rounds, an approving review ([myungjoo-bot](https://github.com/nnstreamer/api/pull/694#pullrequestreview-5151019535)) raised four Low items on `277ec6b`:

1. *Log messages do not say which clause fired or by how much.* Done — both `_ml_loge` calls now carry the tensor index and the sizes, e.g. `(tensor 0, header 128 bytes, memory 96 bytes)` for a truncated header and `(tensor 0, header 0 bytes, memory 128 bytes)` for an unsupported version.
2. *`create_flex_header_file ()` Doxygen misses `size` and the failure/ownership contract of `dir`.* Done.
3. *Document the drop in `ml_pipeline_sink_cb`.* Not done. `nnstreamer.h` is the public native API header, and it has never said that the static branch drops buffers whose tensor count or size mismatch either; a note on the flexible case alone would read as if the static path delivered malformed buffers. This PR makes the existing contract — a valid pointer and a truthful size — hold rather than changing it. Documenting the drop belongs to a change that covers both branches.
4. *`G_STATIC_ASSERT` between `NNS_TENSOR_SIZE_LIMIT` and `ML_TENSOR_SIZE_LIMIT`.* Not done here. The two limits are both 256 today, but an assertion between them would not bound what reaches `mem[]`/`map[]`: `num_tensors` is taken from the buffer itself (`gst_tensor_buffer_get_count ()`, which for a buffer at the 16-memory limit reads the count out of the extra-tensor header), so the question is whether that count is validated, not whether the constants agree. nnstreamer `main` now validates it — nnstreamer/nnstreamer@d4de7840 (item A1 of nnstreamer/nnstreamer#4920) rejects a header whose count exceeds the array — but that is not in a tagged release yet, and this repository does not require a minimum nnstreamer version, so a build against a current release still trusts the header. Whether the api should bound the count itself is a separate item from M9 and is being looked at on its own.

Two items are deliberately left out of this PR:

- **The payload is still not checked against the info the header declares.** `sink_header_only` documents that: the callback gets an info claiming 16 bytes over a 0-byte payload. That is a separate defect from M9, it applies to the sparse format differently, and fixing it here would risk rejecting legitimate flexible streams. It belongs in #690 as its own item.
- **The `goto error` at `i > 0` has no test.** The flex loop does not modify `num_tensors` and every memory is mapped before it runs, so the `error:` cleanup is index-independent and there is no distinct path to cover. Round 2 is right that `tensor_mux`/`tensor_merge` can produce multi-memory flexible buffers; what they cannot easily produce is one whose *second* memory is truncated, which is what such a test would need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


